### PR TITLE
Enable parameterization of raw SQL strings

### DIFF
--- a/postmodern/package.lisp
+++ b/postmodern/package.lisp
@@ -32,7 +32,7 @@
    #:\!index #:\!unique-index #:\!foreign
 
    ;; Reduced S-SQL interface
-   #:sql #:sql-compile
+   #:sql #:sql-compile #:sql-fmt
    #:smallint #:bigint #:numeric #:real #:double-precision
    #:bytea #:text #:varchar
    #:*escape-sql-names-p* #:sql-escape-string #:register-sql-operators

--- a/s-sql/s-sql.lisp
+++ b/s-sql/s-sql.lisp
@@ -18,6 +18,7 @@
            #:sql
            #:sql-compile
            #:sql-template
+	   #:sql-fmt
            #:$$
            #:register-sql-operators
            #:enable-s-sql-syntax
@@ -242,6 +243,9 @@ name.")
   safe, but when the server is configured to allow standard
   strings (parameter 'standard_conforming_strings' is 'on'), the noise
   in queries can be reduced by setting this to T.")
+
+(defun sql-fmt (fmt &rest args)
+  (apply 'format nil fmt (mapcar 'sql-ize args)))
 
 (defun sql-escape-string (string &optional prefix)
   "Escape string data so it can be used in a query."


### PR DESCRIPTION
Hi,

I needed to use raw SQL to generate COPY declarations which S-SQL doesn't seem to support yet.  This commit adds and exports a function sql-fmt that uses CL format and sql-ize to safely parameterize raw SQL queries.
