### PR TITLE
upsert-dao

### DIFF
--- a/postmodern/package.lisp
+++ b/postmodern/package.lisp
@@ -8,7 +8,7 @@
   (:export
    #:dao-class #:dao-exists-p #:dao-keys #:query-dao #:select-dao #:get-dao
    #:with-column-writers
-   #:insert-dao #:update-dao #:save-dao #:save-dao/transaction #:delete-dao #:make-dao
+   #:insert-dao #:update-dao #:save-dao #:save-dao/transaction #:upsert-dao #:delete-dao #:make-dao
    #:define-dao-finalization
    #:dao-table-name #:dao-table-definition
    #:\!dao-def #:*ignore-unknown-columns*)


### PR DESCRIPTION
A different way to insert/update — like save-dao and save-dao/transaction, but it's safe both in and out transactions and doesn't generate an error entry in the Postgres log.  Let me know if you'd like me to implement the save-dao methods in terms of this one.
