### PR TITLE
Insert WITH-STANDARD-IO-SYNTAX between INTERN and FORMAT.

### DIFF
--- a/cl-postgres/communicate.lisp
+++ b/cl-postgres/communicate.lisp
@@ -6,9 +6,11 @@
 ;; some macros that use them create names this way.
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (defun integer-reader-name (bytes signed)
-    (intern (format nil "~a~a~a~a" '#:read- (if signed "" '#:u) '#:int bytes)))
+    (intern (with-standard-io-syntax
+              (format nil "~a~a~a~a" '#:read- (if signed "" '#:u) '#:int bytes))))
   (defun integer-writer-name (bytes signed)
-    (intern (format nil "~a~a~a~a" '#:write- (if signed "" '#:u) '#:int bytes))))
+    (intern (with-standard-io-syntax
+              (format nil "~a~a~a~a" '#:write- (if signed "" '#:u) '#:int bytes)))))
 
 (defmacro integer-reader (bytes)
   "Create a function to read integers from a binary stream."

--- a/postmodern/prepare.lisp
+++ b/postmodern/prepare.lisp
@@ -11,7 +11,7 @@
   (defun next-statement-id ()
     "Provide unique statement names."
     (incf next-id)
-    (intern (format nil "STATEMENT-~A" next-id) :keyword)))
+    (intern (with-standard-io-syntax (format nil "STATEMENT-~A" next-id)) :keyword)))
 
 (defun generate-prepared (function-form query format)
   "Helper macro for the following two functions."


### PR DESCRIPTION
In general, `(intern (format "~a..." 'sym ...))` is incorrect because `format` writes symbols according to `*print-case*`, which may differ from the case of symbol names (uppercase in the customary readtable). When `*print-case*` is `:downcase`, lower case symbols such as `|sym|` get interned.
