### PR TITLE
UNIX domain socket support for Clozure CL.

### DIFF
--- a/doc/cl-postgres.html
+++ b/doc/cl-postgres.html
@@ -55,9 +55,9 @@
     href="http://common-lisp.net/project/cl-plus-ssl/">CL+SSL</a>
     package loaded to initiate the connection.</p>
 
-    <p class="desc">On SBCL, the value <code>:unix</code> may be
-    passed for <code>host</code>, in order to connect using a Unix
-    domain socket instead of a TCP socket.</p>
+    <p class="desc">On SBCL and Clozure CL, the value
+    <code>:unix</code> may be passed for <code>host</code>, in order
+    to connect using a Unix domain socket instead of a TCP socket.</p>
 
     <p class="def">
       <span>function</span>


### PR DESCRIPTION
As with SBCL, this adds support for UNIX domain sockets to Clozure CL.
For Darwin-based machines (i.e. all Macs), we also explicitly add
support for the correct default UNIX socket directory.

The code that constructs the UNIX socket path has been abstracted out
too, since we use it in multiple places now.

It seems to me that `INITIATE-CONNECTION` is beginning to get a bit
unwieldy, and could probably benefit from restructuring, but I have
intentionally avoided that to reduce the impact of this change.
