### PR TITLE
Extended the :update operation with a :from clause

### DIFF
--- a/doc/s-sql.html
+++ b/doc/s-sql.html
@@ -488,7 +488,10 @@
     <p class="desc">Update values in a table. After the table name
     there should follow the keyword <code>:set</code> and any number
     of alternating field names and values, like
-    for <a href="#insert-into"><code>:insert-into</code></a>, and then
+    for <a href="#insert-into"><code>:insert-into</code></a>. Next comes 
+    the optional keyword <code>:from</code>, followed by at least one table name
+    and then any numer of join statements, like for 
+    <a href="#select"><code>:select</code></a>. After the joins,
     an optional <code>:where</code> keyword followed by the condition,
     and <code>:returning</code> keyword followed by a list of field
     names or expressions indicating values to be returned as query

--- a/s-sql/s-sql.lisp
+++ b/s-sql/s-sql.lisp
@@ -686,13 +686,14 @@ to runtime. Used to create stored procedures."
       ,@(when returning `(" RETURNING " ,@(sql-expand-list returning))))))
 
 (def-sql-op :update (table &rest args)
-  (split-on-keywords ((set *) (where ?) (returning ? *)) args
+  (split-on-keywords ((set *) (from * ?) (where ?) (returning ? *)) args
     (when (oddp (length set))
       (sql-error "Invalid amount of :set arguments passed to update sql operator"))
     `("UPDATE " ,@(sql-expand table) " SET "
       ,@(loop :for (field value) :on set :by #'cddr
               :for first = t :then nil
               :append `(,@(if first () '(", ")) ,@(sql-expand field) " = " ,@(sql-expand value)))
+      ,@(if from (cons " FROM " (expand-joins from)))
       ,@(if where (cons " WHERE " (sql-expand (car where))) ())
       ,@(when returning
           (cons " RETURNING " (sql-expand-list returning))))))


### PR DESCRIPTION
So it allows to execute updates such as

``` sql
update table_to_update 
  set column_to_update = table_related.column_to_copy_from
  from table_many_to_many inner join table_related  
    on table_many_to_many.fk1 = table_related.pk
  where table_to_update.pk = table_many_to_many.fk2;
```

Using an s-sql expression such as:

``` common-lisp
(:update 'table-to-update
          :set 'column-to-update 'table-related.column-to-copy        
          :from 'table-many-to-many :inner-join 'table-related
            :on (:= 'table-related.pk 'table-many-to-many.fk1)
          :where (:= 'table-top-update.pk 'table-many-to-many.fk2)
```
