### PR TITLE
Added FTS match :@@ operator

### DIFF
--- a/doc/s-sql.html
+++ b/doc/s-sql.html
@@ -281,6 +281,10 @@
     <p class="desc">Simple SQL string matching operators
     (<code>:ilike</code> is case-insensitive).</p>
 
+    <p class="def"><span>sql-op</span> <a name="match"></a>:@@</p>
+
+    <p class="desc">Fast Text Search match operator.</p>
+
     <p class="def"><span>sql-op</span> <a name="desc"></a>:desc (column)</p>
 
     <p class="desc">Used to invert the meaning of an operator in an <a
@@ -725,6 +729,7 @@
       <li><a href="#regexp">:!~</a></li>
       <li><a href="#regexp">:!~*</a></li>
       <li><a href="#regexp">:~*</a></li>
+      <li><a href="#match">:@@</a></li>
       <li><a href="#deref">:[]</a></li>
       <li><a href="#sql-template">$$</a></li>
       <li><a href="#infix">:and</a></li>

--- a/s-sql/s-sql.lisp
+++ b/s-sql/s-sql.lisp
@@ -464,6 +464,9 @@ with a given arity."
                       :when type :append (list " " (to-type-name type)))
           ")"))))
 
+(def-sql-op :@@ (op1 op2)
+  `("(" ,@(sql-expand op1) " @@ " ,@(sql-expand op2) ")"))
+
 (def-sql-op :distinct (&rest forms)
   `("DISTINCT(" ,@(sql-expand-list forms) ")"))
 


### PR DESCRIPTION
Added a new operator for the Fast Text Search operator @@

Example: 

`````` lisp
(sql (:select 'id 'name
          :from 'people (:as (:to-tsquery "english" "john doe") 'ts-query)
          :where (:@@ (:to-tsvector 'busqueda) 'ts-query)))```
Expands to:
```lisp
"(SELECT id, name FROM people, to_tsquery(E'english', E'john doe') AS ts_query WHERE (to_tsvector(busqueda) @@ ts_query))"```
``````
