### PR TITLE
Handle #\C (CommandComplete) in SEND-EXECUTE

### DIFF
--- a/cl-postgres/protocol.lisp
+++ b/cl-postgres/protocol.lisp
@@ -449,6 +449,10 @@ to the result."
               (funcall row-reader socket row-description)
               (look-for-row socket))
         (message-case socket
+          ;; CommandComplete
+          (#\C (read-str socket)
+               (message-case socket
+                 (#\Z (read-uint1 socket))))
           ;; ReadyForQuery, skipping transaction status
           (#\Z (read-uint1 socket)))))))
 


### PR DESCRIPTION
I'm working on a tiny extension for Postmodern to support the `lo_*` interface.  This actually appears to be trivial; while libpq uses the `#\F` (call a function) message, this is deprecated with the recommendation to simply use `SELECT function(...)`. This works quite well:

``` lisp
(with-transaction ()
  (let (fd)
    (doquery ("SELECT lo_open($1, $2)" 16595 #x20000) (n)
      (setf fd n))
    (doquery ("SELECT lowrite($1, $2::bytea)"
              fd (make-array 5 :element-type '(unsigned-byte 8)
                               :initial-contents '(1 2 3 4 5))) (n)
      (print n))
    (doquery ("SELECT lo_lseek($1, $2, 0)" fd 0) (n)
      (print n))
    (doquery ("SELECT loread($1, $2)" fd 5) (bytes)
      (print bytes))))
```

Unfortunately the protocol handling doesn't work quite right for `lo_create()`.  This returns a `#\C` (CommandComplete) before the `#\Z` (ReadyForQuery), which trips up Postmodern.

I have a short hack which makes this work.  I say hack, because `SEND-EXECUTE` is written linearly when this should ideally be a loop or state machine.  This works by simply handling a `#\C` followed by a`#\Z`, or a `#\Z`.

A simple test case for before/after:

``` lisp
(doquery ("SELECT lo_create(0)") (n) (print n))
```

This should print a valid OID after the patch.  Additionally, I can add wrappers for the large object functions as part of this, or as a separate issue, if desired.
