### PR TITLE
Rework bulk-copy API to allow several COPY within the same transaction. (#37)

### DIFF
--- a/cl-postgres/bulk-copy.lisp
+++ b/cl-postgres/bulk-copy.lisp
@@ -13,9 +13,9 @@
 	    (copier-columns self))))
 
 
-(defun open-db-writer (db-spec table columns)
+(defun open-db-writer (connection table columns)
   (let ((copier (make-instance 'bulk-copier
-                  :database (apply 'open-database db-spec)
+                  :database connection
                   :table table
                   :columns columns)))
     (initialize-copier copier)
@@ -27,9 +27,7 @@
               (socket (connection-socket connection)))
          (with-reconnect-restart connection
            (using-connection connection
-             (send-copy-done socket))))
-    (when abort
-      (close-database (copier-database self))))
+             (send-copy-done socket)))))
   (copier-count self))
 
 (defun db-write-row (self row &optional (data (prepare-row self row)))


### PR DESCRIPTION
Here's the patch implemented as you proposed, or at least my understanding of it. As we are moving away the control of the connection and transaction to the caller, I just removed any transaction management from the `close-db-writer` function.

I did try to implement a `with-copier` macro API in the postmodern package but as the API is used in 3 steps I don't think it makes much sense actually: first open, then write as many rows as you want to, then close.
