### PR TITLE
typo: *table-name*->*table-symbol*

### DIFF
--- a/postmodern/deftable.lisp
+++ b/postmodern/deftable.lisp
@@ -4,7 +4,7 @@
 (setf (documentation '*table-name* 'variable)
       "Used inside deftable to find the name of the table being defined.")
 (defvar *table-symbol*)
-(setf (documentation '*table-name* 'variable)
+(setf (documentation '*table-symbol* 'variable)
       "Used inside deftable to find the symbol naming the table being defined.")
 
 (defvar *tables* ()


### PR DESCRIPTION
The documentation of _table-symbol_ was being set to _table-name_
