### PR TITLE
Improve error reporting, providing HINT, DETAIL and CONTEXT as separate entries.

### DIFF
--- a/cl-postgres/protocol.lisp
+++ b/cl-postgres/protocol.lisp
@@ -118,8 +118,11 @@ database-error condition."
         (error (cl-postgres-error::get-error-type code)
  	       :code code
  	       :message (get-field #\M)
- 	       :detail (or (get-field #\D) (get-field #\H))
- 	       :position (get-field #\p))))))
+ 	       :detail (get-field #\D)
+               :hint (get-field #\H)
+               :context (get-field #\W)
+ 	       :position (let ((position (get-field #\p)))
+                           (when position (parse-integer position))))))))
 
 (define-condition postgresql-warning (simple-warning)
   ())


### PR DESCRIPTION
The PostgreSQL protocol defines error fields with some precision, as can be read at http://www.postgresql.org/docs/current/static/protocol-error-fields.html.

This patch improves the database-error condition to expose important fields separately and fixes get-error so that news fields are properly filled when an error occurs.

Sorry about the mess in terms of commit history in that pull request, it seems I started from a unclean repository. The diff seems ok though, and 32ff43226651ed39725301b537751e16ed58e6b9 should be the only patch to consider here.

I'm going to need the CONTEXT separately in pgloader so that I can parse it to better handle COPY errors.

Happy Christmas,
