### PR TITLE
Use cl-posgres:to-sql-string to evaluate the values inserted into s-sql expressions via s-sql:$$ 

### DIFF
--- a/s-sql/s-sql.lisp
+++ b/s-sql/s-sql.lisp
@@ -348,7 +348,9 @@ to strings \(which will form an SQL query when concatenated)."
     (lambda (&rest args)
       (with-output-to-string (*standard-output*)
         (dolist (element compiled)
-          (princ (if (eq element '$$) (sql-escape (pop args)) element)))))))
+          (princ (if (eq element '$$)
+                     (cl-postgres:to-sql-string (pop args))
+                     element)))))))
 
 ;; The reader syntax.
 


### PR DESCRIPTION
I am using cl-postgres:to-sql-string to convert symbols and keywords to sql values (these are stored in the database using a custom type and need to be written out differently from sql strings, normal lisp strings and sql identifiers).

Given the current handling of `$$`, whose values go through `s-sql:sql-escape`, it is impossible to provide a method to convert symbols to something other than sql identifiers; this patch changes this behaviour and skips sql-escape when interpolating `$$`.

This makes it impossible to compile an s-sql expression like this:

```
(:update a-table :set $$ $$)
```

and then pass in the name of the column at runtime. On the other hand it makes it possible to store symbols in the slots of DAO object (since `update-dao` creates an s-sql expression where `$$` is only used in the place of values and never identifiers).

Another approach to solving this issue would be to introduce an s-sql operator, called :value or something, which calls out to `to-sql-string` (and then change the code used in `update-dao` to wrap `$$` in this `:value` operator). I have not tried to actually implement that because, as far as i can tell, `$$` is meant for values and not identifiers and this change is smaller
