### PR TITLE
Missing </pre> in doc/s-sql.html

### DIFF
--- a/doc/s-sql.html
+++ b/doc/s-sql.html
@@ -464,6 +464,7 @@ Note the use of :order-by without parens
                 (:over (:rank)
                        (:partition-by 'depname :order-by (:desc 'salary)))
                 :from 'empsalary))
+    </pre>
 
     <p class="def"><span>sql-op</span> <a name="window"></a>:window (form)</p>
 


### PR DESCRIPTION
Due a simple missing </pre> tag after the example for `:order-by` the formatting of the rest of the documentation was all indented and improperly formatted.
