### PR TITLE
Add a SERIALIZE-FOR-POSTGRES generic method.

### DIFF
--- a/cl-postgres/messages.lisp
+++ b/cl-postgres/messages.lisp
@@ -152,14 +152,19 @@ for binding data for binary long object columns."
                        (setf (aref param-formats i) format
                              (aref param-sizes i) size
                              (aref param-values i) value)))
+                (declare (inline set-param))
                 (cond ((eq param :null)
                        (set-param 0 0 nil))
                       ((typep param '(vector (unsigned-byte 8)))
                        (set-param 1 (length param) param))
                       (t
                        (unless (typep param 'string)
-                         (setf param (to-sql-string param)))
-                       (set-param 0 (enc-byte-length param) param)))))
+                         (setf param (serialize-for-postgres param)))
+                       (etypecase param
+                         (string
+                          (set-param 0 (enc-byte-length param) param))
+                         ((vector (unsigned-byte 8))
+                          (set-param 1 (length param) param)))))))
     (write-uint1 socket #.(char-code #\B))
     (write-uint4 socket (+ 12
                            (enc-byte-length name)

--- a/cl-postgres/package.lisp
+++ b/cl-postgres/package.lisp
@@ -42,6 +42,7 @@
            #:default-sql-readtable
            #:set-sql-reader
            #:set-sql-datetime-readers
+           #:serialize-for-postgres
            #:to-sql-string
            #:*silently-truncate-rationals*
            #:*query-callback*

--- a/cl-postgres/sql-string.lisp
+++ b/cl-postgres/sql-string.lisp
@@ -103,3 +103,8 @@ whether the string should be escaped before being put into a query.")
     "NULL")
   (:method ((arg t))
     (error "Value ~S can not be converted to an SQL literal." arg)))
+
+(defgeneric serialize-for-postgres (arg)
+  (:documentation "Conversion function used to turn a lisp value into a value that PostgreSQL understands when sent through its socket connection. May return a string or a (vector (unsigned-byte 8)).")
+  (:method (arg)
+    (to-sql-string arg)))


### PR DESCRIPTION
It can be customized to serialize lisp values directly into the socket
stream either as string or as bytes. Defaults to TO-SQL-STRING.

E.g. the integration with local-time can use it to emit the binary
timestamp format of PostgreSQL and avoid printing and parsing of
human readable timestamp strings.
