### PR TITLE
Be more clear around ratio serialization

### DIFF
--- a/cl-postgres/package.lisp
+++ b/cl-postgres/package.lisp
@@ -43,7 +43,7 @@
            #:set-sql-reader
            #:set-sql-datetime-readers
            #:to-sql-string
-           #:*silently-truncate-rationals*
+           #:*silently-truncate-ratios*
            #:*query-callback*
            #:*query-log*
            #:open-db-writer

--- a/cl-postgres/sql-string.lisp
+++ b/cl-postgres/sql-string.lisp
@@ -14,7 +14,7 @@ textual format for binary data."
                       (princ (digit-char (ldb (byte 3 0) byte) 8) out))
                     (princ (code-char byte) out))))))
 
-(defparameter *silently-truncate-ratios* t)
+(defparameter *silently-truncate-ratios* nil)
 
 (defun write-ratio-as-floating-point (number stream digit-length-limit)
   (declare #.*optimize* (type fixnum digit-length-limit))


### PR DESCRIPTION
- Use 'ratio' instead of 'rational' in some names
  - Signal a more descriptive error from WRITE-RATIO-AS-FLOATING-POINT
  - Add CONTINUE restarts to WRITE-RATIO-AS-FLOATING-POINT in case
    the ratio cannot be serialized without a loss of precision, and
    _SILENTLY-TRUNCATE-RATIOS_ is false.

as a separate patch:
- Turn off _silently-truncate-ratios_ by default
