### PR TITLE
enable-s-sql-syntax properly listed as a function in the docs.

### DIFF
--- a/doc/s-sql.html
+++ b/doc/s-sql.html
@@ -71,7 +71,7 @@
     values of the arguments.</p>
 
     <p class="def">
-      <span>macro</span>
+      <span>function</span>
       <a name="enable-s-sql-syntax"></a>
       enable-s-sql-syntax (&amp;optional (char #\Q))
     </p>


### PR DESCRIPTION
The documentation had a small mistake listing enable-s-sql-syntax as a macro instead of a function
