### PR TITLE
Support for closing named parsed / prepared statements

### DIFF
--- a/cl-postgres/messages.lisp
+++ b/cl-postgres/messages.lisp
@@ -105,6 +105,11 @@ message definitions themselves stay readable."
   (string query)
   (uint 2 0))
 
+;; Close a named parsed query, freeing the name.
+(define-message close-prepared-message #\C (name)
+  (uint 1 #.(char-code #\S)) ;; Prepared statement
+  (string name))
+
 (defun formats-to-bytes (formats)
   "Formats have to be passed as arrays of 2-byte integers, with 1
 indicating binary and 0 indicating plain text."

--- a/cl-postgres/protocol.lisp
+++ b/cl-postgres/protocol.lisp
@@ -412,6 +412,19 @@ results."
         ;; ParseComplete
         (#\1)))))
 
+(defun send-close (socket name)
+  "Send a close command to the server, giving it a name."
+  (declare (type stream socket)
+           (type string name)
+           #.*optimize*)
+  (with-syncing
+    (close-prepared-message socket name)
+    (flush-message socket)
+    (force-output socket)
+    (message-case socket
+      ;; CloseComplete
+      (#\3))))
+
 (defun send-execute (socket name parameters row-reader)
   "Execute a previously parsed query, and apply the given row-reader
 to the result."

--- a/cl-postgres/public.lisp
+++ b/cl-postgres/public.lisp
@@ -247,6 +247,14 @@ result."
       (send-parse (connection-socket connection) name query)
       (values))))
 
+(defun unprepare-query (connection name)
+  "Close the prepared query given by name."
+  (check-type name string)
+  (with-reconnect-restart connection
+    (using-connection connection
+      (send-close (connection-socket connection) name)
+      (values))))
+
 (defun exec-prepared (connection name parameters &optional (row-reader 'ignore-row-reader))
   "Execute a previously prepared query with the given parameters,
 apply a row-reader to the result."

--- a/cl-postgres/tests.lisp
+++ b/cl-postgres/tests.lisp
@@ -73,6 +73,14 @@
     (is (equal (exec-prepared connection "test" '(42 nil "foo") 'list-row-reader)
                '((42 nil "foo"))))))
 
+(test unprepare-statement
+  (with-test-connection
+    (prepare-query connection "test" "select true")
+    (unprepare-query connection "test")
+    (prepare-query connection "test" "select false")
+    (is (equal (exec-prepared connection "test" '() 'list-row-reader)
+               '((false))))))
+      
 (test prepared-array-param
   (with-test-connection
     (prepare-query connection "test" "select ($1::int[])[2]")

--- a/doc/cl-postgres.html
+++ b/doc/cl-postgres.html
@@ -197,6 +197,16 @@
     value.</p>
 
     <p class="def">
+      <span>function</span>
+      <a name="unprepare-query"></a>
+      unprepare-query (database-connection name)
+    </p>
+
+    <p class="desc">Close the prepared statement by the given name.
+    This will free resources and allow the name to be associated with
+    a new prepared query.</p>
+
+    <p class="def">
       <span>method</span>
       <a name="to-sql-string"></a>
       to-sql-string (value)


### PR DESCRIPTION
I am not sure about the test. I don't know this testing framework or how to run the tests, but by analogy with existing tests, this seems about right. I have tested the code (lightly) and have been able to close statements and parse new statements re-using a name.