### PR TITLE
Fix typos and cosmetic documentation improvements

### DIFF
--- a/cl-postgres.asd
+++ b/cl-postgres.asd
@@ -10,11 +10,11 @@
 (defparameter *string-file* (if *unicode* "strings-utf-8" "strings-ascii"))
 
 (defsystem :cl-postgres
-  :description "Low-level client library for PosgreSQL"
+  :description "Low-level client library for PostgreSQL"
   :depends-on (:md5
                #-(or sbcl allegro ccl) :usocket
                #+sbcl                  :sb-bsd-sockets)
-  :components 
+  :components
   ((:module :cl-postgres
             :components ((:file "trivial-utf-8")
                          (:file "ieee-floats")

--- a/cl-postgres/protocol.lisp
+++ b/cl-postgres/protocol.lisp
@@ -6,7 +6,7 @@
 (define-condition protocol-error (error)
   ((message :initarg :message))
   (:report (lambda (err stream)
-             (format stream "Postgresql protocol error: ~A"
+             (format stream "PostgreSQL protocol error: ~A"
                      (slot-value err 'message))))
   (:documentation "This is raised if something really unexpected
 happens in the communcation with the server. Should only happen in
@@ -116,12 +116,12 @@ database-error condition."
         (when (or (string= code "57P01") (string= code "57P02"))
           (ensure-socket-is-closed socket))
         (error (cl-postgres-error::get-error-type code)
- 	       :code code
- 	       :message (get-field #\M)
- 	       :detail (get-field #\D)
+               :code code
+               :message (get-field #\M)
+               :detail (get-field #\D)
                :hint (get-field #\H)
                :context (get-field #\W)
- 	       :position (let ((position (get-field #\p)))
+               :position (let ((position (get-field #\p)))
                            (when position (parse-integer position))))))))
 
 (define-condition postgresql-warning (simple-warning)
@@ -133,7 +133,7 @@ database-error condition."
     (flet ((get-field (char)
              (cdr (assoc char data))))
       (warn 'postgresql-warning
-            :format-control "Postgres warning: ~A~@[~%~A~]"
+            :format-control "PostgreSQL warning: ~A~@[~%~A~]"
             :format-arguments (list (get-field #\M) (or (get-field #\D) (get-field #\H)))))))
 
 (defparameter *ssl-certificate-file* nil
@@ -147,7 +147,7 @@ database-error condition."
 ;; cl+ssl:make-ssl-client-stream function before.
 (let ((make-ssl-stream nil))
   (defun initiate-ssl (socket required)
-    "Initiate SSL handshake with the Posgres server, and wrap the
+    "Initiate SSL handshake with the PostgreSQL server, and wrap the
 socket in an SSL stream. When require is true, an error will be raised
 when the server does not support SSL."
     (unless make-ssl-stream

--- a/cl-postgres/public.lisp
+++ b/cl-postgres/public.lisp
@@ -51,7 +51,7 @@ currently connected."
   (defparameter *unix-socket-dir*
     #-(or freebsd darwin) "/var/run/postgresql/"
     #+(or darwin freebsd) "/tmp/"
-    "Directory where the Unix domain socket for Postgres be found.")
+    "Directory where the Unix domain socket for PostgreSQL be found.")
 
   (defun unix-socket-path (base-dir port)
     (unless (char= #\/ (aref base-dir (1- (length base-dir))))

--- a/doc/cl-postgres.html
+++ b/doc/cl-postgres.html
@@ -557,7 +557,7 @@
     <p class="desc">Writes <code>row-data</code> into the table and columns
     referenced by the writer.  <code>row-data</code> is a list of Lisp objects,
     one for each column included when opening the writer.  Arrays (the elements
-    of which must all be the same type) will be serialized into their Postgres
+    of which must all be the same type) will be serialized into their PostgreSQL
     representation before being written into the DB.
     </p>
 

--- a/doc/index.html
+++ b/doc/index.html
@@ -28,7 +28,7 @@
     <p>The biggest differences between this library and <a
     href="http://clsql.b9.com/">CLSQL</a>/CommonSQL are that
     Postmodern has no intention of being portable across different SQL
-    implementations (it embraces non-standard Postgres features), and
+    implementations (it embraces non-standard PostgreSQL features), and
     approaches extensions like lispy SQL and database access objects
     in a quite different way. This library was written because the
     CLSQL approach did not really work for me, your mileage may
@@ -372,7 +372,7 @@
       :where (:and (:= 'relkind "r")
                    (:not-in 'nspname (:set "pg_catalog" "pg_toast"))
                    (:pg-catalog.pg-table-is-visible 'pg-class.oid))))
-;; => "(SELECT relname FROM pg_catalog.pg_class 
+;; => "(SELECT relname FROM pg_catalog.pg_class
 ;;      INNER JOIN pg_catalog.pg_namespace ON (relnamespace = pg_namespace.oid)
 ;;      WHERE ((relkind = 'r') and (nspname NOT IN ('pg_catalog', 'pg_toast'))
 ;;             and pg_catalog.pg_table_is_visible(pg_class.oid)))"</pre>

--- a/doc/postmodern.html
+++ b/doc/postmodern.html
@@ -395,7 +395,7 @@
     <p class="def">
       <span>function</span>
       <a name="commit-hooks"></a>
-      commit-hooks (transaction-or-savepoint), 
+      commit-hooks (transaction-or-savepoint),
       setf (commit-hooks transaction-or-savepoint)
     </p>
 
@@ -917,7 +917,7 @@
       call <a href="#insert-dao"><code>insert-dao</code></a> directly, thus
       the behavior is like <code>save-dao</code>.</li>
       <li>Otherwise we try to update a record with the same primary key.  If
-      it already exists in the database, Postgres will return a non-zero
+      it already exists in the database, PostgreSQL will return a non-zero
       value and we stop here.</li>
       <li>If the update operation succeeds but returns zero, it means the
       record does not exist and we call <code>insert-dao</code>.
@@ -1149,7 +1149,7 @@
         Removes a schema. The schema must be empty, otherwise an error
         is raised.
     </p>
-    
+
     <p class="def">
       <span>function</span>
       <a name="get-search-path"></a>
@@ -1159,7 +1159,7 @@
     <p class="desc">
         Retrieve the current search path.
     </p>
-    
+
     <p class="def">
       <span>function</span>
       <a name="set-search-path"></a>

--- a/doc/s-sql.html
+++ b/doc/s-sql.html
@@ -443,7 +443,7 @@
 
     <p class="desc"><code>Over</code>, <code>partition-by</code> and <code>window</code> are so-called window
     functions. A window function performs a calculation across a set
-    of table rows that are somehow related to the current row.</p> 
+    of table rows that are somehow related to the current row.</p>
 
     <pre class="code desc">
 (query (:select 'salary (:over (:sum 'salary))
@@ -455,7 +455,7 @@
     <p class="desc"><code>Args</code> is a list of one or more columns
     to partition by, optionally followed by an <code>:order-by</code>
     clause.</p>
-    
+
     <pre class="code desc">
 (query (:select 'depname 'subdepname 'empno 'salary
                 (:over (:avg 'salary)
@@ -463,7 +463,7 @@
                 :from 'empsalary))</pre>
 
     <p class="desc">Note the use of <code>:order-by</code> without parens:</p>
-    
+
     <pre class="code desc">
 (query (:select 'depname 'empno 'salary
                 (:over (:rank)
@@ -557,10 +557,10 @@
 
     <p class="desc">Locks the selected rows against concurrent updates. This will prevent the rows
     from being modified or deleted by other transactions until the current transaction ends. The :of
-    keyword should be followed by one or more table names. If provided, Postgres will lock
+    keyword should be followed by one or more table names. If provided, PostgreSQL will lock
     these tables instead of the ones detected in the select statement. The :nowait keyword should be
     provided by itself (with no argument attached to it), after all the :of arguments . If :nowait
-    is provided, Postgres will throw an error if a table cannot be locked immediately, instead of
+    is provided, PostgreSQL will throw an error if a table cannot be locked immediately, instead of
     pausing until it's possible.</p>
 
     <pre class="desc code">
@@ -580,7 +580,7 @@
     should be one of <code>:immutable</code>, <code>:stable</code>, or
     <code>:volatile</code> (see <a
     href="http://www.postgresql.org/docs/current/static/sql-createfunction.html">the
-    Postgres manual</a>). For example, a function that gets foobars by
+    PostgreSQL documentation</a>). For example, a function that gets foobars by
     id:</p>
 
     <pre class="desc code">
@@ -607,9 +607,9 @@
     <p class="desc">Update values in a table. After the table name
     there should follow the keyword <code>:set</code> and any number
     of alternating field names and values, like
-    for <a href="#insert-into"><code>:insert-into</code></a>. Next comes 
+    for <a href="#insert-into"><code>:insert-into</code></a>. Next comes
     the optional keyword <code>:from</code>, followed by at least one table name
-    and then any number of join statements, like for 
+    and then any number of join statements, like for
     <a href="#select"><code>:select</code></a>. After the joins,
     an optional <code>:where</code> keyword followed by the condition,
     and <code>:returning</code> keyword followed by a list of field
@@ -738,7 +738,7 @@
         form as for <a href="#table-constraints"><code>:create-table</code></a>.
         (This is for backwards-compatibility, you should use named constraints.)</dd>
     </dl></div>
-    
+
     <p class="desc">Here is an example using the table defined above:</p>
 
     <pre class="code desc">

--- a/postmodern.asd
+++ b/postmodern.asd
@@ -13,7 +13,7 @@
   (pushnew :postmodern-use-mop *features*))
 
 (defsystem :postmodern
-  :description "PosgreSQL programming API"
+  :description "PostgreSQL programming API"
   :author "Marijn Haverbeke <marijnh@gmail.com>"
   :license "BSD"
   :depends-on (:cl-postgres :s-sql #+postmodern-use-mop :closer-mop

--- a/s-sql/s-sql.lisp
+++ b/s-sql/s-sql.lisp
@@ -109,7 +109,7 @@ and a - to indicate it does not take any elements."
                     "union" "unique" "user" "using" "verbose" "when" "where" "with" "for" "nowait" "share"))
       (setf (gethash word words) t))
     words)
-  "A set of all Postgres' reserved words, for automatic escaping.")
+  "A set of all PostgreSQL's reserved words, for automatic escaping.")
 
 (defparameter *escape-sql-names-p* :auto
   "Setting this to T will make S-SQL add double quotes around
@@ -507,8 +507,8 @@ with a given arity."
 
 (def-sql-op :count (what &optional distinct)
   `("COUNT(" ,@(when (eq distinct :distinct)
-				     '("DISTINCT "))
-	     ,@(sql-expand what)  ")"))
+                 '("DISTINCT "))
+             ,@(sql-expand what)  ")"))
 
 (def-sql-op :between (n start end)
   `("(" ,@(sql-expand n) " BETWEEN " ,@(sql-expand start) " AND " ,@(sql-expand end) ")"))
@@ -715,8 +715,8 @@ to runtime. Used to create stored procedures."
 (def-sql-op :delete-from (table &rest args)
   (split-on-keywords ((where ?) (returning ? *)) args
     `("DELETE FROM " ,@(sql-expand table)
-		     ,@(when where (cons " WHERE " (sql-expand (car where))))
-		     ,@(when returning (cons " RETURNING " (sql-expand-list returning))))))
+                     ,@(when where (cons " WHERE " (sql-expand (car where))))
+                     ,@(when returning (cons " RETURNING " (sql-expand-list returning))))))
 
 (def-sql-op :over (form &rest args)
   (if args `("(" ,@(sql-expand form) " OVER " ,@(sql-expand-list args) ")")
@@ -731,7 +731,7 @@ to runtime. Used to create stored procedures."
 (def-sql-op :parens (op) `(" (" ,@(sql-expand op) ") "))
 
 (def-sql-op :with (&rest args)
-  (let ((x (butlast args)) (y (last args))) 
+  (let ((x (butlast args)) (y (last args)))
     `("WITH " ,@(sql-expand-list x) ,@(sql-expand (car y)))))
 
 (def-sql-op :with-recursive (form1 form2)
@@ -748,10 +748,10 @@ to runtime. Used to create stored procedures."
   "Return the type and whether it may be NULL."
   (if (and (consp type) (eq (car type) 'or))
       (if (and (member 'db-null type) (= (length type) 3))
-	  (if (eq (second type) 'db-null)
-	      (values (third type) t)
-	      (values (second type) t))
-	  (sql-error "Invalid type: ~a. 'or' types must have two alternatives, one of which is ~s."
+          (if (eq (second type) 'db-null)
+              (values (third type) t)
+              (values (second type) t))
+          (sql-error "Invalid type: ~a. 'or' types must have two alternatives, one of which is ~s."
                      type 'db-null))
       (values type nil)))
 
@@ -899,10 +899,10 @@ to runtime. Used to create stored procedures."
   (split-on-keywords ((type) (default ?) (constraint-name ?) (check ?)) args
     (multiple-value-bind (type may-be-null) (dissect-type (car type))
       `("CREATE DOMAIN " ,@(sql-expand name) " AS " ,(to-type-name type)
-			 ,@(when default `(" DEFAULT " ,@(sql-expand (car default))))
-			 ,@(when constraint-name `(" CONSTRAINT " ,@(sql-expand (car constraint-name))))
-			 ,@(unless may-be-null '(" NOT NULL"))
-			 ,@(when check `(" CHECK" ,@(sql-expand (car check))))))))
+                         ,@(when default `(" DEFAULT " ,@(sql-expand (car default))))
+                         ,@(when constraint-name `(" CONSTRAINT " ,@(sql-expand (car constraint-name))))
+                         ,@(unless may-be-null '(" NOT NULL"))
+                         ,@(when check `(" CHECK" ,@(sql-expand (car check))))))))
 
 (def-sql-op :drop-domain (name)
   `("DROP DOMAIN " ,@(sql-expand name)))

--- a/simple-date/cl-postgres-glue.lisp
+++ b/simple-date/cl-postgres-glue.lisp
@@ -1,6 +1,6 @@
 (in-package :simple-date)
 
-;; Postgresql days are measured from 01-01-2000, whereas simple-date
+;; PostgreSQL days are measured from 01-01-2000, whereas simple-date
 ;; uses 01-03-2000.
 
 (defconstant +postgres-day-offset+ -60)


### PR DESCRIPTION
"posgres" -> "postgres"
"postgres" -> "postgresql"
