### PR TITLE
Added support for IPv6 only machines on SBCL.

### DIFF
--- a/cl-postgres/public.lisp
+++ b/cl-postgres/public.lisp
@@ -79,7 +79,7 @@ currently connected."
                         :format :binary
                         :remote-filename path)))
 
-
+#+sbcl
 (defun get-host-address (host)
   "Returns valid IPv4 or IPv6 address for the host."
   ;; get all IPv4 and IPv6 addresses as a list


### PR DESCRIPTION
Previously, cl-postgres just ignored any IPv6 addresses resolving
database's hostname.

This pull closes issue #82