### PR TITLE
Go back to 5am, modernize test systems

### DIFF
--- a/cl-postgres.asd
+++ b/cl-postgres.asd
@@ -27,18 +27,17 @@
                          (:file "interpret" :depends-on ("communicate" "ieee-floats"))
                          (:file "protocol" :depends-on ("interpret" "messages" "errors"))
                          (:file "public" :depends-on ("protocol"))
-                         (:file "bulk-copy" :depends-on ("public"))))))
+                         (:file "bulk-copy" :depends-on ("public")))))
+  :in-order-to ((test-op (test-op :cl-postgres-tests))))
 
 (defsystem :cl-postgres-tests
-  :depends-on (:cl-postgres :eos :simple-date)
+  :depends-on (:cl-postgres :fiveam :simple-date)
   :components
   ((:module :cl-postgres
-            :components ((:file "tests")))))
-
-(defmethod perform ((op asdf:test-op) (system (eql (find-system :cl-postgres))))
-  (asdf:oos 'asdf:load-op :cl-postgres-tests)
-  (funcall (intern (string :prompt-connection) (string :cl-postgres-tests)))
-  (funcall (intern (string :run!) (string :Eos)) :cl-postgres))
+            :components ((:file "tests"))))
+  :perform (test-op (o c)
+             (uiop:symbol-call :cl-postgres-tests '#:prompt-connection)
+             (uiop:symbol-call :fiveam '#:run! :cl-postgres)))
 
 (defmethod perform :after ((op asdf:load-op) (system (eql (find-system :cl-postgres))))
   (when (and (find-package :simple-date)

--- a/cl-postgres/tests.lisp
+++ b/cl-postgres/tests.lisp
@@ -1,6 +1,6 @@
 (defpackage :cl-postgres-tests
-  (:use :common-lisp :Eos :simple-date :cl-postgres :cl-postgres-error)
-  (:export #:prompt-connection))
+  (:use :common-lisp :fiveam :simple-date :cl-postgres :cl-postgres-error)
+  (:export #:prompt-connection #:*test-connection*))
 
 (in-package :cl-postgres-tests)
 
@@ -20,7 +20,7 @@
 
 ;; Adjust the above to some db/user/pass/host/[port] combination that
 ;; refers to a valid postgresql database, then after loading the file,
-;; run the tests with (Eos:run! :cl-postgres)
+;; run the tests with (fiveam:run! :cl-postgres)
 
 (def-suite :cl-postgres)
 (in-suite :cl-postgres)

--- a/postmodern.asd
+++ b/postmodern.asd
@@ -30,18 +30,15 @@
                          #+postmodern-use-mop
                          (:file "table" :depends-on ("util" "transaction"))
                          (:file "deftable" :depends-on
-                                ("query" #+postmodern-use-mop "table"))))))
+                                ("query" #+postmodern-use-mop "table")))))
+  :in-order-to ((test-op (test-op :postmodern-tests))))
 
 (defsystem :postmodern-tests
-  :depends-on (:postmodern :eos :simple-date :simple-date-postgres-glue)
+  :depends-on (:postmodern :fiveam :simple-date :simple-date-postgres-glue
+               :cl-postgres-tests)
   :components
   ((:module :postmodern
-            :components ((:file "tests")))))
-
-(defmethod perform ((op asdf:test-op) (system (eql (find-system :postmodern))))
-  (asdf:oos 'asdf:load-op :postmodern)
-  (asdf:oos 'asdf:load-op :cl-postgres-tests)
-  (asdf:oos 'asdf:load-op :postmodern-tests)
-  (funcall (intern (string :prompt-connection) (string :cl-postgres-tests))
-           (eval (intern (string :*test-connection*) (string :postmodern-tests))))
-  (funcall (intern (string :run!) (string :Eos)) :postmodern))
+            :components ((:file "tests"))))
+  :perform (test-op (o c)
+             (uiop:symbol-call :cl-postgres-tests '#:prompt-connection)
+             (uiop:symbol-call :fiveam '#:run! :postmodern)))

--- a/postmodern/tests.lisp
+++ b/postmodern/tests.lisp
@@ -1,14 +1,12 @@
 (defpackage :postmodern-tests
-  (:use :common-lisp :Eos :postmodern :simple-date))
+  (:use :common-lisp :fiveam :postmodern :simple-date :cl-postgres-tests))
 
 (in-package :postmodern-tests)
-
-(defvar *test-connection* '("test" "test" "" "localhost"))
 
 ;; Adjust the above to some db/user/pass/host combination that refers
 ;; to a valid postgresql database in which no table named test_data
 ;; currently exists. Then after loading the file, run the tests with
-;; (Eos:run! :postmodern)
+;; (fiveam:run! :postmodern)
 
 (def-suite :postmodern)
 (in-suite :postmodern)

--- a/simple-date.asd
+++ b/simple-date.asd
@@ -5,7 +5,8 @@
 (defsystem :simple-date
   :components 
   ((:module :simple-date
-            :components ((:file "simple-date")))))
+            :components ((:file "simple-date"))))
+  :in-order-to ((test-op (test-op :simple-date-tests))))
 
 (defsystem :simple-date-postgres-glue
   :depends-on (:simple-date :cl-postgres)
@@ -15,14 +16,12 @@
             ((:file "cl-postgres-glue")))))
 
 (defsystem :simple-date-tests
-  :depends-on (:eos :simple-date)
+  :depends-on (:fiveam :simple-date)
   :components
   ((:module :simple-date
-            :components ((:file "tests")))))
-
-(defmethod perform ((op asdf:test-op) (system (eql (find-system :simple-date))))
-  (asdf:oos 'asdf:load-op :simple-date-tests)
-  (funcall (intern (string :run!) (string :Eos)) :simple-date))
+            :components ((:file "tests"))))
+  :perform (test-op (o c)
+             (uiop:symbol-call :fiveam '#:run! :simple-date)))
 
 (defmethod perform :after ((op asdf:load-op) (system (eql (find-system :simple-date))))
   (when (and (find-package :cl-postgres)

--- a/simple-date/tests.lisp
+++ b/simple-date/tests.lisp
@@ -1,9 +1,9 @@
 (defpackage :simple-date-tests
-  (:use :common-lisp :Eos :simple-date))
+  (:use :common-lisp :fiveam :simple-date))
 
 (in-package :simple-date-tests)
 
-;; After loading the file, run the tests with (Eos:run! :simple-date)
+;; After loading the file, run the tests with (fiveam:run! :simple-date)
 
 (def-suite :simple-date)
 (in-suite :simple-date)


### PR DESCRIPTION
Eos is discontinued - good thing it's trivial to revert.
Tests for cl-postgres and postmodern should share the connection.
Also, test-op works just fine, so no need for this perform methods.