### PR TITLE
Text and binary interpreter support

### DIFF
--- a/cl-postgres.asd
+++ b/cl-postgres.asd
@@ -51,6 +51,6 @@
   ((:module :cl-postgres
             :components ((:file "simple-date-tests"))))
   :perform (test-op (o c)
-             (uiop:symbol-call :cl-postgres-tests '#:prompt-connection)
+             (uiop:symbol-call :cl-postgres-simple-date-tests '#:prompt-connection)
              (uiop:symbol-call :fiveam '#:run! :cl-postgres-simple-date)))
 

--- a/cl-postgres/interpret.lisp
+++ b/cl-postgres/interpret.lisp
@@ -7,7 +7,9 @@ interpreters for those types know how to parse them.")
 
 (defparameter *sql-readtable* (make-hash-table)
   "The exported special var holding the current read table, a hash
-  mapping OIDs to (binary-p . interpreter-function) pairs.")
+mapping OIDs to instances of the type-interpreter class that contain
+functions for retreiving values from the database in text, and
+possible binary, form.")
 
 (defun interpret-as-text (stream size)
   "This interpreter is used for types that we have no specific

--- a/cl-postgres/interpret.lisp
+++ b/cl-postgres/interpret.lisp
@@ -142,7 +142,7 @@ interpreted as an array of the given type."
                      (funcall (interpreter-reader (get-type-interpreter oid)) stream size))))))
 
 ;; "row" types
-(defparameter *read-row-values-as-binary* nil)
+(defparameter *read-row-values-as-binary* t)
 (set-sql-reader 2249 #'read-row-value :binary-p (lambda () *read-row-values-as-binary*))
 
 (defmacro with-binary-row-values (&body body)

--- a/cl-postgres/interpret.lisp
+++ b/cl-postgres/interpret.lisp
@@ -142,14 +142,23 @@ interpreted as an array of the given type."
                      (funcall (interpreter-reader (get-type-interpreter oid)) stream size))))))
 
 ;; "row" types
-(defparameter *read-row-values-as-binary* t)
+(defparameter *read-row-values-as-binary* nil
+  "Controls whether row values (as in select row(1, 'foo') ) should be
+  received from the database in text or binary form. The default value
+  is nil, specifying that the results be sent back as text. Set this
+  to t to cause the results to be read as binary.")
+
 (set-sql-reader 2249 #'read-row-value :binary-p (lambda () *read-row-values-as-binary*))
 
 (defmacro with-binary-row-values (&body body)
+  "Helper macro to locally set *read-row-values-as-binary* to t while
+executing body so that row values will be returned as binary."
   `(let ((*read-row-values-as-binary* t))
     ,@body))
 
 (defmacro with-text-row-values (&body body)
+  "Helper macro to locally set *read-row-values-as-binary* to nil while
+executing body so that row values will be returned as t."
   `(let ((*read-row-values-as-binary* nil))
     ,@body))
 

--- a/cl-postgres/interpret.lisp
+++ b/cl-postgres/interpret.lisp
@@ -273,9 +273,19 @@ used. Correct for sign bit when using integer format."
          (+ +start-of-2000+ (* days-since-2000 +seconds-in-day+)))
  :timestamp (lambda (useconds-since-2000)
               (+ +start-of-2000+ (floor useconds-since-2000 1000000)))
+ :timestamp-with-timezone (lambda (useconds-since-2000)
+                            (+ +start-of-2000+ (floor useconds-since-2000 1000000)))
  :interval (lambda (months days useconds)
              (multiple-value-bind (sec us) (floor useconds 1000000)
-               `((:months ,months) (:days ,days) (:seconds ,sec) (:useconds ,us)))))
+               `((:months ,months) (:days ,days) (:seconds ,sec) (:useconds ,us))))
+ :time (lambda (usecs)
+         (multiple-value-bind (seconds usecs)
+             (floor usecs 1000000)
+           (multiple-value-bind (minutes seconds)
+               (floor seconds 60)
+             (multiple-value-bind (hours minutes)
+                 (floor minutes 60)
+               `((:hours ,hours) (:minutes ,minutes) (:seconds ,seconds) (:microseconds ,usecs)))))))
 
 ;; Readers for a few of the array types
 

--- a/cl-postgres/interpret.lisp
+++ b/cl-postgres/interpret.lisp
@@ -47,10 +47,8 @@ interpreter and return the appropriate reader."
                                           :use-binary nil
                                           :text-reader #'interpret-as-text)))
   (defun get-type-interpreter (oid)
-    "Returns a pair representing the interpretation rules for this
-type. The car is a boolean indicating whether the type should be
-fetched as binary, and the cdr is a function that will read the value
-from the socket and build a Lisp value from it."
+    "Returns a type-interpreter containing interpretation rules for
+this type."
     (gethash oid *sql-readtable* default-interpreter)))
 
 (defun set-sql-reader (oid function &key (table *sql-readtable*) binary-p)

--- a/cl-postgres/package.lisp
+++ b/cl-postgres/package.lisp
@@ -45,6 +45,9 @@
            #:set-sql-datetime-readers
            #:serialize-for-postgres
            #:to-sql-string
+           #:*read-row-values-as-binary*
+           #:with-binary-row-values
+           #:with-text-row-values
            #:*silently-truncate-rationals*
            #:*query-callback*
            #:*query-log*

--- a/cl-postgres/simple-date-tests.lisp
+++ b/cl-postgres/simple-date-tests.lisp
@@ -14,9 +14,16 @@
 (test row-timestamp-with-time-zone-binary
   (with-test-connection
     (with-binary-row-values
-      (is (time= (caaar (exec-query connection "select row('2010-04-05 14:42:21.500'::timestamp with time zone)"
-                                    'list-row-reader))
-                 (encode-timestamp 2010 4 5 14 42 21 500))))))
+      (destructuring-bind (gmt pdt)
+          (caar
+           (exec-query
+            connection
+            (concatenate 'string
+                         "select row('2010-04-05 14:42:21.500'::timestamp with time zone at time zone 'GMT', "
+                         " '2010-04-05 14:42:21.500'::timestamp with time zone at time zone 'PST')")
+            'list-row-reader))
+        (is (time= gmt (encode-timestamp 2010 4 5 14 42 21 500)))
+        (is (time= pdt (encode-timestamp 2010 4 5 6 42 21 500)))))))
 
 (test row-timestamp-without-time-zone-array-binary
   (with-test-connection

--- a/cl-postgres/simple-date-tests.lisp
+++ b/cl-postgres/simple-date-tests.lisp
@@ -1,6 +1,28 @@
 
-(in-package :cl-postgres-tests)
+(defpackage :cl-postgres-simple-date-tests
+  (:use :common-lisp :fiveam :cl-postgres :cl-postgres-error :simple-date)
+  (:export #:prompt-connection #:*test-connection*))
 
+(in-package :cl-postgres-simple-date-tests)
+
+(defparameter *test-connection* '("test" "test" "" "localhost"))
+
+(defun prompt-connection (&optional (list *test-connection*))
+  (flet ((ask (name pos)
+           (format *query-io* "~a (enter to keep '~a'): " name (nth pos list))
+           (finish-output *query-io*)
+           (let ((answer (read-line *query-io*)))
+             (unless (string= answer "") (setf (nth pos list) answer)))))
+    (format *query-io* "~%To run this test, you must configure a database connection.~%")
+    (ask "Database name" 0)
+    (ask "User" 1)
+    (ask "Password" 2)
+    (ask "Hostname" 3)))
+
+(defmacro with-test-connection (&body body)
+  `(let ((connection (apply 'open-database *test-connection*)))
+    (unwind-protect (progn ,@body)
+      (close-database connection))))
 (def-suite :cl-postgres-simple-date)
 (in-suite :cl-postgres-simple-date)
 

--- a/cl-postgres/simple-date-tests.lisp
+++ b/cl-postgres/simple-date-tests.lisp
@@ -35,6 +35,7 @@
 
 (test row-timestamp-with-time-zone-binary
   (with-test-connection
+    (exec-query connection "set time zone 'GMT'")
     (with-binary-row-values
       (destructuring-bind (gmt pdt)
           (caar

--- a/cl-postgres/simple-date-tests.lisp
+++ b/cl-postgres/simple-date-tests.lisp
@@ -1,0 +1,41 @@
+
+(in-package :cl-postgres-tests)
+
+(def-suite :cl-postgres-simple-date)
+(in-suite :cl-postgres-simple-date)
+
+(test row-timestamp-without-time-zone-binary
+  (with-test-connection
+    (with-binary-row-values
+      (is (time= (caaar (exec-query connection "select row('2010-04-05 14:42:21.500'::timestamp without time zone)"
+                                    'list-row-reader))
+                 (encode-timestamp 2010 4 5 14 42 21 500))))))
+
+(test row-timestamp-with-time-zone-binary
+  (with-test-connection
+    (with-binary-row-values
+      (is (time= (caaar (exec-query connection "select row('2010-04-05 14:42:21.500'::timestamp with time zone)"
+                                    'list-row-reader))
+                 (encode-timestamp 2010 4 5 14 42 21 500))))))
+
+(test row-timestamp-without-time-zone-array-binary
+  (with-test-connection
+    (with-binary-row-values
+      (is (time= (elt (caaar (exec-query connection "select row(ARRAY['2010-04-05 14:42:21.500'::timestamp without time zone])"
+                                         'list-row-reader)) 0)
+                 (encode-timestamp 2010 4 5 14 42 21 500))))))
+
+(test row-time-binary
+  (with-test-connection
+    (with-binary-row-values
+      (is (time= (caaar (exec-query connection "select row('05:00'::time)"
+                                    'list-row-reader))
+                 (encode-time-of-day 5 0))))))
+
+(test row-timestamp-binary
+  (with-test-connection
+    (with-binary-row-values
+      (is (time= (caaar (exec-query connection "select row('2010-04-05 14:42:21.500'::timestamp)"
+                                    'list-row-reader))
+                 (encode-timestamp 2010 4 5 14 42 21 500))))))
+

--- a/cl-postgres/tests.lisp
+++ b/cl-postgres/tests.lisp
@@ -359,6 +359,23 @@
                             'list-row-reader)
                 '(("(\"2010-04-05 14:42:21.5+00\")"))))))
 
+(test row-timestamp-with-time-zone-binary
+  (with-default-readtable
+    (with-test-connection
+      (with-binary-row-values
+        (destructuring-bind (gmt pdt)
+            (caar
+             (exec-query
+              connection
+              (concatenate 'string
+                           "select row('2010-04-05 14:42:21.500'::timestamp with time zone at time zone 'GMT', "
+                           " '2010-04-05 14:42:21.500'::timestamp with time zone at time zone 'PST')")
+              'list-row-reader))
+          (is (equalp (multiple-value-list gmt)
+                      '(21 42 14 5 4 2010 0 NIL 0)))
+          (is (equalp (multiple-value-list pdt)
+                      '(21 42 14 5 4 2010 0 NIL 0))))))))
+
 (test row-timestamp-array
   (with-default-readtable
     (with-test-connection

--- a/cl-postgres/tests.lisp
+++ b/cl-postgres/tests.lisp
@@ -372,9 +372,9 @@
                            " '2010-04-05 14:42:21.500'::timestamp with time zone at time zone 'PST')")
               'list-row-reader))
           (is (equalp (multiple-value-list gmt)
-                      '(21 42 14 5 4 2010 0 NIL 0)))
+                      '(3479467341)))
           (is (equalp (multiple-value-list pdt)
-                      '(21 42 14 5 4 2010 0 NIL 0))))))))
+                      '(3479438541))))))))
 
 (test row-timestamp-array
   (with-default-readtable

--- a/cl-postgres/tests.lisp
+++ b/cl-postgres/tests.lisp
@@ -355,6 +355,7 @@
 
 (test row-timestamp-with-time-zone
   (with-test-connection
+    (exec-query connection "set time zone 'GMT'")
     (is (equalp (exec-query connection "select row('2010-04-05 14:42:21.500'::timestamp with time zone)"
                             'list-row-reader)
                 '(("(\"2010-04-05 14:42:21.5+00\")"))))))
@@ -362,6 +363,7 @@
 (test row-timestamp-with-time-zone-binary
   (with-default-readtable
     (with-test-connection
+      (exec-query connection "set time zone 'GMT'")
       (with-binary-row-values
         (destructuring-bind (gmt pdt)
             (caar

--- a/cl-postgres/tests.lisp
+++ b/cl-postgres/tests.lisp
@@ -1,6 +1,6 @@
 (defpackage :cl-postgres-tests
-  (:use :common-lisp :fiveam :simple-date :cl-postgres :cl-postgres-error)
-  (:export #:prompt-connection #:*test-connection*))
+  (:use :common-lisp :fiveam :cl-postgres :cl-postgres-error)
+  (:export #:prompt-connection #:*test-connection* #:with-test-connection))
 
 (in-package :cl-postgres-tests)
 

--- a/cl-postgres/tests.lisp
+++ b/cl-postgres/tests.lisp
@@ -227,11 +227,41 @@
     (is (time= (elt (caaar (exec-query connection "select row(ARRAY['1980-02-01'::date])" 'list-row-reader)) 0)
                (encode-date 1980 2 1)))))
 
+(test row-timestamp
+  (with-test-connection
+    (is (time= (caaar (exec-query connection "select row('2010-04-05 14:42:21.500'::timestamp)"
+                                  'list-row-reader))
+               (encode-timestamp 2010 4 5 14 42 21 500)))))
+
+(test row-timestamp-without-time-zone
+  (with-test-connection
+    (is (time= (caaar (exec-query connection "select row('2010-04-05 14:42:21.500'::timestamp without time zone)"
+                                  'list-row-reader))
+               (encode-timestamp 2010 4 5 14 42 21 500)))))
+
+(test row-timestamp-with-time-zone
+  (with-test-connection
+    (is (time= (caaar (exec-query connection "select row('2010-04-05 14:42:21.500'::timestamp with time zone)"
+                                  'list-row-reader))
+               (encode-timestamp 2010 4 5 14 42 21 500)))))
+
 (test row-timestamp-array
   (with-test-connection
     (is (time= (elt (caaar (exec-query connection "select row(ARRAY['2010-04-05 14:42:21.500'::timestamp])"
                                        'list-row-reader)) 0)
                (encode-timestamp 2010 4 5 14 42 21 500)))))
+
+(test row-timestamp-without-time-zone-array
+  (with-test-connection
+    (is (time= (elt (caaar (exec-query connection "select row(ARRAY['2010-04-05 14:42:21.500'::timestamp without time zone])"
+                                       'list-row-reader)) 0)
+               (encode-timestamp 2010 4 5 14 42 21 500)))))
+
+(test row-time
+  (with-test-connection
+    (is (time= (caaar (exec-query connection "select row('05:00'::time)"
+                                  'list-row-reader))
+               (encode-time-of-day 5 0)))))
 
 (test row-interval-array
   (with-test-connection

--- a/simple-date/simple-date.lisp
+++ b/simple-date/simple-date.lisp
@@ -4,6 +4,7 @@
            #:timestamp #:encode-timestamp #:decode-timestamp
            #:timestamp-to-universal-time #:universal-time-to-timestamp
            #:interval #:encode-interval #:decode-interval
+           #:time-of-day #:encode-time-of-day #:decode-time-of-day
            #:time-add #:time-subtract
            #:time= #:time> #:time< #:time<= #:time>=))
 
@@ -167,6 +168,40 @@ time of day is not important."))
   "Returns the weekday of the given date as a number between 0 and 6,
 0 being Sunday and 6 being Saturday."
   (+ (mod (+ (days date) 3) 7)))
+
+(defclass time-of-day ()
+  ((hours :initarg :hours :accessor hours)
+   (minutes :initarg :minutes :accessor minutes)
+   (seconds :initarg :seconds :accessor seconds)
+   (microseconds :initarg :microseconds :accessor microseconds))
+  (:documentation "This class is used to represent time of day in
+  hours, minutes, seconds and microseconds."))
+
+(defmethod print-object ((time time-of-day) stream)
+  (print-unreadable-object (time stream :type t)
+    (with-accessors ((hours hours)
+                     (minutes minutes)
+                     (seconds seconds)
+                     (microseconds microseconds))
+        time
+      (format stream "~2,'0d:~2,'0d:~2,'0d~@[.~6,'0d~]"
+              hours minutes seconds (if (zerop microseconds) nil microseconds)))))
+
+(defun encode-time-of-day (hour minute &optional (second 0) (microsecond 0))
+  "Create a timestamp object."
+  (make-instance 'time-of-day
+                 :hours hour
+                 :minutes minute
+                 :seconds second
+                 :microseconds microsecond))
+
+(defun decode-time-of-day (time)
+  (with-accessors ((hours hours)
+                   (minutes minutes)
+                   (seconds seconds)
+                   (microseconds microseconds))
+      time
+    (values hours minutes seconds microseconds)))
 
 (defclass timestamp (date)
   ((millisecs :initarg :ms :accessor millisecs))
@@ -337,6 +372,12 @@ indicating whether they denote the same time or period."))
 (defmethod time= ((a interval) (b interval))
   (and (= (millisecs a) (millisecs b))
        (= (months a) (months b))))
+
+(defmethod time= ((a time-of-day) (b time-of-day))
+  (and (= (hours a) (hours b))
+       (= (minutes a) (minutes b))
+       (= (seconds a) (seconds b))
+       (= (microseconds a) (microseconds b))))
 
 (defgeneric time< (a b)
   (:documentation "Compare two time-related values, returns a boolean


### PR DESCRIPTION
So I think this is ready to go. I like the idea of the type-interpreter, rather than just a cons for the issue of whether to use binary, and possibly providing both a binary and a text reader. But, the big question I have is whether I should have avoided this altogether by adding the reader for type 2249 (row types) to my own readtable and left the whole issue to the application. Or we could provide some sort of *binary-row-sql-readtable* that folks could use. Lots of ways to solve the problem that are now more apparent to me, but what's here works. One open question is what's the default for row types? binary or text?