### PR TITLE
Simple date sql readtable

### DIFF
--- a/cl-postgres/simple-date-tests.lisp
+++ b/cl-postgres/simple-date-tests.lisp
@@ -19,10 +19,16 @@
     (ask "Password" 2)
     (ask "Hostname" 3)))
 
+(defmacro with-simple-date-readtable (&body body)
+  `(let ((*sql-readtable* (simple-date-cl-postgres-glue:simple-date-sql-readtable)))
+    ,@body))
+
 (defmacro with-test-connection (&body body)
   `(let ((connection (apply 'open-database *test-connection*)))
-    (unwind-protect (progn ,@body)
-      (close-database connection))))
+    (with-simple-date-readtable
+      (unwind-protect (progn ,@body)
+        (close-database connection)))))
+
 (def-suite :cl-postgres-simple-date)
 (in-suite :cl-postgres-simple-date)
 

--- a/simple-date/simple-date.lisp
+++ b/simple-date/simple-date.lisp
@@ -4,7 +4,8 @@
            #:timestamp #:encode-timestamp #:decode-timestamp
            #:timestamp-to-universal-time #:universal-time-to-timestamp
            #:interval #:encode-interval #:decode-interval
-           #:time-of-day #:encode-time-of-day #:decode-time-of-day
+           #:time-of-day #:hours #:minutes #:seconds #:microseconds
+           #:encode-time-of-day #:decode-time-of-day
            #:time-add #:time-subtract
            #:time= #:time> #:time< #:time<= #:time>=))
 


### PR DESCRIPTION
Saves the pristine simple-date sql readtable for use by tests so we don't have to play games with the order of loading the files when running the tests.