### PR TITLE
respect text/binary choice for record arrays

### DIFF
--- a/cl-postgres/interpret.lisp
+++ b/cl-postgres/interpret.lisp
@@ -232,9 +232,15 @@ executing body so that row values will be returned as t."
                1561 ;; bit array
                1563 ;; varbit array
                1231 ;; numeric array
-               2287 ;; record array
                ))
   (set-sql-reader oid #'read-binary-array-value :binary-p t))
+
+;; 2287 record array
+;;
+;; NOTE: need to treat this separately because if we want the record
+;; (row types) to come back as text, we have to read the array value
+;; as text.
+(set-sql-reader 2287 #'read-binary-array-value :binary-p (lambda () *read-row-values-as-binary*))
 
 (define-interpreter 600 "point" ((point-x-bits uint 8)
                                  (point-y-bits uint 8))

--- a/cl-postgres/tests.lisp
+++ b/cl-postgres/tests.lisp
@@ -627,3 +627,14 @@
                    'list-row-reader)
                   '(((#2A((0 0)))) ((NIL)) ((#2A((2 2)))) ((NIL)) ((NIL))))))
         (exec-query connection "drop table test")))))
+
+(test array-row-text
+  (with-test-connection
+    (is (equalp (exec-query connection "select array_agg(row(1,2,3));" 'list-row-reader)
+                '(("{\"(1,2,3)\"}"))))))
+
+(test array-row-binary
+  (with-test-connection
+    (cl-postgres::with-binary-row-values
+      (is (equalp (exec-query connection "select array_agg(row(1,2,3));" 'list-row-reader)
+                  '((#((1 2 3)))))))))


### PR DESCRIPTION
I thought we were done with this, but there's another corner case I overlooked: an array of row types. In this case, we have to decide text/binary when we request the array value. Since the default for row types is text, we better default to text for arrays of rows as well.

 * when we read a record array (row types), we need to decide ahead of
   time if we want text or binary. In other words, we can't get a binary
   array with text row types in it. Therefore, we'll respect the row
   type text/binary choice and use that to decide of the record array
   should come back as text or binary.

* add test for this while we're at it