### PR TITLE
Timestamp text reader

### DIFF
--- a/cl-postgres/interpret.lisp
+++ b/cl-postgres/interpret.lisp
@@ -56,18 +56,20 @@ this type."
 (defun set-sql-reader (oid function &key (table *sql-readtable*) binary-p)
   "Add an sql reader to a readtable. When the reader is not binary, it
 is wrapped by a function that will read the string from the socket."
-  (setf (gethash oid table)
-        (make-instance 'type-interpreter
-                       :oid oid
-                       :use-binary binary-p
-                       :binary-reader
-                       (when binary-p function)
-                       :text-reader
-                       (if binary-p
-                           'interpret-as-text
-                           (lambda (stream size)
-                             (funcall function
-                                      (enc-read-string stream :byte-length size))))))
+  (if function
+      (setf (gethash oid table)
+            (make-instance 'type-interpreter
+                           :oid oid
+                           :use-binary binary-p
+                           :binary-reader
+                           (when binary-p function)
+                           :text-reader
+                           (if binary-p
+                               'interpret-as-text
+                               (lambda (stream size)
+                                 (funcall function
+                                          (enc-read-string stream :byte-length size))))))
+      (remhash oid table))
   table)
 
 (defmacro binary-reader (fields &body value)

--- a/cl-postgres/interpret.lisp
+++ b/cl-postgres/interpret.lisp
@@ -319,13 +319,17 @@ used. Correct for sign bit when using integer format."
 
 ;; Public interface for adding date/time readers
 
+(defconstant +timestamp-oid+ 1114)
+(defconstant +timestamptz-oid+ 1184)
+(defconstant +time-oid+ 1083)
+
 (defun set-sql-datetime-readers (&key date timestamp timestamp-with-timezone interval time
                                  (table *sql-readtable*))
   (when date (set-date-reader date table))
-  (when timestamp (set-usec-reader 1114 timestamp table))
-  (when timestamp-with-timezone (set-usec-reader 1184 timestamp-with-timezone table))
+  (when timestamp (set-usec-reader +timestamp-oid+ timestamp table))
+  (when timestamp-with-timezone (set-usec-reader +timestamptz-oid+ timestamp-with-timezone table))
   (when interval (set-interval-reader interval table))
-  (when time (set-usec-reader 1083 time table))
+  (when time (set-usec-reader +time-oid+ time table))
   table)
 
 ;; Provide meaningful defaults for the date/time readers.

--- a/cl-postgres/package.lisp
+++ b/cl-postgres/package.lisp
@@ -56,7 +56,10 @@
            #:close-db-writer
            #:*ssl-certificate-file*
            #:*ssl-key-file*
-           #+(and sbcl unix) #:*unix-socket-dir*))
+           #+(and sbcl unix) #:*unix-socket-dir*
+           #:+timestamp-oid+
+           #:+timestamptz-oid+
+           #:+time-oid+))
 
 (defpackage :cl-postgres-error
   (:use :common-lisp :cl-postgres)

--- a/cl-postgres/tests.lisp
+++ b/cl-postgres/tests.lisp
@@ -67,6 +67,23 @@
         (is (= b 3479467341))
         (is (equal c '((:MONTHS 24) (:DAYS -4) (:SECONDS 0) (:USECONDS 0))))))))
 
+(test timestamp-with-time-zone-text
+  (let ((*sql-readtable* (copy-sql-readtable)))
+    (set-sql-reader +timestamptz-oid+ nil)
+    (with-test-connection
+      (exec-query connection "set time zone 'GMT'")
+      (is (equalp (exec-query connection "select '2010-04-05 14:42:21.500'::timestamp with time zone"
+                              'list-row-reader)
+                  '(("2010-04-05 14:42:21.5+00"))))
+      (exec-query connection "set time zone 'PST8PDT'")
+      (is (equalp (exec-query connection "select '2010-04-05 14:42:21.500'::timestamp with time zone"
+                              'list-row-reader)
+                  '(("2010-04-05 14:42:21.5-07"))))
+      (exec-query connection "set time zone 'GMT'")
+      (is (equalp (exec-query connection "select '2010-04-05 14:42:21.500'::timestamp at time zone 'America/New_York'"
+                              'list-row-reader)
+                  '(("2010-04-05 18:42:21.5+00")))))))
+
 (test alist-row-reader
   (with-test-connection
     (is (equal (exec-query connection "select 42 as foo, 99 as bar" 'alist-row-reader)


### PR DESCRIPTION
These commits allow for:

1) removing the sql-reader for a given oid by passing NIL as the function argument to set-sql-reader

2) defining and exporting constants for time, timestamp, and timestamptz (timestamp with time zone) oids

3) tests for text reading of timestamps with time zones

If you like this interface, we can continue to define constants for the other oids that have (default) binary readers.