### PR TITLE
Fixed compilation on SBCL < 1.2.5.

### DIFF
--- a/cl-postgres.asd
+++ b/cl-postgres.asd
@@ -18,7 +18,8 @@
   ((:module :cl-postgres
             :components ((:file "trivial-utf-8")
                          (:file "ieee-floats")
-                         (:file "package")
+                         (:file "features")
+                         (:file "package" :depends-on ("features"))
                          (:file "errors" :depends-on ("package"))
                          (:file "sql-string" :depends-on ("package"))
                          (:file #.*string-file* :depends-on ("package" "trivial-utf-8"))

--- a/cl-postgres/features.lisp
+++ b/cl-postgres/features.lisp
@@ -1,0 +1,13 @@
+(defpackage :cl-postgres.features
+  (:use :common-lisp)
+  (:export #:sbcl-available
+           #:sbcl-ipv6-available))
+(in-package :cl-postgres.features)
+
+
+(eval-when (:compile-toplevel :load-toplevel)
+  (when (find-package 'sb-bsd-sockets)
+    (pushnew 'sbcl-available *features*)
+
+    (when (find-symbol "INET6-SOCKET" 'sb-bsd-sockets)
+      (pushnew 'sbcl-ipv6-available *features*))))


### PR DESCRIPTION
A new package cl-postgres.features was added.
It probes features and adds them to *features*.

Right now it only tests if SBCL's sb-bsd-sockets are available
and if IPv6 is available in it. First feature is needed because
event 1.3.x version could be compiled without support
for bsd-sockets.

Tested on 1.2.4.debian and on 1.3.12 on the same debian, but installed with Roswell. But all these tests were on IPv4 network. I'll test in IPv6 only environment tomorrow.