### PR TITLE
Fix .asd files so they work well with ASDF 3.3

### DIFF
--- a/postmodern.asd
+++ b/postmodern.asd
@@ -12,14 +12,16 @@
   #+(or allegro clisp ecl lispworks mcl openmcl cmu sbcl)
   (pushnew :postmodern-use-mop *features*))
 
-(defsystem :postmodern
+(defsystem "postmodern"
   :description "PostgreSQL programming API"
   :author "Marijn Haverbeke <marijnh@gmail.com>"
   :license "BSD"
-  :depends-on (:cl-postgres :s-sql #+postmodern-use-mop :closer-mop
-                            #+postmodern-thread-safe :bordeaux-threads)
+  :depends-on ("cl-postgres"
+               "s-sql"
+               (:feature :postmodern-use-mop "closer-mop")
+               (:feature :postmodern-thread-safe "bordeaux-threads"))
   :components
-  ((:module :postmodern
+  ((:module "postmodern"
             :components ((:file "package")
                          (:file "connect" :depends-on ("package"))
                          (:file "query" :depends-on ("connect"))
@@ -27,17 +29,17 @@
                          (:file "util" :depends-on ("query"))
                          (:file "transaction" :depends-on ("query"))
                          (:file "namespace" :depends-on ("query"))
-                         #+postmodern-use-mop
-                         (:file "table" :depends-on ("util" "transaction"))
+                         (:file "table" :depends-on ("util" "transaction")
+                                :if-feature :postmodern-use-mop)
                          (:file "deftable" :depends-on
-                                ("query" #+postmodern-use-mop "table")))))
-  :in-order-to ((test-op (test-op :postmodern-tests))))
+                                ("query" (:feature :postmodern-use-mop "table"))))))
+  :in-order-to ((test-op (test-op "postmodern/tests"))))
 
-(defsystem :postmodern-tests
-  :depends-on (:postmodern :fiveam :simple-date :simple-date-postgres-glue
-               :cl-postgres-tests)
+(defsystem "postmodern/tests"
+  :depends-on ("postmodern" "fiveam" "simple-date" "simple-date/postgres-glue"
+                            "cl-postgres/tests")
   :components
-  ((:module :postmodern
+  ((:module "postmodern"
             :components ((:file "tests"))))
   :perform (test-op (o c)
              (uiop:symbol-call :cl-postgres-tests '#:prompt-connection)

--- a/s-sql.asd
+++ b/s-sql.asd
@@ -1,9 +1,5 @@
-(defpackage :s-sql-system
-  (:use :common-lisp :asdf))
-(in-package :s-sql-system)
-
-(defsystem :s-sql
-  :depends-on (:cl-postgres)
-  :components 
-  ((:module :s-sql
+(defsystem "s-sql"
+  :depends-on ("cl-postgres")
+  :components
+  ((:module "s-sql"
     :components ((:file "s-sql")))))

--- a/simple-date.asd
+++ b/simple-date.asd
@@ -1,29 +1,29 @@
-(defpackage :simple-date-system
-  (:use :common-lisp :asdf))
-(in-package :simple-date-system)
-
-(defsystem :simple-date
-  :components 
-  ((:module :simple-date
+(defsystem "simple-date"
+  :components
+  ((:module "simple-date"
             :components ((:file "simple-date"))))
-  :in-order-to ((test-op (test-op :simple-date-tests))))
+  :in-order-to ((test-op (test-op "simple-date/tests"))))
 
-(defsystem :simple-date-postgres-glue
-  :depends-on (:simple-date :cl-postgres)
+(defsystem "simple-date/tests"
+  :depends-on ("fiveam" "simple-date")
   :components
-  ((:module :simple-date
-            :components
-            ((:file "cl-postgres-glue")))))
-
-(defsystem :simple-date-tests
-  :depends-on (:fiveam :simple-date)
-  :components
-  ((:module :simple-date
+  ((:module "simple-date"
             :components ((:file "tests"))))
   :perform (test-op (o c)
              (uiop:symbol-call :fiveam '#:run! :simple-date)))
 
-(defmethod perform :after ((op asdf:load-op) (system (eql (find-system :simple-date))))
-  (when (and (find-package :cl-postgres)
-             (not (find-symbol (symbol-name '#:+postgres-day-offset+) :simple-date)))
-    (asdf:oos 'asdf:load-op :simple-date-postgres-glue)))
+(defsystem "simple-date/postgres-glue"
+  :depends-on ("simple-date" "cl-postgres")
+  :components
+  ((:module "simple-date"
+            :components
+            ((:file "cl-postgres-glue")))))
+
+#|
+;; The definitions below should work, unlike the bogus method they replace;
+;; but I recommend instead explicit dependency on simple-date/postgres-glue.
+(load-system "asdf-system-connections")
+(defsystem-connection "simple-date/with-postgres"
+  :requires ("simple-date" "cl-postgres")
+  :depends-on ("simple-date/postgres-glue"))
+|#


### PR DESCRIPTION
Do NOT call OPERATE (via its alias OOS) from within PERFORM :AFTER methods.

Follow the recommended ASDF best practices.
https://gitlab.common-lisp.net/asdf/asdf/blob/master/doc/best_practices.md

Keep as comments the recommended way to establish system connections
(which itself is discouraged).