### PR TITLE
Fix bug in QUERY macro.

### DIFF
--- a/postmodern/query.lisp
+++ b/postmodern/query.lisp
@@ -97,10 +97,11 @@ it specifies the format in which the results should be returned."
                      :else :collect arg)))
     (destructuring-bind (reader result-form) (reader-for-format format)
       (let ((base (if args
-                      `(progn
-                        (prepare-query *database* "" ,(real-query query))
-                        (exec-prepared *database* "" (list ,@args) ,reader))
-                      `(exec-query *database* ,(real-query query) ,reader))))
+		      (let ((vars (loop :for x :in args :collect (gensym))))
+			`(let ,(loop :for v :in vars :for a :in args :collect `(,v ,a))
+			   (prepare-query *database* "" ,(real-query query))
+			   (exec-prepared *database* "" (list ,@vars) ,reader)))
+		      `(exec-query *database* ,(real-query query) ,reader))))
         `(,result-form ,base)))))
 
 (defmacro execute (query &rest args)


### PR DESCRIPTION
There is a bug in the "query" macro: if any of the args is a form that evaluates "query", the result will be incorrect. The reason is that the macro first calls "prepare-query" and then evaluates the arguments.
Another call to the query macro will destroy the prepared query, since "query" always uses the same name for the prepared statement (empty string).