### PR TITLE
Escaping should prohibt downcase and any other changes to name

### DIFF
--- a/doc/s-sql.html
+++ b/doc/s-sql.html
@@ -130,8 +130,12 @@
     <code>T</code>, in which case every name is escaped,
     <code>NIL</code>, in which case none is, or <code>:auto</code>,
     which causes only <a
-    href="http://www.postgresql.org/docs/current/static/sql-keywords-appendix.html">reserved
+    href="http://www.postgresql.org/docs/current/static/sql-keywords-appendix.html"> reserved
     words</a> to be escaped.. The default value is <code>:auto</code>.
+    Binding this variable to :literal, shall not only add quotations,
+    but also prevents any additional alteration beyond changing character
+    case in the name. This allows to use names that contains arythmetic operators
+    and other characters that are normally replacde by underscore.
     Be careful when binding this with <code>let</code> and such
     &#x2015; since a lot of SQL compilation tends to happen at
     compile-time, the result might not be what you expect.</p>

--- a/s-sql/s-sql.lisp
+++ b/s-sql/s-sql.lisp
@@ -138,7 +138,7 @@ escape-p is :auto and the name contains reserved words."
                         (every #'digit-char-p (the string (subseq str 1))))
                    (princ str)
                    (loop :for ch :of-type character :across str
-                         :do (if (or (eq ch #\*) (alphanumericp ch))
+                         :do (if (or (eql ch #\*) (alphanumericp ch))
                                  (write-char ch)
                                  (write-char #\_))))))
         (declare (dynamic-extent (function string-fragment)

--- a/s-sql/s-sql.lisp
+++ b/s-sql/s-sql.lisp
@@ -139,7 +139,7 @@ escape-p is :auto and the name contains reserved words."
                         (char= (char str 0) #\$)
                         (every #'digit-char-p (the string (subseq str 1))))
                    (princ str)
-                   (loop :for ch :of-type character :across str
+                   (loop :for ch :across str
                          :do (if (or (eql ch #\*) (alphanumericp ch))
                                  (write-char ch)
                                  (write-char #\_))))))

--- a/s-sql/s-sql.lisp
+++ b/s-sql/s-sql.lisp
@@ -151,7 +151,7 @@ escape-p is :auto and the name contains reserved words."
               :for downcase := (map 'string #'char-downcase substring)
               :for auto-escape := (and (eq escape-p :auto)
                                        (gethash downcase *postgres-reserved-words*))
-              :for escape := (and (not auto-escape) escape-p)
+              :for escape := (and (not (eq escape-p :auto)) escape-p)
               :do (progn
                     (if escape
                         (format t "\"~a\"" substring)

--- a/s-sql/s-sql.lisp
+++ b/s-sql/s-sql.lisp
@@ -123,40 +123,39 @@ only for reserved words.")
 column, or operation name. Add quotes when escape-p is true, or
 escape-p is :auto and the name contains reserved words."
   (declare (optimize (speed 3) (debug 0)))
-  (let ((*print-pretty* nil)
-        (name (string name)))
+  (let* ((*print-pretty* nil)
+         (name (string name))
+         (length (length name)))
     (with-output-to-string (*standard-output*)
-      (flet ((subseq-downcase (str from to)
-               (let ((result (make-string (- to from))))
-                 (loop :for i :from from :below to
-                       :for p :from 0
-                       :do (setf (char result p) (if *downcase-symbols*
-                                                     (char-downcase (char str i))
-                                                     (char str i))))
-                 result))
+      (flet ((string-fragment (str from to)
+               (make-array (- to from) :element-type 'character
+                                       :displaced-to str
+                                       :displaced-index-offset from))
              (write-element (str)
                (declare (type string str))
-               (let ((escape-p (if (eq escape-p :auto)
-                                   (gethash str *postgres-reserved-words*)
-                                   escape-p)))
-                 (when escape-p
-                   (write-char #\"))
-                 (if (and (> (length str) 1) ;; Placeholders like $2
-                          (char= (char str 0) #\$)
-                          (every #'digit-char-p (the string (subseq str 1))))
-                     (princ str)
-                     (loop :for ch :of-type character :across str
-                           :do (if (or (eq ch #\*) (alphanumericp ch))
-                                   (write-char ch)
-                                   (write-char #\_))))
-                 (when escape-p
-                   (write-char #\")))))
-
+               (if (and (> (length str) 1) ;; Placeholders like $2
+                        (char= (char str 0) #\$)
+                        (every #'digit-char-p (the string (subseq str 1))))
+                   (princ str)
+                   (loop :for ch :of-type character :across str
+                         :do (if (or (eq ch #\*) (alphanumericp ch))
+                                 (write-char ch)
+                                 (write-char #\_))))))
+        (declare (dynamic-extent (function string-fragment)
+                                 (function write-element)))
         (loop :for start := 0 :then (1+ dot)
               :for dot := (position #\. name) :then (position #\. name :start start)
-              :do (write-element (subseq-downcase name start (or dot (length name))))
-              :if dot :do (princ #\.)
-              :else :do (return))))))
+              :for substring := (string-fragment name start (or dot length))
+              :for escape := (or (and (eq escape-p :auto)
+                                      (gethash substring *postgres-reserved-words*))
+                                 escape-p)
+              :do (progn
+                    (if escape
+                        (format t "\"~a\"" substring)
+                        (write-element (map 'string #'char-downcase substring)))
+                    (if (null dot)
+                        (return)
+                        (princ #\.))))))))
 
 (defun from-sql-name (str)
   "Convert a string to something that might have been its original

--- a/s-sql/s-sql.lisp
+++ b/s-sql/s-sql.lisp
@@ -152,7 +152,9 @@ escape-p is :auto and the name contains reserved words."
               :do (progn
                     (if escape
                         (format t "\"~a\"" substring)
-                        (write-element (map 'string #'char-downcase substring)))
+                        (write-element (if *downcase-symbols*
+                                           (map 'string #'char-downcase substring)
+                                           substring)))
                     (if (null dot)
                         (return)
                         (princ #\.))))))))

--- a/s-sql/s-sql.lisp
+++ b/s-sql/s-sql.lisp
@@ -194,7 +194,7 @@ characters other than #\-"
 (deftype serial8 () 'integer)
 
 (deftype db-null ()
-  ")Type for representing NULL values. Use like \(or integer db-null)
+  "Type for representing NULL values. Use like \(or integer db-null)
 for declaring a type to be an integer that may be null."
   '(eql :null))
 


### PR DESCRIPTION
I noticed this when I had to work with tables named in foo/bar convention. This little issue prohibits me from using S-SQL in my project.