### PR TITLE
fixes issue 110 on heap exhaustion and corrects a typo in s-sql/tests.lisp

### DIFF
--- a/cl-postgres/public.lisp
+++ b/cl-postgres/public.lisp
@@ -22,7 +22,7 @@ connection when it is somehow closed."))
 which is to store information about the prepared statements that
 exists for it."
   (or (slot-value connection 'meta)
-      (let ((meta-data (make-hash-table)))
+      (let ((meta-data (make-hash-table :test 'equal)))
         (setf (slot-value connection 'meta) meta-data)
         meta-data)))
 
@@ -101,10 +101,10 @@ currently connected."
                 (ecase (sb-bsd-sockets:host-ent-address-type host-ent)
                   (2  'sb-bsd-sockets:inet-socket)
                   (10 'sb-bsd-sockets:inet6-socket))
-                
+
                 #-cl-postgres.features:sbcl-ipv6-available
                 'sb-bsd-sockets:inet-socket
-                
+
                 :type :stream :protocol :tcp))
          (address (sb-bsd-sockets:host-ent-address host-ent)))
     (sb-bsd-sockets:socket-connect sock address port)

--- a/postmodern/prepare.lisp
+++ b/postmodern/prepare.lisp
@@ -5,18 +5,18 @@
   (let ((meta (connection-meta connection)))
     (unless (gethash id meta)
       (setf (gethash id meta) t)
-      (prepare-query connection (symbol-name id) query))))
+      (prepare-query connection id query))))
 
 (let ((next-id 0))
   (defun next-statement-id ()
     "Provide unique statement names."
     (incf next-id)
-    (intern (with-standard-io-syntax (format nil "STATEMENT-~A" next-id)) :keyword)))
+    (with-standard-io-syntax (format nil "STATEMENT-~A" next-id))))
 
 (defun generate-prepared (function-form query format)
   "Helper macro for the following two functions."
   (destructuring-bind (reader result-form) (reader-for-format format)
-    (let ((base `(exec-prepared *database* (symbol-name statement-id) params ,reader)))
+    (let ((base `(exec-prepared *database* statement-id params ,reader)))
       `(let ((statement-id (next-statement-id))
              (query ,(real-query query)))
         (,@function-form (&rest params)

--- a/s-sql/tests.lisp
+++ b/s-sql/tests.lisp
@@ -1090,7 +1090,7 @@ FROM manufacturers m LEFT JOIN LATERAL get_product_names(m.id) pname ON true;
 
 (test create-table-full-1
       "Test :create-table with extended table constraints."
-      (is (equal (s-sql:sql (:create-table faa.d_airports
+      (is (equal (s-sql:sql (:create-table-full faa.d_airports
 			    ((AirportID :type integer)
 			     (Name      :type text)
 			     (City      :type text)
@@ -1105,8 +1105,7 @@ FROM manufacturers m LEFT JOIN LATERAL get_product_names(m.id) pname ON true;
 			     (TZ        :type text))
 			    ()
 			    ((:distributed-by (airport_code)))))
-	  "CREATE TABLE faa.d_airports (airportid INTEGER NOT NULL, name TEXT NOT NULL, city TEXT NOT NULL, country TEXT NOT NULL, airport_code TEXT NOT NULL, icoa_code TEXT NOT NULL, latitude FLOAT8 NOT NULL, longitude FLOAT8 NOT NULL, altitud
-e FLOAT8 NOT NULL, timezoneoffset REAL NOT NULL, dst_flag TEXT NOT NULL, tz TEXT NOT NULL) DISTRIBUTED BY (airport_code) ")))
+	  "CREATE TABLE faa.d_airports (airportid INTEGER NOT NULL, name TEXT NOT NULL, city TEXT NOT NULL, country TEXT NOT NULL, airport_code TEXT NOT NULL, icoa_code TEXT NOT NULL, latitude FLOAT8 NOT NULL, longitude FLOAT8 NOT NULL, altitude FLOAT8 NOT NULL, timezoneoffset REAL NOT NULL, dst_flag TEXT NOT NULL, tz TEXT NOT NULL) DISTRIBUTED BY (airport_code) ")))
 
 (test sequence-tests
       "sequence testing"


### PR DESCRIPTION
This changes the meta-information hash to use strings instead of keywords, thus eliminating a source of heap exhaustion. See Issue 110.

It also corrects a few typos in the s-sql/tests.lisp test on the new create-table-full function.