### PR TITLE
Optimize WITH-CONNECTION for quoted lists 

### DIFF
--- a/postmodern/connect.lisp
+++ b/postmodern/connect.lisp
@@ -69,9 +69,14 @@ database."
 
 (defmacro with-connection (spec &body body)
   "Locally establish a database connection, and bind *database* to it."
-  `(let ((*database* (apply #'connect ,spec)))
-    (unwind-protect (progn ,@body)
-      (disconnect *database*))))
+  (let ((connect-form (if (and (listp spec)
+                               (= 2 (length spec))
+                               (eq (first spec) 'quote))
+                          `(funcall #'connect ,@(second spec))
+                          `(apply #'connect ,spec))))
+    `(let ((*database* ,connect-form))
+       (unwind-protect (progn ,@body)
+         (disconnect *database*)))))
 
 (defvar *max-pool-size* nil
   "The maximum amount of connection that will be kept in a single

--- a/postmodern/connect.lisp
+++ b/postmodern/connect.lisp
@@ -67,9 +67,10 @@ database."
     (unwind-protect (funcall thunk)
       (disconnect *database*))))
 
-(defmacro with-connection (spec &body body)
+(defmacro with-connection (spec &body body &environment env)
   "Locally establish a database connection, and bind *database* to it."
-  (let ((connect-form (if (and (listp spec)
+  (let ((connect-form (if (and (constantp spec env)
+                               (listp spec)
                                (= 2 (length spec))
                                (eq (first spec) 'quote))
                           `(funcall #'connect ,@(second spec))


### PR DESCRIPTION
Because of https://bugs.launchpad.net/sbcl/+bug/1750466 the `APPLY` call in `WITH-CONNECTION` generates compiler notes in SBCL.

`SPEC` is evaluated. Because `SPEC` might be a variable or a function call that produces the spec, it is important to keep the call to `APPLY`, but we can typecheck at macroexpansion time to see if we are dealing with a quoted list and optimize for that scenario.

Therefore, if the macro is called like `(with-connection '("foo" "bar" ...) ...)`, the `APPLY` call, unnecessary in this scenario, is replaced with a `FUNCALL`.

This is a small optimization that breaks the clarity of the `WITH-CONNECTION` macro and is **ugly**, therefore please only merge it if you think that it is worth it.