### PR TITLE
Fix for usocket dependency not being loaded by default on ABCL (as su…

### DIFF
--- a/cl-postgres.asd
+++ b/cl-postgres.asd
@@ -12,7 +12,7 @@
 (defsystem "cl-postgres"
   :description "Low-level client library for PostgreSQL"
   :depends-on ("md5"
-               (:feature (:or :sbcl :allegro :ccl :genera) "usocket")
+               (:feature (:or :sbcl :allegro :ccl :genera :armedbear) "usocket")
                (:feature :sbcl (:require :sb-bsd-sockets)))
   :components
   ((:module "cl-postgres"


### PR DESCRIPTION
…ggested by sabracrolleton).

Fixes https://github.com/marijnh/Postmodern/issues/149.

Command line ABCL session on Windows 10 (x64):

```
X:\Users\ps\Projects\Lisp\CommonLisp\Postmodern>java -jar \lisp\abcl-bin-1.5.0\abcl.jar
Armed Bear Common Lisp 1.5.0
Java 10.0.1 Oracle Corporation
Java HotSpot(TM) 64-Bit Server VM
Low-level initialization completed in 1.683 seconds.
Startup completed in 10.914 seconds.
Loading C:\Users\ps\.abclrc completed in 60.356 seconds.
Type ":help" for a list of available commands.
CL-USER(1): (ql:uninstall "postmodern")
T
CL-USER(2): (ql:uninstall "cl-postgres")
NIL
CL-USER(3): (push "./" asdf:*central-registry*)
("./" #P"C:/Users/ps/quicklisp/quicklisp/")
CL-USER(4): (asdf:operate 'asdf:load-op 'cl-postgres)
WARNING: System definition file #P"C:/Users/ps/quicklisp/dists/quicklisp/software/flexi-streams-20180328-git/flexi-streams.asd" contains definition for system "flexi-streams-test". Please only define "flexi-streams" and secondary systems with a name starting with "flexi-streams/" (e.g. "flexi-streams/test") in that file.
; Compiling X:/Users/ps/Projects/Lisp/CommonLisp/Postmodern/cl-postgres/trivial-utf-8.lisp ...
; (DEFPACKAGE :CL-POSTGRES-TRIVIAL-UTF-8 ...)
; (IN-PACKAGE :CL-POSTGRES-TRIVIAL-UTF-8)
; (DEFPARAMETER *OPTIMIZE* ...)
; (DEFUN UTF-8-BYTE-LENGTH ...)
; (DEFMACRO AS-UTF-8-BYTES ...)
; (DEFUN STRING-TO-UTF-8-BYTES ...)

... MANY SKIPPED LINES ...

; (DEFUN SEND-COPY-DONE ...)
; Wrote C:/Users/ps/AppData/Local/cache/common-lisp/abcl-1.5.0-fasl43-win-x64/X/Users/ps/Projects/Lisp/CommonLisp/Postmodern/cl-postgres/bulk-copy-tmpPHAQGTW7.abcl (3.207 seconds)

; Compilation unit finished
;   Caught 2 WARNING conditions
;   Caught 2 STYLE-WARNING conditions

#<ASDF/LISP-ACTION:LOAD-OP >
#<ASDF/PLAN:SEQUENTIAL-PLAN {CD26C8C}>
CL-USER(5):
```