### PR TITLE
Initial framework for adding isolation level support to transactions

### DIFF
--- a/cl-postgres/sql-string.lisp
+++ b/cl-postgres/sql-string.lisp
@@ -60,13 +60,14 @@ it will throw an error noting the loss of precision and offering to continue or 
                    (fail)
                    (return))
                  (multiple-value-bind (quotient rem) (floor (* remainder 10))
-                   (princ quotient stream)	                     (princ quotient stream)
+                   (princ quotient stream)
                    (setf remainder rem)))))))))
 
 (defparameter *silently-truncate-rationals* t)
 
 (defun write-rational-as-floating-point (number stream digit-length-limit)
-  "The same as write-ratio-as-floating point. Note the difference between rational and ratio. Kept for backwards compatibility.
+  "DEPRECATED. The same as write-ratio-as-floating point. Note the difference between rational and ratio.
+Kept for backwards compatibility.
 Given a ratio, a stream and a digital-length-limit, if *silently-truncate-rationals* is true,
 will return a potentially truncated ratio. If false and the digital-length-limit is reached,
 it will throw an error noting the loss of precision and offering to continue or reset
@@ -110,7 +111,7 @@ it will throw an error noting the loss of precision and offering to continue or 
                    (fail)
                    (return))
                  (multiple-value-bind (quotient rem) (floor (* remainder 10))
-                   (princ quotient stream)	                     (princ quotient stream)
+                   (princ quotient stream)
                    (setf remainder rem)))))))))
 
 (defun write-quoted (string out)

--- a/cl-postgres/tests.lisp
+++ b/cl-postgres/tests.lisp
@@ -701,7 +701,7 @@
     (signals error (cl-postgres::write-rational-as-floating-point (/ 1321 7) *standard-output* 5))
     (setf cl-postgres:*silently-truncate-rationals* t)
     (is (equal  (with-output-to-string (s) (cl-postgres::write-rational-as-floating-point (/ 1321 7) s 5))
-                "188.7711"))
+                "188.71"))
     (setf cl-postgres:*silently-truncate-rationals* old-silently-truncate)))
 
 (test write-ratio-as-floating-point
@@ -710,5 +710,5 @@
     (signals error (cl-postgres::write-ratio-as-floating-point (/ 1321 7) *standard-output* 5))
     (setf cl-postgres:*silently-truncate-ratios* t)
     (is (equal  (with-output-to-string (s) (cl-postgres::write-ratio-as-floating-point (/ 1321 7) s 5))
-                "188.7711"))
+                "188.71"))
     (setf cl-postgres:*silently-truncate-ratios* old-silently-truncate)))

--- a/postmodern.asd
+++ b/postmodern.asd
@@ -17,8 +17,11 @@
   :author "Marijn Haverbeke <marijnh@gmail.com>"
   :maintainer "Sabra Crolleton <sabra.crolleton@gmail.com>"
   :license "BSD"
-  :depends-on ("cl-postgres"
+  :depends-on ("alexandria"
+               "cl-postgres"
                "s-sql"
+               "global-vars"
+               "log4cl"
                (:feature :postmodern-use-mop "closer-mop")
                (:feature :postmodern-thread-safe "bordeaux-threads"))
   :components

--- a/postmodern/package.lisp
+++ b/postmodern/package.lisp
@@ -57,6 +57,14 @@
    ;; Condition type from cl-postgres
    #:database-error #:database-error-message #:database-error-code
    #:database-error-detail #:database-error-query #:database-error-cause
-   #:database-connection-error #:database-error-constraint-name))
+   #:database-connection-error #:database-error-constraint-name
+
+   ;; ported from postgres-json
+   #:*transaction-mode*
+   #:call-with-transaction
+   #:call-with-logical-transaction
+   #:call-with-ensured-transaction
+   #:abort-logical-transaction
+   #:commit-logical-transaction))
 
 (in-package :postmodern)

--- a/postmodern/transaction.lisp
+++ b/postmodern/transaction.lisp
@@ -2,6 +2,7 @@
 
 (defparameter *transaction-level* 0)
 (defparameter *current-logical-transaction* nil)
+(defvar *transaction-mode* "")
 
 (defclass transaction-handle ()
   ((open-p :initform t :accessor transaction-open-p)
@@ -16,7 +17,7 @@ arguments) to be executed at commit and abort time, respectively."))
 
 (defun call-with-transaction (body)
   (let ((transaction (make-instance 'transaction-handle)))
-    (execute "BEGIN")
+    (execute (format nil "BEGIN ~A" *transaction-mode*)) ; 4) This one line change
     (unwind-protect
          (multiple-value-prog1
              (let ((*transaction-level* (1+ *transaction-level*))
@@ -121,7 +122,7 @@ transaction or savepoint to NAME (if supplied)"
   (abort-transaction transaction))
 
 (defmethod commit-logical-transaction ((savepoint savepoint-handle))
-  (commit-transaction savepoint))
+  (release-savepoint savepoint))
 
 (defmethod commit-logical-transaction ((transaction transaction-handle))
   (commit-transaction transaction))
@@ -135,3 +136,192 @@ transaction or savepoint to NAME (if supplied)"
   "Executes body within a with-transaction form if and only if no
 transaction is already in progress."
   `(call-with-ensured-transaction (lambda () ,@body)))
+
+
+;;;; Postmodern transactions with isolation levels and RO, RW
+;;;; settings plus serialization failure handling.
+
+;;; The following adds support for setting the isolation level of a
+;;; Postmodern transaction, and setting the read only or read write
+;;; status of that transaction at the same time. See
+;;; http://www.postgresql.org/docs/9.4/static/sql-set-transaction.html
+
+;;; There is also support for a rudimentary retry loop to catch the
+;;; cl-postgres-error:serialization-failure conditions that may arise
+;;; when using 'repeatable read' or 'serializable' isolation levels.
+;;; Since 'read committed' is the default isolation level, many
+;;; Postgres users will never have seen such failures.  Postgres-JSON
+;;; requires either of the above isolation levels because of, say,
+;;; SUPERSEDE keeping a full history under the covers...
+
+;;; A small change to Postmodern is required to support these
+;;; additions, see postgres/postmodern.lisp
+
+;;;; Public specials
+
+(alexandria:define-constant +serializable-rw+
+    "isolation level serializable read write" :test 'string=
+    :documentation "START TRANSACTION string to set Postgres 'Serializable' isolation level and read/write.")
+
+(alexandria:define-constant +repeatable-read-rw+
+  "isolation level repeatable read read write" :test 'string=
+  :documentation "START TRANSACTION string to set Postgres 'Repeatable read' isolation level and read/write."  )
+
+(alexandria:define-constant +read-committed-ro+
+  "isolation level read committed read only" :test 'string=
+  :documentation "START TRANSACTION string to set Postgres 'Read committed' isolation level, which is the default, and read only.")
+
+(alexandria:define-constant +read-committed-rw+
+  "isolation level read committed read write" :test 'string=
+  :documentation "START TRANSACTION string to set Postgres 'Read committed' isolation level, which is the default, and read write.")
+
+(defvar *pgj-default-isolation-level* '+repeatable-read-rw+
+  "The isolation level, a symbol, to use for WITH-MODEL-TRANSACTION.
+For models that maintain history can only be +REPEATABLE-READ-RW+ or
++SERIALIZABLE-RW+.  For models without history could conceivably be
++READ-COMMITTED-RW+.")
+
+;;;; Implementation
+
+;; This should be thread safe as it it only ever bound local to a
+;; specific thread.
+(defvar *top-isolation-level* nil
+  "When we start the first transaction in a nested group, bind this
+to the isolation level requested.")
+
+;; By abuse of notation I am referring to the combination of isolation
+;; level _and_ read only/read write settings as just 'isolation
+;; level'.  For calculating the congruence of nested transactions the
+;; true isolation level is paramount but clearly you can't nest a RW
+;; level inside a RO one...
+(defvar *isolation-levels-hierarchy*
+  '(+read-committed-ro+ +read-committed-rw+ +repeatable-read-rw+ +serializable-rw+)
+  "A list of symbols for string constants which set Postgres isolation
+levels, and read only or read/write settings.  Nested transactions must
+be started with an isolation level to the left of, or at the same
+level as, the top level in the nested group.")
+
+(defun potential-serialization-failure-p (isolation-level)
+  "Certain isolation levels require client handling of the
+cl-postgres-error:serialization-failure condition.  This function
+returns true if ISOLATION-LEVEL, a symbol, is such an isolation
+level."
+  (member isolation-level '(+repeatable-read-rw+ +serializable-rw+)))
+
+(defun isolation-level-position (isolation-level)
+  "What POSITION does ISOLATION-LEVEL, a symbol, hold in the
+*ISOLATION-LEVELS-HIERARCHY*?"
+  (position isolation-level *isolation-levels-hierarchy*))
+
+(defun nestable-isolation-level-p (top-isolation-level isolation-level)
+  "Can you nest a new (virtual) transaction with ISOLATION-LEVEL, a
+symbol, inside a (true) transaction with TOP-ISOLATION-LEVEL?"
+  (<= (isolation-level-position isolation-level)
+      (isolation-level-position top-isolation-level)))
+
+(define-condition incompatible-transaction-setting (error)
+  ((transaction-name :initarg :transaction-name :reader transaction-name)
+   (original :initarg :original :reader original)
+   (current :initarg :current :reader current))
+  (:report (lambda (condition stream)
+             (format stream "You cannot nest the transaction named ~A with isolation level ~A
+inside a transaction with isolation level ~A."
+                     (transaction-name condition)
+                     (current condition)
+                     (original condition))))
+  (:documentation "Signaled for a nested invocation of
+WITH-ENSURED-TRANSACTION-LEVEL or WITH-LOGICAL-TRANSACTION-LEVEL
+inside a previous invocation with an incongruent isolation level."))
+
+(defun check-isolation-level (label isolation-level)
+  (unless (nestable-isolation-level-p *top-isolation-level* isolation-level)
+    (error 'incompatible-transaction-setting
+           :transaction-name label
+           :original *top-isolation-level*
+           :current isolation-level)))
+
+(defun transaction-thunk (transaction body)
+  `(lambda (,transaction)
+    (declare (ignorable ,transaction))
+    ,@body))
+
+;;;; Transactions proper in CALL-WITH style.
+;;;; Semi public - some clients may need/want these
+
+(defun call-with-transaction-level (label isolation-level thunk)
+  (log:debug "Starting transaction ~A" label)
+  ;; See postgres/postmodern.lisp for our proposed mods to Postmodern
+  (let ((pomo:*transaction-mode* (symbol-value isolation-level))
+        (*top-isolation-level* isolation-level))
+    (multiple-value-prog1 (pomo:call-with-transaction thunk)
+      (log:debug "Completing transaction ~A" label))))
+
+(defun call-with-logical-transaction-level (label isolation-level thunk)
+  (multiple-value-prog1
+      (if *top-isolation-level*
+          (progn
+            (check-isolation-level label isolation-level)
+            (log:debug "Nesting logical transaction ~A" label)
+            (pomo:call-with-logical-transaction label thunk))
+          (call-with-transaction-level label isolation-level thunk))
+    (log:debug "Completing logical transaction ~A" label)))
+
+(defun call-with-ensured-transaction-level (label isolation-level thunk)
+  (multiple-value-prog1
+      (if *top-isolation-level*
+          (progn
+            (check-isolation-level label isolation-level)
+            (log:trace "Nesting ensured transaction ~A" label)
+            ;; There is no "real" transaction to abort, so don't pass in label
+            (funcall thunk nil))
+          (progn
+            (log:trace "Starting ensured transaction ~A" label)
+            (call-with-transaction-level label isolation-level thunk)))
+    (log:trace "Completing ensured transaction ~A" label)))
+
+(defun call-with-retry-serialization-failure (label thunk)
+  (if *serialization-failure-sleep-times*
+      (dolist (sleep *serialization-failure-sleep-times* (funcall thunk))
+        (log:trace "In retry serial loop with sleep: ~A" sleep)
+        (handler-case
+            (return (funcall thunk))
+          (cl-postgres-error:serialization-failure ()
+            (log:debug "Handle serialization failure of ~A.  Sleeping around: ~A" label sleep)
+            (unless (zerop sleep) ; Do not wait the first time through
+              (sleep (+ sleep (/ (random 2000) 1000)))))))
+      (funcall thunk)))
+
+;;;; Public macro interface
+
+;;; These have the same name but with
+;;; a -level suffix.  The do the same thing but allow specification of
+;;; an isolation level.
+
+(defmacro with-transaction-level ((name isolation-level) &body body)
+  "Unilaterally evaluate BODY inside a Postmodern WITH-TRANSACTION
+form with Postgres 'transaction mode' set to the symbol-value of
+ISOLATION-LEVEL, a symbol.  The symbol NAME is bound to the Postmodern
+`transaction-handle' and may be used in calls to Postmodern's
+abort-transaction and commit-transaction."
+  `(call-with-transaction-level ',name ',isolation-level
+                                ,(transaction-thunk name body)))
+
+(defmacro with-logical-transaction-level ((name isolation-level) &body body)
+  "Similar to Postmodern's WITH-LOGICAL-TRANSACTION but start any top
+level transaction with Postgres 'transaction mode' set to the
+symbol-value of ISOLATION-LEVEL.  The symbol NAME is bound to the
+Postmodern `transaction-handle' and may be used in calls to
+Postmodern's abort-transaction and commit-transaction.  The condition
+`incompatible-transaction-setting' will be signaled for incongruent
+nested isolation levels."
+  `(call-with-logical-transaction-level ',name ',isolation-level
+                                        ,(transaction-thunk name body)))
+
+(defmacro ensure-transaction-level ((isolation-level) &body body)
+  "Similar to Postmodern's ENSURE-TRANSACTION but start any top level
+transaction with Postgres 'transaction mode' set to the symbol-value
+of ISOLATION-LEVEL.  The condition `incompatible-transaction-setting'
+will be signaled for incongruent nested isolation levels."
+  (let ((label (gensym "TRAN")))
+    `(call-with-ensured-transaction-level ',label ',isolation-level
+                                          ,(transaction-thunk label body))))

--- a/postmodern/util.lisp
+++ b/postmodern/util.lisp
@@ -538,6 +538,7 @@ table."
                          'usename))
      collect (first x)))
 
+;;;; Misc that need to be reorganized
 
 (defun change-toplevel-database (new-database user password host)
   "Just changes the database assuming you are using a toplevel connection.
@@ -549,3 +550,63 @@ Recommended only for development work."
 (defun list-connections ()
   "Returns info from pg_stat_activity on open connections"
   (query (:select '* :from 'pg-stat-activity)))
+
+
+(defun create-db-sequence (sequence &optional (schema *pgj-schema*))
+  "Create a PostgreSQL sequence with name SEQUENCE in SCHEMA (both symbols).
+Requires an active DB connection."
+  (run `(:create-sequence ,(qualified-name sequence schema)))
+  (values))
+
+(defun drop-db-table-cascade (table)
+  "Drop a Postgres TABLE, a string, and all dependent views,
+indexes etc.  Use with care."
+  (run (format nil "drop table ~A cascade" table)))
+
+(defun drop-db-schema-cascade (schema)
+  "Drop a PostgreSQL schema and cascade delete all contained DB
+objects(!) with name SCHEMA, a symbol.  Requires an active DB
+connection."
+  (when (string-equal "public" (symbol-name schema))
+    (error 'database-safety-net
+           :attempted-to "Drop schema PUBLIC"
+           :suggestion "Try pomo:drop-schema"))
+  (pomo:drop-schema schema :cascade t)
+  (values))
+
+(defun %table-exists-p (table)
+  "Does TABLE, a string, exist in the Postgres backend?"
+  (let ((query (sql-compile `(:select (:type ,table regclass)))))
+    (first-value (ignore-errors (query query :single)))))
+
+(defun flush-prepared-queries ()
+  "If you get a 'Database error 26000: prepared statement ... does not
+exist error' while mucking around at the REPL, call this.  A similar
+error in production code should be investigated."
+  (setf *query-functions* (make-hash-table :test #'equal)))
+
+(defvar *debug-sql* nil
+  "Set true to inspect S-SQL forms sent to RUN, instead of compiling
+and executing.")
+
+;;;; Qualified PostgreSQL table names using Postmodern's S-SQL
+
+(defun qualified-name (name &optional (schema *pgj-schema*))
+  "Return the S-SQL :dot form of NAME and SCHEMA, both symbols."
+  `(:dot ',schema ',name))
+
+(defun qualified-name-string (name &optional (schema *pgj-schema*))
+  "Return a string of the Postgres 'qualified name' of NAME and SCHEMA,
+both symbols."
+  (sql-compile (qualified-name name schema)))
+
+;;;; Utility
+
+(defun run (form)
+  "Compile and then run the S-SQL form FORM, unless *DEBUG-SQL* is true
+is which case just PRINT the FORM."
+  (if *debug-sql*
+      (print form)
+      (if (stringp form)
+          (query form)
+          (query (sql-compile form)))))

--- a/s-sql/s-sql.lisp
+++ b/s-sql/s-sql.lisp
@@ -452,7 +452,7 @@ string."
 (register-sql-operators :unary :not)
 (register-sql-operators :n-ary :+ :* :% :& :|\|| :|\|\|| :and :or :union (:union-all "union all"))
 (register-sql-operators :n-or-unary :- :~)
-(register-sql-operators :2+-ary  := :/ :!= :<> :< :> :<= :>= :^ :~* :!~ :!~* :like :ilike
+(register-sql-operators :2+-ary  := :/ :!= :<> :< :> :<= :>= :^ :~* :!~ :!~* :like :ilike :->> :#> :#>>
                         :intersect (:intersect-all "intersect all")
                         :except (:except-all "except all"))
 ;; PostGIS operators


### PR DESCRIPTION
Also corrects typos in write-rational-as-floating-point, write-ratio-as-floating-point.

Still need to write up documentation for the beginning of isolation level support