### PR TITLE
With-transaction and with-logical-transaction can now specify isolation levels

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -78,7 +78,7 @@ There is a reason for reserved words and it is upstream in postgresql.
 - [ ]   Ensure transactions can deal with reconnections/restarts
 - [X]   Ensure prepared statements and reconnect restart work together
 - [ ]   IPV6 connections
-- [ ]   Expand transaction isolation. Currently with-transaction does not allow specifying the isolation level.
+- [X]   Expand transaction isolation. Currently with-transaction does not allow specifying the isolation level.
         See https://www.postgresql.org/docs/current/static/transaction-iso.html
 
 ## Error Messages

--- a/doc/isolation-notes.html
+++ b/doc/isolation-notes.html
@@ -1,0 +1,1226 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<head>
+<!-- 2018-09-09 Sun 09:46 -->
+<meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Transaction and Isolation Notes</title>
+<meta name="generator" content="Org mode" />
+<style type="text/css">
+ <!--/*--><![CDATA[/*><!--*/
+  .title  { text-align: center;
+             margin-bottom: .2em; }
+  .subtitle { text-align: center;
+              font-size: medium;
+              font-weight: bold;
+              margin-top:0; }
+  .todo   { font-family: monospace; color: red; }
+  .done   { font-family: monospace; color: green; }
+  .priority { font-family: monospace; color: orange; }
+  .tag    { background-color: #eee; font-family: monospace;
+            padding: 2px; font-size: 80%; font-weight: normal; }
+  .timestamp { color: #bebebe; }
+  .timestamp-kwd { color: #5f9ea0; }
+  .org-right  { margin-left: auto; margin-right: 0px;  text-align: right; }
+  .org-left   { margin-left: 0px;  margin-right: auto; text-align: left; }
+  .org-center { margin-left: auto; margin-right: auto; text-align: center; }
+  .underline { text-decoration: underline; }
+  #postamble p, #preamble p { font-size: 90%; margin: .2em; }
+  p.verse { margin-left: 3%; }
+  pre {
+    border: 1px solid #ccc;
+    box-shadow: 3px 3px 3px #eee;
+    padding: 8pt;
+    font-family: monospace;
+    overflow: auto;
+    margin: 1.2em;
+  }
+  pre.src {
+    position: relative;
+    overflow: visible;
+    padding-top: 1.2em;
+  }
+  pre.src:before {
+    display: none;
+    position: absolute;
+    background-color: white;
+    top: -10px;
+    right: 10px;
+    padding: 3px;
+    border: 1px solid black;
+  }
+  pre.src:hover:before { display: inline;}
+  /* Languages per Org manual */
+  pre.src-asymptote:before { content: 'Asymptote'; }
+  pre.src-awk:before { content: 'Awk'; }
+  pre.src-C:before { content: 'C'; }
+  /* pre.src-C++ doesn't work in CSS */
+  pre.src-clojure:before { content: 'Clojure'; }
+  pre.src-css:before { content: 'CSS'; }
+  pre.src-D:before { content: 'D'; }
+  pre.src-ditaa:before { content: 'ditaa'; }
+  pre.src-dot:before { content: 'Graphviz'; }
+  pre.src-calc:before { content: 'Emacs Calc'; }
+  pre.src-emacs-lisp:before { content: 'Emacs Lisp'; }
+  pre.src-fortran:before { content: 'Fortran'; }
+  pre.src-gnuplot:before { content: 'gnuplot'; }
+  pre.src-haskell:before { content: 'Haskell'; }
+  pre.src-hledger:before { content: 'hledger'; }
+  pre.src-java:before { content: 'Java'; }
+  pre.src-js:before { content: 'Javascript'; }
+  pre.src-latex:before { content: 'LaTeX'; }
+  pre.src-ledger:before { content: 'Ledger'; }
+  pre.src-lisp:before { content: 'Lisp'; }
+  pre.src-lilypond:before { content: 'Lilypond'; }
+  pre.src-lua:before { content: 'Lua'; }
+  pre.src-matlab:before { content: 'MATLAB'; }
+  pre.src-mscgen:before { content: 'Mscgen'; }
+  pre.src-ocaml:before { content: 'Objective Caml'; }
+  pre.src-octave:before { content: 'Octave'; }
+  pre.src-org:before { content: 'Org mode'; }
+  pre.src-oz:before { content: 'OZ'; }
+  pre.src-plantuml:before { content: 'Plantuml'; }
+  pre.src-processing:before { content: 'Processing.js'; }
+  pre.src-python:before { content: 'Python'; }
+  pre.src-R:before { content: 'R'; }
+  pre.src-ruby:before { content: 'Ruby'; }
+  pre.src-sass:before { content: 'Sass'; }
+  pre.src-scheme:before { content: 'Scheme'; }
+  pre.src-screen:before { content: 'Gnu Screen'; }
+  pre.src-sed:before { content: 'Sed'; }
+  pre.src-sh:before { content: 'shell'; }
+  pre.src-sql:before { content: 'SQL'; }
+  pre.src-sqlite:before { content: 'SQLite'; }
+  /* additional languages in org.el's org-babel-load-languages alist */
+  pre.src-forth:before { content: 'Forth'; }
+  pre.src-io:before { content: 'IO'; }
+  pre.src-J:before { content: 'J'; }
+  pre.src-makefile:before { content: 'Makefile'; }
+  pre.src-maxima:before { content: 'Maxima'; }
+  pre.src-perl:before { content: 'Perl'; }
+  pre.src-picolisp:before { content: 'Pico Lisp'; }
+  pre.src-scala:before { content: 'Scala'; }
+  pre.src-shell:before { content: 'Shell Script'; }
+  pre.src-ebnf2ps:before { content: 'ebfn2ps'; }
+  /* additional language identifiers per "defun org-babel-execute"
+       in ob-*.el */
+  pre.src-cpp:before  { content: 'C++'; }
+  pre.src-abc:before  { content: 'ABC'; }
+  pre.src-coq:before  { content: 'Coq'; }
+  pre.src-groovy:before  { content: 'Groovy'; }
+  /* additional language identifiers from org-babel-shell-names in
+     ob-shell.el: ob-shell is the only babel language using a lambda to put
+     the execution function name together. */
+  pre.src-bash:before  { content: 'bash'; }
+  pre.src-csh:before  { content: 'csh'; }
+  pre.src-ash:before  { content: 'ash'; }
+  pre.src-dash:before  { content: 'dash'; }
+  pre.src-ksh:before  { content: 'ksh'; }
+  pre.src-mksh:before  { content: 'mksh'; }
+  pre.src-posh:before  { content: 'posh'; }
+  /* Additional Emacs modes also supported by the LaTeX listings package */
+  pre.src-ada:before { content: 'Ada'; }
+  pre.src-asm:before { content: 'Assembler'; }
+  pre.src-caml:before { content: 'Caml'; }
+  pre.src-delphi:before { content: 'Delphi'; }
+  pre.src-html:before { content: 'HTML'; }
+  pre.src-idl:before { content: 'IDL'; }
+  pre.src-mercury:before { content: 'Mercury'; }
+  pre.src-metapost:before { content: 'MetaPost'; }
+  pre.src-modula-2:before { content: 'Modula-2'; }
+  pre.src-pascal:before { content: 'Pascal'; }
+  pre.src-ps:before { content: 'PostScript'; }
+  pre.src-prolog:before { content: 'Prolog'; }
+  pre.src-simula:before { content: 'Simula'; }
+  pre.src-tcl:before { content: 'tcl'; }
+  pre.src-tex:before { content: 'TeX'; }
+  pre.src-plain-tex:before { content: 'Plain TeX'; }
+  pre.src-verilog:before { content: 'Verilog'; }
+  pre.src-vhdl:before { content: 'VHDL'; }
+  pre.src-xml:before { content: 'XML'; }
+  pre.src-nxml:before { content: 'XML'; }
+  /* add a generic configuration mode; LaTeX export needs an additional
+     (add-to-list 'org-latex-listings-langs '(conf " ")) in .emacs */
+  pre.src-conf:before { content: 'Configuration File'; }
+
+  table { border-collapse:collapse; }
+  caption.t-above { caption-side: top; }
+  caption.t-bottom { caption-side: bottom; }
+  td, th { vertical-align:top;  }
+  th.org-right  { text-align: center;  }
+  th.org-left   { text-align: center;   }
+  th.org-center { text-align: center; }
+  td.org-right  { text-align: right;  }
+  td.org-left   { text-align: left;   }
+  td.org-center { text-align: center; }
+  dt { font-weight: bold; }
+  .footpara { display: inline; }
+  .footdef  { margin-bottom: 1em; }
+  .figure { padding: 1em; }
+  .figure p { text-align: center; }
+  .inlinetask {
+    padding: 10px;
+    border: 2px solid gray;
+    margin: 10px;
+    background: #ffffcc;
+  }
+  #org-div-home-and-up
+   { text-align: right; font-size: 70%; white-space: nowrap; }
+  textarea { overflow-x: auto; }
+  .linenr { font-size: smaller }
+  .code-highlighted { background-color: #ffff00; }
+  .org-info-js_info-navigation { border-style: none; }
+  #org-info-js_console-label
+    { font-size: 10px; font-weight: bold; white-space: nowrap; }
+  .org-info-js_search-highlight
+    { background-color: #ffff00; color: #000000; font-weight: bold; }
+  .org-svg { width: 90%; }
+  /*]]>*/-->
+</style>
+<link rel="stylesheet" type="text/css" href="style.css" />
+<script type="text/javascript">
+/*
+@licstart  The following is the entire license notice for the
+JavaScript code in this tag.
+
+Copyright (C) 2012-2017 Free Software Foundation, Inc.
+
+The JavaScript code in this tag is free software: you can
+redistribute it and/or modify it under the terms of the GNU
+General Public License (GNU GPL) as published by the Free Software
+Foundation, either version 3 of the License, or (at your option)
+any later version.  The code is distributed WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE.  See the GNU GPL for more details.
+
+As additional permission under GNU GPL version 3 section 7, you
+may distribute non-source (e.g., minimized or compacted) forms of
+that code without the copy of the GNU GPL normally required by
+section 4, provided you include this license notice and a URL
+through which recipients can access the Corresponding Source.
+
+
+@licend  The above is the entire license notice
+for the JavaScript code in this tag.
+*/
+<!--/*--><![CDATA[/*><!--*/
+ function CodeHighlightOn(elem, id)
+ {
+   var target = document.getElementById(id);
+   if(null != target) {
+     elem.cacheClassElem = elem.className;
+     elem.cacheClassTarget = target.className;
+     target.className = "code-highlighted";
+     elem.className   = "code-highlighted";
+   }
+ }
+ function CodeHighlightOff(elem, id)
+ {
+   var target = document.getElementById(id);
+   if(elem.cacheClassElem)
+     elem.className = elem.cacheClassElem;
+   if(elem.cacheClassTarget)
+     target.className = elem.cacheClassTarget;
+ }
+/*]]>*///-->
+</script>
+</head>
+<body>
+<div id="content">
+<h1 class="title">Transaction and Isolation Notes</h1>
+<div id="table-of-contents">
+<h2>Table of Contents</h2>
+<div id="text-table-of-contents">
+<ul>
+<li><a href="#orgce893f6">Postmodern transaction calls with transaction names and isolation levels</a></li>
+<li><a href="#orge7b7307">Introduction to ACID, Transactions and Isolation Levels</a></li>
+<li><a href="#orgad3a14b">Transactions</a>
+<ul>
+<li>
+<ul>
+<li><a href="#org632d2a7">What happens if we nest transactions?</a></li>
+</ul>
+</li>
+</ul>
+</li>
+<li><a href="#org2718562">The Concurrency Problem</a>
+<ul>
+<li><a href="#org32ae683">Summary</a></li>
+<li><a href="#orgf171a5a">Problem Explanation</a>
+<ul>
+<li><a href="#orgf168768">Dirty Read</a></li>
+<li><a href="#org98f53fd">Nonrepeatable Read</a></li>
+<li><a href="#org59035d8">Phantom Read</a></li>
+<li><a href="#org119c9a4">For More Fun</a></li>
+</ul>
+</li>
+<li><a href="#orgfd76894">Isolation Levels</a>
+<ul>
+<li><a href="#orgebb7a8d">Read Committed Isolation Level</a></li>
+<li><a href="#org39d8607">Repeatable Read Isolation Level</a></li>
+<li><a href="#orga4529c5">Serializable Isolation Level</a></li>
+</ul>
+</li>
+</ul>
+</li>
+<li><a href="#orgc25bfba">For Futher Reading</a></li>
+</ul>
+</div>
+</div>
+
+<div id="outline-container-orgce893f6" class="outline-2">
+<h2 id="orgce893f6">Postmodern transaction calls with transaction names and isolation levels</h2>
+<div class="outline-text-2" id="text-orgce893f6">
+<p>
+Transactions are one or more statements wrapped together which either all
+succeed and are "committed" or none of them succeed, in which case any state
+changes are rolled back to the beginning of the transaction. In the case of
+postmodern, there are two main macros available for use:
+</p>
+
+<ul class="org-ul">
+<li>with-transaction (for general use)</li>
+<li>with-logical-transaction (for nested transactions and savepoints)</li>
+</ul>
+
+<p>
+When you get into situations where you expect concurrent transactions, you
+can specify the whether the transaction is allowed only read access or
+both read and write access to the database table rows and you can specify
+either the default isolation level or a specific isolation level for that
+transaction. If you need more information on what isolation levels are, and
+when to use them, see below.
+</p>
+
+<p>
+Postgresql defaults to the read committed isolation level with
+read and write access. This is also postmodern's default, but that can be
+changed by setting postmodern:*isolation-level* to your desired setting.
+</p>
+
+<p>
+The available settings in postmodern follow the sql standard are:
+</p>
+
+<ul class="org-ul">
+<li>:read-committed-rw (read committed with read and write)</li>
+<li>:read-committed-ro (read committed with read only)</li>
+<li>:repeatable-read-rw (repeatable read with read and write)</li>
+<li>:repeatable-read-ro (repeatable read with read only)</li>
+<li>:serializable (serializable with read and write)</li>
+</ul>
+
+<p>
+(Ok. "Loosely" follows the sql standard because we combine read-write and
+read-only constraints with the sql standard isolation levels. There is one
+unsafe isolation level defined by the standard, but neither postgresql nor
+any other major database implements it.)
+</p>
+
+<p>
+Postmodern generally provides the ability to specify the name of a transaction
+and the isolation level per the key words above. Examples of use are below
+and "george" is used as the name of the transaction (not quoted or as a string):
+</p>
+<div class="org-src-container">
+<pre class="src src-lisp">(with-transaction ()
+  (execute (:insert-into 'test-data :set 'value 77)))
+
+(with-transaction (george)
+  (execute (:insert-into 'test-data :set 'value 22)))
+
+(with-transaction (george :read-committed-rw)
+  (execute (:insert-into 'test-data :set 'value 33)))
+
+(with-transaction (:serializable)
+  (execute (:insert-into 'test-data :set 'value 44)))
+
+(with-logical-transaction ()
+  (execute (:insert-into 'test-data :set 'value 77)))
+
+(with-logical-transaction (george)
+  (execute (:insert-into 'test-data :set 'value 22)))
+
+(with-logical-transaction (george :read-committed-rw)
+  (execute (:insert-into 'test-data :set 'value 33)))
+
+(with-logical-transaction (:serializable)
+  (execute (:insert-into 'test-data :set 'value 44)))
+</pre>
+</div>
+</div>
+</div>
+
+<div id="outline-container-orge7b7307" class="outline-2">
+<h2 id="orge7b7307">Introduction to ACID, Transactions and Isolation Levels</h2>
+<div class="outline-text-2" id="text-orge7b7307">
+<p>
+Databases like Postgresql are not simply data storage, they are
+transaction management systems. In the context of transactions with multiple
+operations within the transaction, either all of them commit or none of them
+commit (the transaction is rolled back). Transactions include single
+statement transactions as well as multiple statement transactions that are
+wrapped inside BEGIN – COMMIT Commands. (In the case of postmodern macros
+with-transaction and with-logical-transaction, the commit command is handled
+for you automatically.)
+</p>
+
+<p>
+You may have heard of databases being "ACID" compliant or having ACID
+functionality. Transactions are the “A” (Atomicity) in “ACID”.
+“C” is “Consistency”, “I” is “Isolation” and “D” is “Durability”. As you can
+tell, everything in ACID in designed to maintain the integrity of the data.
+Without atomicity, you risk leaving data in a partial or invalid state and
+everything which depends on the data will break. (And your dba will be
+upset – the question is – will they then try to break you?)
+</p>
+
+<p>
+Consistency ensures that every transaction will move the database from one
+valid state to another valid state. Consider two users A and B signing up
+with the same desired username “myname” almost simultaneously. The system
+checks to see whether “myname” is in use for A. It is not, so it starts the
+process of creating a record for “myname”. The system checks for B to see
+whether “myname” is in use. Since it has not yet finished creating the record
+for A, it appears to be available for B, so it starts the process of
+creating a user record for B using “myname”. One or both can end up in an
+invalid state.
+</p>
+
+<p>
+You can prevent the inconsistent state by either putting a uniqueness check
+on the user table for usernames or you use an isolation level like
+serializable on your transactions. In either case, B’s commit will fail,
+you have to restart that transaction, but the data that is now in the system
+is safe and consistent..
+</p>
+
+<p>
+Isolation levels define what is allowed to happen if there are two transactions
+tyring to access the same data simultaneously. More on this below.
+</p>
+
+<p>
+Durability means that committed transactions must stay committed, even in
+the event of a crash, power loss, etc.
+</p>
+</div>
+</div>
+
+<div id="outline-container-orgad3a14b" class="outline-2">
+<h2 id="orgad3a14b">Transactions</h2>
+<div class="outline-text-2" id="text-orgad3a14b">
+<p>
+It is easy show the impact of transactions in action. Consider the following:
+</p>
+
+<div class="org-src-container">
+<pre class="src src-lisp">(execute (:create-table test-data ((value :type integer))))
+
+(with-transaction ()
+  (execute (:insert-into 'test-data :set 'value 77)))
+(query (:select '* :from 'test-data))
+((77))
+</pre>
+</div>
+<p>
+The postmodern macro with-transaction completes with a call to
+commit-transaction. So absent any intervening actions, the transaction
+will commit at the end of the form.
+</p>
+
+<p>
+For purposes of the following examples, assume that we truncated
+the table prior to each example so we have the same base line each time.
+</p>
+<div class="org-src-container">
+<pre class="src src-lisp">(ignore-errors
+  (with-transaction ()
+    (execute (:insert-into 'test-data :set 'value 2))
+    (error "no wait")))
+NIL
+#&lt;SIMPLE-ERROR "no wait" {100D581653}&gt;
+
+(with-test-connection (query (:select '* :from 'test-data)))
+NIL
+</pre>
+</div>
+<p>
+This time we triggered an error before the transaction concluded. Because the
+error was inside the transaction, it invalidated all statements inside the
+transction and the tentative insertion never happened.
+(Actually more complicated than this, but from an application developer
+standpoint, we can think of it this way.)
+</p>
+
+<p>
+Now lets actually give the transaction a name and make a superflous call to
+commit-transaction within the transaction.
+</p>
+<div class="org-src-container">
+<pre class="src src-lisp">(with-transaction (transaction)
+  (execute (:insert-into 'test-data :set 'value 2))
+  (commit-transaction transaction))
+
+(query (:select '* :from 'test-data))
+((2))
+</pre>
+</div>
+<p>
+As you can see, making the unnecessary call to commit-tranaction does not
+trigger the insertion twice.
+</p>
+
+<p>
+We can also decide to abort the transaction without triggering an error:
+</p>
+<div class="org-src-container">
+<pre class="src src-lisp">(with-transaction (transaction)
+  (execute (:insert-into 'test-data :set 'value 44))
+  (abort-transaction transaction))
+
+(query (:select '* :from 'test-data))
+NIL
+</pre>
+</div>
+<p>
+As expected, the insertion was never committed due to the call to
+abort-transaction.
+</p>
+</div>
+
+<div id="outline-container-org632d2a7" class="outline-4">
+<h4 id="org632d2a7">What happens if we nest transactions?</h4>
+<div class="outline-text-4" id="text-org632d2a7">
+<p>
+Postgresql does not fully support nested transactions. Full support of
+nested transactions would mean that a succesful sub-transaction does not get
+rolled back if a parent transaction (direct or indirect) gets rolled back.
+</p>
+
+<p>
+Postgresql allows the use of savepoints, which can get you to a consistent
+state but means that if any transaction in a nested transaction sequence
+is rolled back, then everything in the transaction is rolled back. Postmodern
+provides savepoints automatically in a nested situation if you use the macro
+with-logical-transaction. Postmodern also provides a macro with-savepoint
+if you need to handle them manually.
+</p>
+
+<p>
+If you do not use savepoints, the result of nested transactions may not be
+consistent. Some or all of subtransactions may or may not get committed
+if there is an error anywhere in the nest.
+</p>
+
+<p>
+The <a href="https://www.postgresql.org/docs/10/static/sql-begin.html">official postgresql documentation</a> states that "Issuing a begin when already
+inside a transaction will provoke a warning message. The state of the
+transaction is not affected." While this sounds like the subtransactions just
+get treated as part of the outer transaction, you cannot rely on that
+interpretation.
+</p>
+
+<p>
+Morale of the story. If you are going to nest transactions in postmdern, use
+the with-logical-transaction macro, do not use the with-transaction macro.
+</p>
+
+<p>
+Now lets talk about concurrency issues and the trade-offs between different
+isolation levels.
+</p>
+</div>
+</div>
+</div>
+
+<div id="outline-container-org2718562" class="outline-2">
+<h2 id="org2718562">The Concurrency Problem</h2>
+<div class="outline-text-2" id="text-org2718562">
+</div>
+<div id="outline-container-org32ae683" class="outline-3">
+<h3 id="org32ae683">Summary</h3>
+<div class="outline-text-3" id="text-org32ae683">
+<p>
+Consider when you have multiple concurrent transactions or multiple concurrent
+database events. These create potential race conditions as well as potential
+overwrite issues, creating hard to find bugs. The base problem is easy to
+understand – what happens when two users try to access the same row of data
+concurrently.
+</p>
+
+<p>
+Think about how databases using MVCC (multi-version concurrency control)
+execute statements inside a transaction. The data generated by the transaction
+is kept off to the side, away from other data until the entire transaction
+can be committed. Once it is committed, it becomes visible to all future
+transactions and the old row which it may have edited becomes marked as
+invalid. The invalid row still exists in the system until the next VACUUM.
+Of course, this does not mean that the system prevents user B from overwriting
+user A’s changes from an hour ago. We are solely focused on concurrency issues
+here.
+</p>
+
+<p>
+All committed transactions are written to the write-ahead log (WAL or “xlog”).
+In case of trouble, Postgresql can replay the WAL log to recover changes that
+did not get into the actual data files. Postgresql also has a commit
+log “pg_xact” which summarizes transactions and whether the transaction
+committed or aborted. Any transaction that was a read only transaction is
+never written to the WAL or commit logs. As it was not intended to modify any
+data, there is no need. However, if the transaction is aborted, that fact will
+still be noted in the WAL and commit logs. (You can also configure postgresql
+to log all queries, but that is not the default.)
+</p>
+
+<p>
+Now think about the situation at a little more granular level.
+</p>
+
+<ul class="org-ul">
+<li>If two transactions read the old state and then perform changes concurrently, the last write transaction will be effective and the previous write transaction may be lost unless you have explicit locking.</li>
+
+<li>If two transactions with multiple statements read the old state and then both transactions perform changes concurrently, you may end up in an inconsistent data state.</li>
+
+<li>If one transaction reads the old state and prepares to make a change based on the value of the old state, but another transaction modifies the old state before the first transaction finishes, the first transaction has now made a decision based on bad data.</li>
+
+<li>If you execute the same query twice and get back more or fewer elements in the second execution than the first execution.</li>
+</ul>
+
+<p>
+Depending on your application, these may or may not be something that you need
+to worry about.
+</p>
+
+<p>
+The SQL standard actually has four transaction isolation levels.
+Postgresql only implements three of those - "Read Uncommitted" is not
+implemented and the default transaction level for Postgresql is “read committed”.
+Postgresql allows the user to specify the isolation level of a transaction
+on a transaction by transaction basis. As you might expect, there are trade-offs.
+Stronger isolation levels have more overhead and may trigger more transactions
+that need to be repeated (and therefore you will have to write the code to
+handle the necessary repeats).
+</p>
+
+<p>
+We explain this table just below:
+</p>
+
+<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">
+
+
+<colgroup>
+<col  class="org-left" />
+
+<col  class="org-left" />
+
+<col  class="org-left" />
+
+<col  class="org-left" />
+
+<col  class="org-left" />
+</colgroup>
+<thead>
+<tr>
+<th scope="col" class="org-left">Isolation Level</th>
+<th scope="col" class="org-left">Dirty Read</th>
+<th scope="col" class="org-left">Nonrepeatable Read</th>
+<th scope="col" class="org-left">Phantom Read</th>
+<th scope="col" class="org-left">Serialization Anomaly</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="org-left">Read Uncommitted</td>
+<td class="org-left">Allowed</td>
+<td class="org-left">Possible</td>
+<td class="org-left">Possible</td>
+<td class="org-left">Possible</td>
+</tr>
+
+<tr>
+<td class="org-left">Read Committed *</td>
+<td class="org-left">Not Possible</td>
+<td class="org-left">Possible</td>
+<td class="org-left">Possible</td>
+<td class="org-left">Possible</td>
+</tr>
+
+<tr>
+<td class="org-left">Repeatable Read</td>
+<td class="org-left">Not Possible</td>
+<td class="org-left">Not Possible</td>
+<td class="org-left">Allowed by SQL Standard, not allowed in Postgresql</td>
+<td class="org-left">Possible</td>
+</tr>
+
+<tr>
+<td class="org-left">Serializable</td>
+<td class="org-left">Not Possible</td>
+<td class="org-left">Not Possible</td>
+<td class="org-left">Not Possible</td>
+<td class="org-left">Not Possible</td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+
+<div id="outline-container-orgf171a5a" class="outline-3">
+<h3 id="orgf171a5a">Problem Explanation</h3>
+<div class="outline-text-3" id="text-orgf171a5a">
+</div>
+<div id="outline-container-orgf168768" class="outline-4">
+<h4 id="orgf168768">Dirty Read</h4>
+<div class="outline-text-4" id="text-orgf168768">
+<p>
+A Dirty Read is a transaction reads data written by a concurrent uncommitted
+transaction. You can specify a transaction as having a “Read Uncommitted”
+level, but Postgresql will internally just give you a “Read Committed”
+isolation level.
+</p>
+
+<p>
+Assume sales are 2100 at the beginning
+</p>
+<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">
+
+
+<colgroup>
+<col  class="org-left" />
+
+<col  class="org-left" />
+</colgroup>
+<tbody>
+<tr>
+<td class="org-left">Transaction 1</td>
+<td class="org-left">Transaction 2</td>
+</tr>
+
+<tr>
+<td class="org-left">BEGIN</td>
+<td class="org-left">BEGIN</td>
+</tr>
+
+<tr>
+<td class="org-left">(:select 'sales :from 'table1 :where (:= 'id 21)</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">(:update 'table1 :set 'sales 2200 :where (:= 'id 21)) ;no commit</td>
+</tr>
+
+<tr>
+<td class="org-left">(:select 'sales :from 'table1 :where (:= 'id 21)</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left">END</td>
+<td class="org-left">END</td>
+</tr>
+</tbody>
+</table>
+
+<p>
+The second select will read sales as 2200 even though Transaction 2 did not
+fully commit.
+</p>
+</div>
+</div>
+
+<div id="outline-container-org98f53fd" class="outline-4">
+<h4 id="org98f53fd">Nonrepeatable Read</h4>
+<div class="outline-text-4" id="text-org98f53fd">
+<p>
+A Nonrepeatable read is a transaction re-reads data it has previously read and
+finds the data has been modified by another transaction that committed since
+the initial read.
+</p>
+
+<p>
+Assume sales are 2100 at the beginning
+</p>
+<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">
+
+
+<colgroup>
+<col  class="org-left" />
+
+<col  class="org-left" />
+</colgroup>
+<tbody>
+<tr>
+<td class="org-left">Transaction 1</td>
+<td class="org-left">Transaction 2</td>
+</tr>
+
+<tr>
+<td class="org-left">BEGIN</td>
+<td class="org-left">BEGIN</td>
+</tr>
+
+<tr>
+<td class="org-left">(:select 'sales :from 'table1 :where (:= 'id 21)</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">(:update 'table1 :set 'sales 2200 :where (:= 'id 21))</td>
+</tr>
+
+<tr>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">COMMIT;</td>
+</tr>
+
+<tr>
+<td class="org-left">(:select 'sales :from 'table1 :where (:= 'id 21)</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left">END</td>
+<td class="org-left">END</td>
+</tr>
+</tbody>
+</table>
+
+<p>
+The second select will read sales as 2200. At least transaction 2 actually
+committed first.
+</p>
+
+<p>
+If you are just trying to avoid lost updates, you can use row level locks
+with select FOR UPDATE under read committed. That avoids the update being
+lost or aborted. Of course, now you need to worry about how to handle
+situations where one transaction gets stalled and holds a transaction too long.
+</p>
+
+<p>
+For select statements, you can add a row level lock by adding FOR SHARE to the
+end of the SELECT. For updates, use FOR UPDATE. In postmodern, if you are using
+s-sql, you can include :for-share or :for-update in the select statement. E.g.
+</p>
+
+<div class="org-src-container">
+<pre class="src src-lisp">(query (:for-update (:select :* :from 'foo 'bar 'baz) :of 'bar 'baz :nowait))
+</pre>
+</div>
+<p>
+See <a href="s-sql.html">s-sql.html</a> for further details.
+</p>
+</div>
+</div>
+
+<div id="outline-container-org59035d8" class="outline-4">
+<h4 id="org59035d8">Phantom Read</h4>
+<div class="outline-text-4" id="text-org59035d8">
+<p>
+A Phantom Read is where a transaction re-executes a query returning a set of
+rows and finds that the set of rows has changed (not necessarily row 215,
+but some one or more of the rows in the query set). Phantom Reads are
+prevented by using the “Repeatable Read” isolation level. Row level locks
+will not solve this problem.
+</p>
+
+<p>
+Assume first select returns 50:
+</p>
+
+<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">
+
+
+<colgroup>
+<col  class="org-left" />
+
+<col  class="org-left" />
+</colgroup>
+<tbody>
+<tr>
+<td class="org-left">Transaction 1</td>
+<td class="org-left">Transaction 2</td>
+</tr>
+
+<tr>
+<td class="org-left">BEGIN</td>
+<td class="org-left">BEGIN</td>
+</tr>
+
+<tr>
+<td class="org-left">(:select (:count '*) :from 'table1 :where (:= 'region 1))</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">(:insert-into 'table1 :set 'sales 2200))</td>
+</tr>
+
+<tr>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">COMMIT;</td>
+</tr>
+
+<tr>
+<td class="org-left">(:select (:count '*) :from 'table1 :where (:= 'region 1))</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left">END</td>
+<td class="org-left">END</td>
+</tr>
+</tbody>
+</table>
+
+<p>
+The second select will return 51. Depending on what else might be happening in
+transaction 1, the difference between the number of rows at the beginning and
+the number of rows at the end may cause calculations to be inconsistent
+internally to the transaction.
+</p>
+</div>
+</div>
+
+<div id="outline-container-org119c9a4" class="outline-4">
+<h4 id="org119c9a4">For More Fun</h4>
+<div class="outline-text-4" id="text-org119c9a4">
+<p>
+Now consider you have banking application A which runs in multiple sessions and
+does not use transactions and the user withdraws 100 from each of two sessions
+and the balance started at 300.
+</p>
+
+<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">
+
+
+<colgroup>
+<col  class="org-left" />
+
+<col  class="org-left" />
+</colgroup>
+<tbody>
+<tr>
+<td class="org-left">Session 1</td>
+<td class="org-left">Session 2</td>
+</tr>
+
+<tr>
+<td class="org-left">(:select 'balance :from 'accounts :where (:= 'user-id 1))</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">(:select 'balance :from 'accounts :where (:= 'user-id 1))</td>
+</tr>
+
+<tr>
+<td class="org-left">Application calculates the balance should be 200</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left">(:update 'accounts :set 'balance 200)</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Application calculates the balance should be 200</td>
+</tr>
+
+<tr>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">(:update 'accounts :set 'balance 200)</td>
+</tr>
+</tbody>
+</table>
+
+<p>
+At this point the application has subtracted 200 (100 in each session), but
+the account balance still shows 200. Transactions would not have made a
+difference.
+</p>
+
+<p>
+Now implemented slightly differently:
+</p>
+<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">
+
+
+<colgroup>
+<col  class="org-left" />
+
+<col  class="org-left" />
+</colgroup>
+<tbody>
+<tr>
+<td class="org-left">Session 1</td>
+<td class="org-left">Session 2</td>
+</tr>
+
+<tr>
+<td class="org-left">(:select 'balance :from 'accounts :where (:= 'user-id 1))</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">(:select 'balance :from 'accounts :where (:= 'user-id 1))</td>
+</tr>
+
+<tr>
+<td class="org-left">(:update 'accounts :set 'balance (:- 'balance 100))</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">(:update 'accounts :set 'balance (:- 'balance 100))</td>
+</tr>
+</tbody>
+</table>
+
+<p>
+Do you know what the balance is now? It should be 100 because you put the
+calculation back into the database where it belongs. But life gets more
+complicated than these simple examples. Complex queries and updates provide
+more possibilities for concurrent transactions to generate conflicting,
+leading to solutions such as "row level locking" and "isolation levels".
+</p>
+</div>
+</div>
+</div>
+
+<div id="outline-container-orgfd76894" class="outline-3">
+<h3 id="orgfd76894">Isolation Levels</h3>
+<div class="outline-text-3" id="text-orgfd76894">
+<p>
+The official postgresql documentation can be found <a href="https://www.postgresql.org/docs/current/static/transaction-iso.html">here</a>.
+</p>
+</div>
+
+<div id="outline-container-orgebb7a8d" class="outline-4">
+<h4 id="orgebb7a8d">Read Committed Isolation Level</h4>
+<div class="outline-text-4" id="text-orgebb7a8d">
+<p>
+Read Committed is the default isolation level in Postgresql. In general
+it has the best balance between locking and performance. This isolation level
+means that the existing row is read after the transaction is completed but not
+yet written. If the row has not changed, then the transaction is executed. If
+the row has changed from when it started building the transaction, then it
+starts the transaction over again.
+</p>
+
+<p>
+The “Read Committed” default isolation level is safe when you are concurrently
+reading. If there are multiple select statements in a single transaction, each
+select statement will have its own snapshot of the database (which might not
+be the same if another transaction is concurrently modifying the database).
+The “Read Committed” isolation level is not necessarily safe for concurrent
+updates. In other words, the concurrent updates would be performed serially,
+potentially surprising the user whose commit is overridden. Update and
+Delete statements in a “Read Committed” isolation level will create a
+snapshot of the database, use that snapshot to find the rows matching the
+where clause and then try to lock that row of the snapshot. If any rows are
+already locked by an update or delete statement in another transaction, the
+update or delete statement will wait for the other transaction to commit or
+abort. If it commits, the update or delete will re-evaluate the where clause
+on the new version of the row to determine whether it needs to be modified.
+</p>
+
+<p>
+Assume our banking problem using transactions at the Postgresql default
+isolation level of "read committed".
+</p>
+
+<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">
+
+
+<colgroup>
+<col  class="org-left" />
+
+<col  class="org-left" />
+</colgroup>
+<tbody>
+<tr>
+<td class="org-left">Session 1</td>
+<td class="org-left">Session 2</td>
+</tr>
+
+<tr>
+<td class="org-left">BEGIN</td>
+<td class="org-left">BEGIN</td>
+</tr>
+
+<tr>
+<td class="org-left">(:select 'balance :from 'accounts :where (:= 'user-id 1))</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">; Deferred (:select 'balance :from 'accounts :where (:= 'user-id 1))</td>
+</tr>
+
+<tr>
+<td class="org-left">Application calculates the balance should be 200</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left">(:update 'accounts :set 'balance 200)</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left">COMMIT</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Application calculates the balance should be 100</td>
+</tr>
+
+<tr>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">(:update 'accounts :set 'balance 100)</td>
+</tr>
+
+<tr>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">COMMIT</td>
+</tr>
+</tbody>
+</table>
+
+<p>
+The Session 2 select query notices that the row is already engaged and would be
+deferred until Transaction 1 is committed. At that point it reads the
+balance (now 200), tells the application, and the application subtracts 100
+and tells the database to update the balance to 100.
+</p>
+</div>
+</div>
+
+<div id="outline-container-org39d8607" class="outline-4">
+<h4 id="org39d8607">Repeatable Read Isolation Level</h4>
+<div class="outline-text-4" id="text-org39d8607">
+<p>
+In Postgresql, a “Repeatable Read” isolation level takes a snapshot of the
+current state of the database and all queries in the transaction will use
+that snapshot. So if another transaction modifies a row, a second select
+statement in a repeatable read isolation level would not be affected because
+it is looking solely at the snapshot that was taken at the beginning of the
+transaction.
+</p>
+
+<p>
+Things happen differently if the transaction using a “Repeatable Read”
+isolation level wants to Update or Delete a row.
+</p>
+
+<p>
+If a Phantom read is detected when the transaction wants to commit, a
+Repeatable Read would go back and re-read the table and repeat the
+transaction. Update and Delete statements in a “Repeatable Read” isolation
+level will create a snapshot of the database, use that snapshot to find the
+rows matching the where clause and then check to see if another transaction
+is currently trying to modify the rows  (not just the columns) that the
+Update or Delete statement is trying to modify. If the other transaction
+aborts, the Update or Delete statement will modify the relevant rows and
+continue. If the other transaction commits, then the repeatable read
+transaction will abort with an error message about “could not serialize
+access due to concurrent update”.
+</p>
+
+<p>
+If you are running transaction at isolation level “repeatable read”,
+concurrent updates can be expected to trigger query failures  from time
+to time that need to be handled, typically by re-running the transaction.
+The following error message can be expected:
+</p>
+
+<ul class="org-ul">
+<li>“ERROR: could not serialize due to concurrent update” (Under</li>
+</ul>
+<p>
+either “repeatable read” or “serializable”.)
+</p>
+
+<p>
+Repeatable read addresses a different problem than our banking problem
+above, so the result in this case is the same as "read committed".
+</p>
+</div>
+</div>
+
+<div id="outline-container-orga4529c5" class="outline-4">
+<h4 id="orga4529c5">Serializable Isolation Level</h4>
+<div class="outline-text-4" id="text-orga4529c5">
+<p>
+The Serializable Isolation level tells postgresql to effectively serialize all
+transactions. That ensures validity at the cost of a hit to performance.
+</p>
+
+<p>
+If you are running transaction at isolation level “serializable”, concurrent
+updates can be expected to trigger query failures  from time to time that
+need to be handled, typically by re-running the transaction. The following
+two errors can be expected:
+</p>
+
+<ul class="org-ul">
+<li>“ERROR: could not serialize due to concurrent update” (Under either “repeatable read” or “serializable”.)</li>
+
+<li>“ERROR: could not serialize access due to read/write dependencies among transactions. (Under “serializable”).</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+
+<div id="outline-container-orgc25bfba" class="outline-2">
+<h2 id="orgc25bfba">For Futher Reading</h2>
+<div class="outline-text-2" id="text-orgc25bfba">
+<ul class="org-ul">
+<li><a href="https://www.postgresql.org/docs/current/static/transaction-iso.html">https://www.postgresql.org/docs/current/static/transaction-iso.html</a></li>
+<li><a href="https://www.postgresql.org/docs/current/static/sql-set-transaction.html">https://www.postgresql.org/docs/current/static/sql-set-transaction.html</a></li>
+<li><a href="http://elliot.land/post/sql-transaction-isolation-levels-explained">http://elliot.land/post/sql-transaction-isolation-levels-explained</a></li>
+<li><a href="https://blog.2ndquadrant.com/postgresql-anti-patterns-read-modify-write-cycles/">https://blog.2ndquadrant.com/postgresql-anti-patterns-read-modify-write-cycles/</a></li>
+<li><a href="https://dba.stackexchange.com/questions/131226/set-serializable-isolation-for-update-query-postgresql-9-4">https://dba.stackexchange.com/questions/131226/set-serializable-isolation-for-update-query-postgresql-9-4</a></li>
+<li><a href="https://www.enterprisedb.com/docs/en/9.0/pg/transaction-iso.html">https://www.enterprisedb.com/docs/en/9.0/pg/transaction-iso.html</a></li>
+<li><a href="https://wiki.postgresql.org/wiki/SSI">https://wiki.postgresql.org/wiki/SSI</a></li>
+<li><a href="https://dba.stackexchange.com/questions/202775/how-to-write-validation-trigger-which-works-with-all-isolation-levels">https://dba.stackexchange.com/questions/202775/how-to-write-validation-trigger-which-works-with-all-isolation-levels</a></li>
+<li><a href="https://stackoverflow.com/questions/45923021/apparent-transaction-isolation-violation-in-postgresql">https://stackoverflow.com/questions/45923021/apparent-transaction-isolation-violation-in-postgresql</a></li>
+<li><a href="https://brandur.org/http-transactions">https://brandur.org/http-transactions</a></li>
+<li><a href="https://brandur.org/idempotency-keys">https://brandur.org/idempotency-keys</a></li>
+<li><a href="https://brandur.org/postgres-reads">https://brandur.org/postgres-reads</a></li>
+<li><a href="http://malisper.me/postgres-transaction-isolation-levels/">http://malisper.me/postgres-transaction-isolation-levels/</a></li>
+<li><a href="https://begriffs.com/posts/2017-08-01-practical-guide-sql-isolation.html">https://begriffs.com/posts/2017-08-01-practical-guide-sql-isolation.html</a> (includes the "zoo" of transaction phenomena)</li>
+<li><a href="http://shiroyasha.io/transaction-isolation-levels-in-postgresql.html">http://shiroyasha.io/transaction-isolation-levels-in-postgresql.html</a></li>
+<li><a href="https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/tr-95-51.pdf">A Critique of ANSI SQL Isolation Levels</a></li>
+<li><a href="http://www.cs.umb.edu/~poneil/ROAnom.pdf">A Read-Only Transaction Anomaly Under Snapshot Isolation</a></li>
+<li><a href="http://vldb.org/pvldb/vol5/p1850_danrkports_vldb2012.pdf">Serializable Snapshot Isolation in PostgreSQL</a></li>
+<li><a href="https://www.postgresql.org/docs/current/static/applevel-consistency.html">https://www.postgresql.org/docs/current/static/applevel-consistency.html</a></li>
+<li><a href="http://jimgray.azurewebsites.net/papers/thetransactionconcept.pdf">The Transaction Concept: Virtues and Limitations</a></li>
+</ul>
+</div>
+</div>
+</div>
+<div id="postamble" class="status">
+<p class="date">Created: 2018-09-09 Sun 09:46</p>
+<p class="validation"><a href="http://validator.w3.org/check?uri=referer">Validate</a></p>
+</div>
+</body>
+</html>

--- a/doc/isolation-notes.org
+++ b/doc/isolation-notes.org
@@ -1,0 +1,470 @@
+#+TITLE: Transaction and Isolation Notes
+#+OPTIONS: num:nil
+#+HTML_HEAD: <link rel="stylesheet" type="text/css" href="style.css" />
+#+OPTIONS: ^:nil
+
+* Postmodern transaction calls with transaction names and isolation levels
+Transactions are one or more statements wrapped together which either all
+succeed and are "committed" or none of them succeed, in which case any state
+changes are rolled back to the beginning of the transaction. In the case of
+postmodern, there are two main macros available for use:
+
+- with-transaction (for general use)
+- with-logical-transaction (for nested transactions and savepoints)
+
+When you get into situations where you expect concurrent transactions, you
+can specify the whether the transaction is allowed only read access or
+both read and write access to the database table rows and you can specify
+either the default isolation level or a specific isolation level for that
+transaction. If you need more information on what isolation levels are, and
+when to use them, see below.
+
+Postgresql defaults to the read committed isolation level with
+read and write access. This is also postmodern's default, but that can be
+changed by setting postmodern:*isolation-level* to your desired setting.
+
+The available settings in postmodern follow the sql standard are:
+
+- :read-committed-rw (read committed with read and write)
+- :read-committed-ro (read committed with read only)
+- :repeatable-read-rw (repeatable read with read and write)
+- :repeatable-read-ro (repeatable read with read only)
+- :serializable (serializable with read and write)
+
+(Ok. "Loosely" follows the sql standard because we combine read-write and
+read-only constraints with the sql standard isolation levels. There is one
+unsafe isolation level defined by the standard, but neither postgresql nor
+any other major database implements it.)
+
+Postmodern generally provides the ability to specify the name of a transaction
+and the isolation level per the key words above. Examples of use are below
+and "george" is used as the name of the transaction (not quoted or as a string):
+#+BEGIN_SRC lisp
+(with-transaction ()
+  (execute (:insert-into 'test-data :set 'value 77)))
+
+(with-transaction (george)
+  (execute (:insert-into 'test-data :set 'value 22)))
+
+(with-transaction (george :read-committed-rw)
+  (execute (:insert-into 'test-data :set 'value 33)))
+
+(with-transaction (:serializable)
+  (execute (:insert-into 'test-data :set 'value 44)))
+
+(with-logical-transaction ()
+  (execute (:insert-into 'test-data :set 'value 77)))
+
+(with-logical-transaction (george)
+  (execute (:insert-into 'test-data :set 'value 22)))
+
+(with-logical-transaction (george :read-committed-rw)
+  (execute (:insert-into 'test-data :set 'value 33)))
+
+(with-logical-transaction (:serializable)
+  (execute (:insert-into 'test-data :set 'value 44)))
+#+END_SRC
+
+* Introduction to ACID, Transactions and Isolation Levels
+
+Databases like Postgresql are not simply data storage, they are
+transaction management systems. In the context of transactions with multiple
+operations within the transaction, either all of them commit or none of them
+commit (the transaction is rolled back). Transactions include single
+statement transactions as well as multiple statement transactions that are
+wrapped inside BEGIN – COMMIT Commands. (In the case of postmodern macros
+with-transaction and with-logical-transaction, the commit command is handled
+for you automatically.)
+
+You may have heard of databases being "ACID" compliant or having ACID
+functionality. Transactions are the “A” (Atomicity) in “ACID”.
+“C” is “Consistency”, “I” is “Isolation” and “D” is “Durability”. As you can
+tell, everything in ACID in designed to maintain the integrity of the data.
+Without atomicity, you risk leaving data in a partial or invalid state and
+everything which depends on the data will break. (And your dba will be
+upset – the question is – will they then try to break you?)
+
+Consistency ensures that every transaction will move the database from one
+valid state to another valid state. Consider two users A and B signing up
+with the same desired username “myname” almost simultaneously. The system
+checks to see whether “myname” is in use for A. It is not, so it starts the
+process of creating a record for “myname”. The system checks for B to see
+whether “myname” is in use. Since it has not yet finished creating the record
+for A, it appears to be available for B, so it starts the process of
+creating a user record for B using “myname”. One or both can end up in an
+invalid state.
+
+You can prevent the inconsistent state by either putting a uniqueness check
+on the user table for usernames or you use an isolation level like
+serializable on your transactions. In either case, B’s commit will fail,
+you have to restart that transaction, but the data that is now in the system
+is safe and consistent..
+
+Isolation levels define what is allowed to happen if there are two transactions
+tyring to access the same data simultaneously. More on this below.
+
+Durability means that committed transactions must stay committed, even in
+the event of a crash, power loss, etc.
+
+* Transactions
+
+It is easy show the impact of transactions in action. Consider the following:
+
+#+BEGIN_SRC lisp
+(execute (:create-table test-data ((value :type integer))))
+
+(with-transaction ()
+  (execute (:insert-into 'test-data :set 'value 77)))
+(query (:select '* :from 'test-data))
+((77))
+#+END_SRC
+The postmodern macro with-transaction completes with a call to
+commit-transaction. So absent any intervening actions, the transaction
+will commit at the end of the form.
+
+For purposes of the following examples, assume that we truncated
+the table prior to each example so we have the same base line each time.
+#+BEGIN_SRC lisp
+(ignore-errors
+  (with-transaction ()
+    (execute (:insert-into 'test-data :set 'value 2))
+    (error "no wait")))
+NIL
+#<SIMPLE-ERROR "no wait" {100D581653}>
+
+(with-test-connection (query (:select '* :from 'test-data)))
+NIL
+#+END_SRC
+This time we triggered an error before the transaction concluded. Because the
+error was inside the transaction, it invalidated all statements inside the
+transction and the tentative insertion never happened.
+(Actually more complicated than this, but from an application developer
+standpoint, we can think of it this way.)
+
+Now lets actually give the transaction a name and make a superflous call to
+commit-transaction within the transaction.
+#+BEGIN_SRC lisp
+(with-transaction (transaction)
+  (execute (:insert-into 'test-data :set 'value 2))
+  (commit-transaction transaction))
+
+(query (:select '* :from 'test-data))
+((2))
+#+END_SRC
+As you can see, making the unnecessary call to commit-tranaction does not
+trigger the insertion twice.
+
+We can also decide to abort the transaction without triggering an error:
+#+BEGIN_SRC lisp
+(with-transaction (transaction)
+  (execute (:insert-into 'test-data :set 'value 44))
+  (abort-transaction transaction))
+
+(query (:select '* :from 'test-data))
+NIL
+#+END_SRC
+As expected, the insertion was never committed due to the call to
+abort-transaction.
+
+*** What happens if we nest transactions?
+Postgresql does not fully support nested transactions. Full support of
+nested transactions would mean that a succesful sub-transaction does not get
+rolled back if a parent transaction (direct or indirect) gets rolled back.
+
+Postgresql allows the use of savepoints, which can get you to a consistent
+state but means that if any transaction in a nested transaction sequence
+is rolled back, then everything in the transaction is rolled back. Postmodern
+provides savepoints automatically in a nested situation if you use the macro
+with-logical-transaction. Postmodern also provides a macro with-savepoint
+if you need to handle them manually.
+
+If you do not use savepoints, the result of nested transactions may not be
+consistent. Some or all of subtransactions may or may not get committed
+if there is an error anywhere in the nest.
+
+The [[https://www.postgresql.org/docs/10/static/sql-begin.html][official postgresql documentation]] states that "Issuing a begin when already
+inside a transaction will provoke a warning message. The state of the
+transaction is not affected." While this sounds like the subtransactions just
+get treated as part of the outer transaction, you cannot rely on that
+interpretation.
+
+Morale of the story. If you are going to nest transactions in postmdern, use
+the with-logical-transaction macro, do not use the with-transaction macro.
+
+Now lets talk about concurrency issues and the trade-offs between different
+isolation levels.
+
+* The Concurrency Problem
+** Summary
+Consider when you have multiple concurrent transactions or multiple concurrent
+database events. These create potential race conditions as well as potential
+overwrite issues, creating hard to find bugs. The base problem is easy to
+understand – what happens when two users try to access the same row of data
+concurrently.
+
+Think about how databases using MVCC (multi-version concurrency control)
+execute statements inside a transaction. The data generated by the transaction
+is kept off to the side, away from other data until the entire transaction
+can be committed. Once it is committed, it becomes visible to all future
+transactions and the old row which it may have edited becomes marked as
+invalid. The invalid row still exists in the system until the next VACUUM.
+Of course, this does not mean that the system prevents user B from overwriting
+user A’s changes from an hour ago. We are solely focused on concurrency issues
+here.
+
+All committed transactions are written to the write-ahead log (WAL or “xlog”).
+In case of trouble, Postgresql can replay the WAL log to recover changes that
+did not get into the actual data files. Postgresql also has a commit
+log “pg_xact” which summarizes transactions and whether the transaction
+committed or aborted. Any transaction that was a read only transaction is
+never written to the WAL or commit logs. As it was not intended to modify any
+data, there is no need. However, if the transaction is aborted, that fact will
+still be noted in the WAL and commit logs. (You can also configure postgresql
+to log all queries, but that is not the default.)
+
+Now think about the situation at a little more granular level.
+
+- If two transactions read the old state and then perform changes concurrently, the last write transaction will be effective and the previous write transaction may be lost unless you have explicit locking.
+
+- If two transactions with multiple statements read the old state and then both transactions perform changes concurrently, you may end up in an inconsistent data state.
+
+- If one transaction reads the old state and prepares to make a change based on the value of the old state, but another transaction modifies the old state before the first transaction finishes, the first transaction has now made a decision based on bad data.
+
+- If you execute the same query twice and get back more or fewer elements in the second execution than the first execution.
+
+Depending on your application, these may or may not be something that you need
+to worry about.
+
+The SQL standard actually has four transaction isolation levels.
+Postgresql only implements three of those - "Read Uncommitted" is not
+implemented and the default transaction level for Postgresql is “read committed”.
+Postgresql allows the user to specify the isolation level of a transaction
+on a transaction by transaction basis. As you might expect, there are trade-offs.
+Stronger isolation levels have more overhead and may trigger more transactions
+that need to be repeated (and therefore you will have to write the code to
+handle the necessary repeats).
+
+We explain this table just below:
+
+| Isolation Level  | Dirty Read   | Nonrepeatable Read | Phantom Read                                       | Serialization Anomaly |
+|------------------+--------------+--------------------+----------------------------------------------------+-----------------------|
+| Read Uncommitted | Allowed      | Possible           | Possible                                           | Possible              |
+| Read Committed * | Not Possible | Possible           | Possible                                           | Possible              |
+| Repeatable Read  | Not Possible | Not Possible       | Allowed by SQL Standard, not allowed in Postgresql | Possible              |
+| Serializable     | Not Possible | Not Possible       | Not Possible                                       | Not Possible          |
+
+** Problem Explanation
+*** Dirty Read
+A Dirty Read is a transaction reads data written by a concurrent uncommitted
+transaction. You can specify a transaction as having a “Read Uncommitted”
+level, but Postgresql will internally just give you a “Read Committed”
+isolation level.
+
+Assume sales are 2100 at the beginning
+| Transaction 1                                    | Transaction 2                                                    |
+| BEGIN                                            | BEGIN                                                            |
+| (:select 'sales :from 'table1 :where (:= 'id 21) |                                                                  |
+|                                                  | (:update 'table1 :set 'sales 2200 :where (:= 'id 21)) ;no commit |
+| (:select 'sales :from 'table1 :where (:= 'id 21) |                                                                  |
+| END                                              | END                                                              |
+
+The second select will read sales as 2200 even though Transaction 2 did not
+fully commit.
+
+*** Nonrepeatable Read
+A Nonrepeatable read is a transaction re-reads data it has previously read and
+finds the data has been modified by another transaction that committed since
+the initial read.
+
+Assume sales are 2100 at the beginning
+| Transaction 1                                    | Transaction 2                                                    |
+| BEGIN                                            | BEGIN                                                            |
+| (:select 'sales :from 'table1 :where (:= 'id 21) |                                                                  |
+|                                                  | (:update 'table1 :set 'sales 2200 :where (:= 'id 21))            |
+|                                                  | COMMIT;                                                          |
+| (:select 'sales :from 'table1 :where (:= 'id 21) |                                                                  |
+| END                                              | END                                                              |
+
+The second select will read sales as 2200. At least transaction 2 actually
+committed first.
+
+If you are just trying to avoid lost updates, you can use row level locks
+with select FOR UPDATE under read committed. That avoids the update being
+lost or aborted. Of course, now you need to worry about how to handle
+situations where one transaction gets stalled and holds a transaction too long.
+
+For select statements, you can add a row level lock by adding FOR SHARE to the
+end of the SELECT. For updates, use FOR UPDATE. In postmodern, if you are using
+s-sql, you can include :for-share or :for-update in the select statement. E.g.
+
+#+BEGIN_SRC lisp
+(query (:for-update (:select :* :from 'foo 'bar 'baz) :of 'bar 'baz :nowait))
+#+END_SRC
+See [[file:s-sql.html]] for further details.
+
+*** Phantom Read
+A Phantom Read is where a transaction re-executes a query returning a set of
+rows and finds that the set of rows has changed (not necessarily row 215,
+but some one or more of the rows in the query set). Phantom Reads are
+prevented by using the “Repeatable Read” isolation level. Row level locks
+will not solve this problem.
+
+Assume first select returns 50:
+
+| Transaction 1                                             | Transaction 2                            |
+| BEGIN                                                     | BEGIN                                    |
+| (:select (:count '*) :from 'table1 :where (:= 'region 1)) |                                          |
+|                                                           | (:insert-into 'table1 :set 'sales 2200)) |
+|                                                           | COMMIT;                                  |
+| (:select (:count '*) :from 'table1 :where (:= 'region 1)) |                                          |
+| END                                                       | END                                      |
+
+The second select will return 51. Depending on what else might be happening in
+transaction 1, the difference between the number of rows at the beginning and
+the number of rows at the end may cause calculations to be inconsistent
+internally to the transaction.
+
+*** For More Fun
+Now consider you have banking application A which runs in multiple sessions and
+does not use transactions and the user withdraws 100 from each of two sessions
+and the balance started at 300.
+
+| Session 1                                                 | Session 2                                                 |
+| (:select 'balance :from 'accounts :where (:= 'user-id 1)) |                                                           |
+|                                                           | (:select 'balance :from 'accounts :where (:= 'user-id 1)) |
+| Application calculates the balance should be 200          |                                                           |
+| (:update 'accounts :set 'balance 200)                     |                                                           |
+|                                                           | Application calculates the balance should be 200          |
+|                                                           | (:update 'accounts :set 'balance 200)                     |
+
+At this point the application has subtracted 200 (100 in each session), but
+the account balance still shows 200. Transactions would not have made a
+difference.
+
+Now implemented slightly differently:
+| Session 1                                                 | Session 2                                                 |
+| (:select 'balance :from 'accounts :where (:= 'user-id 1)) |                                                           |
+|                                                           | (:select 'balance :from 'accounts :where (:= 'user-id 1)) |
+| (:update 'accounts :set 'balance (:- 'balance 100))       |                                                           |
+|                                                           | (:update 'accounts :set 'balance (:- 'balance 100))       |
+
+Do you know what the balance is now? It should be 100 because you put the
+calculation back into the database where it belongs. But life gets more
+complicated than these simple examples. Complex queries and updates provide
+more possibilities for concurrent transactions to generate conflicting,
+leading to solutions such as "row level locking" and "isolation levels".
+
+** Isolation Levels
+The official postgresql documentation can be found [[https://www.postgresql.org/docs/current/static/transaction-iso.html][here]].
+
+*** Read Committed Isolation Level
+Read Committed is the default isolation level in Postgresql. In general
+it has the best balance between locking and performance. This isolation level
+means that the existing row is read after the transaction is completed but not
+yet written. If the row has not changed, then the transaction is executed. If
+the row has changed from when it started building the transaction, then it
+starts the transaction over again.
+
+The “Read Committed” default isolation level is safe when you are concurrently
+reading. If there are multiple select statements in a single transaction, each
+select statement will have its own snapshot of the database (which might not
+be the same if another transaction is concurrently modifying the database).
+The “Read Committed” isolation level is not necessarily safe for concurrent
+updates. In other words, the concurrent updates would be performed serially,
+potentially surprising the user whose commit is overridden. Update and
+Delete statements in a “Read Committed” isolation level will create a
+snapshot of the database, use that snapshot to find the rows matching the
+where clause and then try to lock that row of the snapshot. If any rows are
+already locked by an update or delete statement in another transaction, the
+update or delete statement will wait for the other transaction to commit or
+abort. If it commits, the update or delete will re-evaluate the where clause
+on the new version of the row to determine whether it needs to be modified.
+
+Assume our banking problem using transactions at the Postgresql default
+isolation level of "read committed".
+
+| Session 1                                                 | Session 2                                                            |
+| BEGIN                                                     | BEGIN                                                                |
+| (:select 'balance :from 'accounts :where (:= 'user-id 1)) |                                                                      |
+|                                                           | ; Deferred (:select 'balance :from 'accounts :where (:= 'user-id 1)) |
+| Application calculates the balance should be 200          |                                                                      |
+| (:update 'accounts :set 'balance 200)                     |                                                                      |
+| COMMIT                                                    |                                                                      |
+|                                                           | Application calculates the balance should be 100                     |
+|                                                           | (:update 'accounts :set 'balance 100)                                |
+|                                                           | COMMIT                                                               |
+
+The Session 2 select query notices that the row is already engaged and would be
+deferred until Transaction 1 is committed. At that point it reads the
+balance (now 200), tells the application, and the application subtracts 100
+and tells the database to update the balance to 100.
+
+*** Repeatable Read Isolation Level
+In Postgresql, a “Repeatable Read” isolation level takes a snapshot of the
+current state of the database and all queries in the transaction will use
+that snapshot. So if another transaction modifies a row, a second select
+statement in a repeatable read isolation level would not be affected because
+it is looking solely at the snapshot that was taken at the beginning of the
+transaction.
+
+Things happen differently if the transaction using a “Repeatable Read”
+isolation level wants to Update or Delete a row.
+
+If a Phantom read is detected when the transaction wants to commit, a
+Repeatable Read would go back and re-read the table and repeat the
+transaction. Update and Delete statements in a “Repeatable Read” isolation
+level will create a snapshot of the database, use that snapshot to find the
+rows matching the where clause and then check to see if another transaction
+is currently trying to modify the rows  (not just the columns) that the
+Update or Delete statement is trying to modify. If the other transaction
+aborts, the Update or Delete statement will modify the relevant rows and
+continue. If the other transaction commits, then the repeatable read
+transaction will abort with an error message about “could not serialize
+access due to concurrent update”.
+
+If you are running transaction at isolation level “repeatable read”,
+concurrent updates can be expected to trigger query failures  from time
+to time that need to be handled, typically by re-running the transaction.
+The following error message can be expected:
+
+- “ERROR: could not serialize due to concurrent update” (Under
+either “repeatable read” or “serializable”.)
+
+Repeatable read addresses a different problem than our banking problem
+above, so the result in this case is the same as "read committed".
+
+*** Serializable Isolation Level
+The Serializable Isolation level tells postgresql to effectively serialize all
+transactions. That ensures validity at the cost of a hit to performance.
+
+If you are running transaction at isolation level “serializable”, concurrent
+updates can be expected to trigger query failures  from time to time that
+need to be handled, typically by re-running the transaction. The following
+two errors can be expected:
+
+- “ERROR: could not serialize due to concurrent update” (Under either “repeatable read” or “serializable”.)
+
+- “ERROR: could not serialize access due to read/write dependencies among transactions. (Under “serializable”).
+
+* For Futher Reading
+
+- https://www.postgresql.org/docs/current/static/transaction-iso.html
+- https://www.postgresql.org/docs/current/static/sql-set-transaction.html
+- http://elliot.land/post/sql-transaction-isolation-levels-explained
+- https://blog.2ndquadrant.com/postgresql-anti-patterns-read-modify-write-cycles/
+- https://dba.stackexchange.com/questions/131226/set-serializable-isolation-for-update-query-postgresql-9-4
+- https://www.enterprisedb.com/docs/en/9.0/pg/transaction-iso.html
+- https://wiki.postgresql.org/wiki/SSI
+- https://dba.stackexchange.com/questions/202775/how-to-write-validation-trigger-which-works-with-all-isolation-levels
+- https://stackoverflow.com/questions/45923021/apparent-transaction-isolation-violation-in-postgresql
+- https://brandur.org/http-transactions
+- https://brandur.org/idempotency-keys
+- https://brandur.org/postgres-reads
+- http://malisper.me/postgres-transaction-isolation-levels/
+- https://begriffs.com/posts/2017-08-01-practical-guide-sql-isolation.html (includes the "zoo" of transaction phenomena)
+- http://shiroyasha.io/transaction-isolation-levels-in-postgresql.html
+- [[https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/tr-95-51.pdf][A Critique of ANSI SQL Isolation Levels]]
+- [[http://www.cs.umb.edu/~poneil/ROAnom.pdf][A Read-Only Transaction Anomaly Under Snapshot Isolation]]
+- [[http://vldb.org/pvldb/vol5/p1850_danrkports_vldb2012.pdf][Serializable Snapshot Isolation in PostgreSQL]]
+- [[https://www.postgresql.org/docs/current/static/applevel-consistency.html]]
+- [[http://jimgray.azurewebsites.net/papers/thetransactionconcept.pdf][The Transaction Concept: Virtues and Limitations]]

--- a/doc/postmodern.html
+++ b/doc/postmodern.html
@@ -3,7 +3,7 @@
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 <head>
-<!-- 2018-08-11 Sat 20:00 -->
+<!-- 2018-09-09 Sun 09:55 -->
 <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Postmodern Reference Manual</title>
@@ -234,137 +234,138 @@ for the JavaScript code in this tag.
 <h2>Table of Contents</h2>
 <div id="text-table-of-contents">
 <ul>
-<li><a href="#org41ad3a7">Connecting</a>
+<li><a href="#org12bf2ab">Connecting</a>
 <ul>
-<li><a href="#org16047f6">class database-connection</a></li>
-<li><a href="#org1324a15">function connect (database user password host &amp;key (port 5432) pooled-p use-ssl)</a></li>
-<li><a href="#org9cbc355">variable <b>default-use-ssl</b></a></li>
-<li><a href="#orge7e09aa">method disconnect (database-connection)</a></li>
-<li><a href="#org7022b61">function connected-p (database-connection)</a></li>
-<li><a href="#orgb357674">method reconnect (database-connection)</a></li>
-<li><a href="#org1c3cf0b">variable <b>database</b></a></li>
-<li><a href="#org19a858b">macro with-connection (spec &amp;body body)</a></li>
-<li><a href="#orgf603140">macro call-with-connection (spec thunk)</a></li>
-<li><a href="#orgaf93a1e">function connect-toplevel (database user password host &amp;key (port 5432))</a></li>
-<li><a href="#org2c329fe">function disconnect-toplevel ()</a></li>
-<li><a href="#org111e702">function clear-connection-pool ()</a></li>
-<li><a href="#org7cfedf0">variable <b>max-pool-size</b></a></li>
+<li><a href="#org00e8166">class database-connection</a></li>
+<li><a href="#orgc064b1e">function connect (database user password host &amp;key (port 5432) pooled-p use-ssl)</a></li>
+<li><a href="#org68186df">variable <b>default-use-ssl</b></a></li>
+<li><a href="#orgd9a937c">method disconnect (database-connection)</a></li>
+<li><a href="#orgde9e513">function connected-p (database-connection)</a></li>
+<li><a href="#org1eacefb">method reconnect (database-connection)</a></li>
+<li><a href="#org36b95c0">variable <b>database</b></a></li>
+<li><a href="#org9128424">macro with-connection (spec &amp;body body)</a></li>
+<li><a href="#org924da0f">macro call-with-connection (spec thunk)</a></li>
+<li><a href="#orga51009d">function connect-toplevel (database user password host &amp;key (port 5432))</a></li>
+<li><a href="#org27d9f96">function disconnect-toplevel ()</a></li>
+<li><a href="#org8844a45">function clear-connection-pool ()</a></li>
+<li><a href="#org8110919">variable <b>max-pool-size</b></a></li>
 </ul>
 </li>
-<li><a href="#org1aee8ff">Querying</a>
+<li><a href="#org6f305ee">Querying</a>
 <ul>
-<li><a href="#orgaa868cd">macro query (query &amp;rest args/format)</a></li>
-<li><a href="#orgf3ecdd9">macro execute (query &amp;rest args)</a></li>
-<li><a href="#org79e4e1e">macro doquery (query (&amp;rest names) &amp;body body)</a></li>
-<li><a href="#org63d983c">macro prepare (query &amp;optional (format :rows))</a></li>
-<li><a href="#org1c4872b">macro defprepared (name query &amp;optional (format :rows))</a></li>
-<li><a href="#org95d9032">macro defprepared-with-names (name (&amp;rest args) (query &amp;rest query-args) &amp;optional (format :rows))</a></li>
-<li><a href="#orgbfb927e">macro with-transaction ((&amp;optional name) &amp;body body)</a></li>
-<li><a href="#orgf71c73d">function commit-transaction (transaction)</a></li>
-<li><a href="#orgf847006">function abort-transaction (transaction)</a></li>
-<li><a href="#org2e4f103">macro with-savepoint (name &amp;body body)</a></li>
-<li><a href="#org1e01691">function release-savepoint (savepoint)</a></li>
-<li><a href="#org763b22f">function rollback-savepoint (savepoint)</a></li>
-<li><a href="#org98941b1">function commit-hooks (transaction-or-savepoint), setf (commit-hooks transaction-or-savepoint)</a></li>
-<li><a href="#orga1023a0">function abort-hooks (transaction-or-savepoint), setf (abort-hooks transaction-or-savepoint)</a></li>
-<li><a href="#org2823946">macro with-logical-transaction ((&amp;optional name) &amp;body body)</a></li>
-<li><a href="#org7f65c91">function abort-logical-transaction (transaction-or-savepoint)</a></li>
-<li><a href="#orgdaeb32a">function commit-logical-transaction (transaction-or-savepoint)</a></li>
-<li><a href="#orgb767910">variable <b>current-logical-transaction</b></a></li>
-<li><a href="#org8c1a03c">macro ensure-transaction (&amp;body body)</a></li>
-<li><a href="#orge407acf">macro with-schema ((namespace &amp;key :strict t :if-not-exist :create :drop-after) &amp;body body)</a></li>
-<li><a href="#orgc76d2c0">function sequence-next (sequence)</a></li>
-<li><a href="#org34a8888">function coalesce (&amp;rest arguments)</a></li>
+<li><a href="#org4cc93e0">macro query (query &amp;rest args/format)</a></li>
+<li><a href="#org17818eb">macro execute (query &amp;rest args)</a></li>
+<li><a href="#orgb44cfc9">macro doquery (query (&amp;rest names) &amp;body body)</a></li>
+<li><a href="#org1300f89">macro prepare (query &amp;optional (format :rows))</a></li>
+<li><a href="#org9c4a4e0">macro defprepared (name query &amp;optional (format :rows))</a></li>
+<li><a href="#orgd4e448c">macro defprepared-with-names (name (&amp;rest args) (query &amp;rest query-args) &amp;optional (format :rows))</a></li>
+<li><a href="#orgeb29edd">macro with-transaction ((&amp;optional name isolation-level) &amp;body body)</a></li>
+<li><a href="#org0b309fc">function commit-transaction (transaction)</a></li>
+<li><a href="#org5805244">function abort-transaction (transaction)</a></li>
+<li><a href="#orga8e4c4b">macro with-savepoint (name &amp;body body)</a></li>
+<li><a href="#orgd9a0074">function release-savepoint (savepoint)</a></li>
+<li><a href="#org75b1276">function rollback-savepoint (savepoint)</a></li>
+<li><a href="#orgc16cdba">function commit-hooks (transaction-or-savepoint), setf (commit-hooks transaction-or-savepoint)</a></li>
+<li><a href="#org630966a">function abort-hooks (transaction-or-savepoint), setf (abort-hooks transaction-or-savepoint)</a></li>
+<li><a href="#org59e1b11">macro with-logical-transaction ((&amp;optional name isolation-level) &amp;body body)</a></li>
+<li><a href="#org199841e">function abort-logical-transaction (transaction-or-savepoint)</a></li>
+<li><a href="#org8176940">function commit-logical-transaction (transaction-or-savepoint)</a></li>
+<li><a href="#orgd106c94">variable <b>current-logical-transaction</b></a></li>
+<li><a href="#org7092455">macro ensure-transaction (&amp;body body)</a></li>
+<li><a href="#org577c796">macro with-schema ((namespace &amp;key :strict t :if-not-exist :create :drop-after) &amp;body body)</a></li>
+<li><a href="#orgc89e778">function sequence-next (sequence)</a></li>
+<li><a href="#orga3d089c">function coalesce (&amp;rest arguments)</a></li>
 </ul>
 </li>
-<li><a href="#org868514f">Inspecting the database</a>
+<li><a href="#orgf8bb9fa">Inspecting the database</a>
 <ul>
-<li><a href="#orgbbc34ae">function list-tables (&amp;optional strings-p)</a></li>
-<li><a href="#org691be0f">function table-exists-p (name)</a></li>
-<li><a href="#org1f2a898">function table-description (name &amp;optional schema-name)</a></li>
-<li><a href="#org77bf5e8">function list-sequences (&amp;optional strings-p)</a></li>
-<li><a href="#org673c5cb">function sequence-exists-p (name)</a></li>
-<li><a href="#orgb23b47f">function list-views (&amp;optional strings-p)</a></li>
-<li><a href="#org29e9f9b">function view-exists-p (name)</a></li>
-<li><a href="#org604f57f">function list-schemata ()</a></li>
-<li><a href="#org5cb5498">function schema-exist-p (schema) NOW DEPRECATED IN FAVOR OF schema-exists-p which is more consistent with naming of other functions.</a></li>
-<li><a href="#orgd42abc6">function schema-exists-p (schema)</a></li>
-<li><a href="#orgdb30f09">function database-version ()</a></li>
-<li><a href="#orgb83fa4f">function num-records-in-database ()</a></li>
-<li><a href="#orgd08e9c4">function current-database ()</a></li>
-<li><a href="#orgb0e14c5">function database-exists-p (database-name)</a></li>
-<li><a href="#orga714e8d">function database-size (&amp;optional database-name)</a></li>
-<li><a href="#org3dc8479">function list-databases (&amp;key (order-by-size nil) (size t))</a></li>
-<li><a href="#org76e3f6a">function list-schemas ()</a></li>
-<li><a href="#orgf8ed3d2">function list-tablespaces ()</a></li>
-<li><a href="#orga04ef47">function list-available-types ()</a></li>
-<li><a href="#orgbfe5e00">function list-table-sizes (&amp;key (schema "public") (order-by-size nil) (size t))</a></li>
-<li><a href="#org0f079b0">function table-size (table-name)</a></li>
-<li><a href="#orgc280c15">function more-table-info (table-name)</a></li>
-<li><a href="#org6250e37">function list-columns (table-name)</a></li>
-<li><a href="#org15757d6">function list-columns-with-types (table-name)</a></li>
-<li><a href="#orge927d6b">function column-exists-p (table-name column-name)</a></li>
-<li><a href="#org92bd4ee">function describe-views (&amp;optional (schema "public")</a></li>
-<li><a href="#org2f56533">function list-database-functions ()</a></li>
-<li><a href="#org2b8c171">function list-indices (&amp;optional strings-p)</a></li>
-<li><a href="#org43b5670">function list-table-indices (table-name &amp;optional strings-p)</a></li>
-<li><a href="#orgf9a87c2">function list-indexed-column-and-attributes (table-name)</a></li>
-<li><a href="#org04e53ef">function list-index-definitions (table-name)</a></li>
-<li><a href="#org913139b">function list-foreign-keys (table-name)</a></li>
-<li><a href="#org08202c8">function list-unique-or-primary-constraints (table-name)</a></li>
-<li><a href="#org61ccc27">function list-all-constraints (table-name)</a></li>
-<li><a href="#org6e13985">function describe-constraint (table-name constraint-name)</a></li>
-<li><a href="#org2a704ab">function describe-foreign-key-constraints ()</a></li>
-<li><a href="#orga3784b7">function list-triggers (&amp;optional table-name)</a></li>
-<li><a href="#orgd09029b">function list-detailed-triggers ()</a></li>
-<li><a href="#org0c9e9f9">function list-database-users ()</a></li>
-<li><a href="#org21e6cb7">function change-toplevel-database (new-database user password host)</a></li>
+<li><a href="#org243efd1">function list-tables (&amp;optional strings-p)</a></li>
+<li><a href="#org1c59df2">function table-exists-p (name)</a></li>
+<li><a href="#org21239d7">function table-description (name &amp;optional schema-name)</a></li>
+<li><a href="#orgb093db7">function list-sequences (&amp;optional strings-p)</a></li>
+<li><a href="#org44d0c87">function sequence-exists-p (name)</a></li>
+<li><a href="#orgc01d47e">function list-views (&amp;optional strings-p)</a></li>
+<li><a href="#org9018f6c">function view-exists-p (name)</a></li>
+<li><a href="#org78fe14c">function list-schemata ()</a></li>
+<li><a href="#org9f0317b">function schema-exist-p (schema) NOW DEPRECATED IN FAVOR OF schema-exists-p which is more consistent with naming of other functions.</a></li>
+<li><a href="#orgbca9e67">function schema-exists-p (schema)</a></li>
+<li><a href="#orgae44c0f">function database-version ()</a></li>
+<li><a href="#org4e0cfdb">function num-records-in-database ()</a></li>
+<li><a href="#orgd0f05b7">function current-database ()</a></li>
+<li><a href="#org4bb05ac">function database-exists-p (database-name)</a></li>
+<li><a href="#org3e07ff6">function database-size (&amp;optional database-name)</a></li>
+<li><a href="#org2600479">function list-databases (&amp;key (order-by-size nil) (size t))</a></li>
+<li><a href="#orgc8d4f8c">function list-schemas ()</a></li>
+<li><a href="#orged2ac89">function list-tablespaces ()</a></li>
+<li><a href="#orgf8f1ff9">function list-available-types ()</a></li>
+<li><a href="#org92647f7">function list-table-sizes (&amp;key (schema "public") (order-by-size nil) (size t))</a></li>
+<li><a href="#org4d7e175">function table-size (table-name)</a></li>
+<li><a href="#org1259140">function more-table-info (table-name)</a></li>
+<li><a href="#org5b8aa84">function list-columns (table-name)</a></li>
+<li><a href="#org7ed6366">function list-columns-with-types (table-name)</a></li>
+<li><a href="#org4199ffb">function column-exists-p (table-name column-name)</a></li>
+<li><a href="#org7b83386">function describe-views (&amp;optional (schema "public")</a></li>
+<li><a href="#org7bdefe3">function list-database-functions ()</a></li>
+<li><a href="#orgaecd074">function list-indices (&amp;optional strings-p)</a></li>
+<li><a href="#org8b0bb3c">function list-table-indices (table-name &amp;optional strings-p)</a></li>
+<li><a href="#orgd50ec5d">function list-indexed-column-and-attributes (table-name)</a></li>
+<li><a href="#org077d80b">function list-index-definitions (table-name)</a></li>
+<li><a href="#org2938392">function find-primary-key-info (table-name &amp;optional (just-key nil))</a></li>
+<li><a href="#org854d2a3">function list-foreign-keys (table-name)</a></li>
+<li><a href="#orgbf5f27b">function list-unique-or-primary-constraints (table-name)</a></li>
+<li><a href="#org6efd450">function list-all-constraints (table-name)</a></li>
+<li><a href="#org718ae74">function describe-constraint (table-name constraint-name)</a></li>
+<li><a href="#orgfb319ea">function describe-foreign-key-constraints ()</a></li>
+<li><a href="#org64616d3">function list-triggers (&amp;optional table-name)</a></li>
+<li><a href="#orgd536f5b">function list-detailed-triggers ()</a></li>
+<li><a href="#org6b6447b">function list-database-users ()</a></li>
+<li><a href="#orgc5a2e78">function change-toplevel-database (new-database user password host)</a></li>
 </ul>
 </li>
-<li><a href="#org00207e6">Database access objects</a>
+<li><a href="#org8e171a0">Database access objects</a>
 <ul>
-<li><a href="#org841b506">metaclass dao-class</a></li>
-<li><a href="#org01f46ef">method dao-keys (class)</a></li>
-<li><a href="#orgbddb9c7">method dao-keys (dao)</a></li>
-<li><a href="#org63c8766">method dao-exists-p (dao)</a></li>
-<li><a href="#orga2273af">method make-dao (type &amp;rest args &amp;key &amp;allow-other-keys)</a></li>
-<li><a href="#orga8f1d62">macro define-dao-finalization (((dao-name class) &amp;rest keyword-args) &amp;body body)</a></li>
-<li><a href="#orgb80db1e">method get-dao (type &amp;rest keys)</a></li>
-<li><a href="#org3e66f17">macro select-dao (type &amp;optional (test t) &amp;rest sort)</a></li>
-<li><a href="#org01592fc">macro do-select-dao (((type type-var) &amp;optional (test t) &amp;rest sort) &amp;body body)</a></li>
-<li><a href="#orgef6c4d3">macro query-dao (type query &amp;rest args)</a></li>
-<li><a href="#org2946618">function do-query-dao (((type type-var) query &amp;rest args) &amp;body body)</a></li>
-<li><a href="#org213b819">variable <b>ignore-unknown-columns</b></a></li>
-<li><a href="#org112977f">method insert-dao (dao)</a></li>
-<li><a href="#org7949047">method update-dao (dao)</a></li>
-<li><a href="#org97b3733">function save-dao (dao)</a></li>
-<li><a href="#org156dacc">function save-dao/transaction (dao)</a></li>
-<li><a href="#orge4bc9c5">method upsert-dao (dao)</a></li>
-<li><a href="#org539b51d">method delete-dao (dao)</a></li>
-<li><a href="#org5bade60">function dao-table-name (class)</a></li>
-<li><a href="#org7e43de5">function dao-table-definition (class)</a></li>
-<li><a href="#org052ee19">macro with-column-writers ((&amp;rest writers) &amp;body body)</a></li>
+<li><a href="#orge295326">metaclass dao-class</a></li>
+<li><a href="#orgc99ce39">method dao-keys (class)</a></li>
+<li><a href="#orga60662e">method dao-keys (dao)</a></li>
+<li><a href="#org6d8b270">method dao-exists-p (dao)</a></li>
+<li><a href="#org2a05082">method make-dao (type &amp;rest args &amp;key &amp;allow-other-keys)</a></li>
+<li><a href="#orgc1573bd">macro define-dao-finalization (((dao-name class) &amp;rest keyword-args) &amp;body body)</a></li>
+<li><a href="#orgdbc27b5">method get-dao (type &amp;rest keys)</a></li>
+<li><a href="#org97c09c2">macro select-dao (type &amp;optional (test t) &amp;rest sort)</a></li>
+<li><a href="#org4b1d641">macro do-select-dao (((type type-var) &amp;optional (test t) &amp;rest sort) &amp;body body)</a></li>
+<li><a href="#org1c187f4">macro query-dao (type query &amp;rest args)</a></li>
+<li><a href="#orgfbff399">function do-query-dao (((type type-var) query &amp;rest args) &amp;body body)</a></li>
+<li><a href="#orgc109f47">variable <b>ignore-unknown-columns</b></a></li>
+<li><a href="#orgca2d6be">method insert-dao (dao)</a></li>
+<li><a href="#org5622a60">method update-dao (dao)</a></li>
+<li><a href="#org8598d13">function save-dao (dao)</a></li>
+<li><a href="#org182b7bd">function save-dao/transaction (dao)</a></li>
+<li><a href="#org715b41c">method upsert-dao (dao)</a></li>
+<li><a href="#org3580abf">method delete-dao (dao)</a></li>
+<li><a href="#org82ec0d0">function dao-table-name (class)</a></li>
+<li><a href="#org542a0c7">function dao-table-definition (class)</a></li>
+<li><a href="#orgca4318c">macro with-column-writers ((&amp;rest writers) &amp;body body)</a></li>
 </ul>
 </li>
-<li><a href="#org2a813a6">Table definition and creation</a>
+<li><a href="#orge70903a">Table definition and creation</a>
 <ul>
-<li><a href="#org452ce06">macro deftable (name &amp;body definition)</a></li>
-<li><a href="#orga55f8be">function !dao-def ()</a></li>
-<li><a href="#org2724621">function !index (&amp;rest columns), !unique-index (&amp;rest columns)</a></li>
-<li><a href="#orga0e6dc9">function !foreign (target-table columns &amp;optional target-columns &amp;key on-delete on-update deferrable initially-deferred)</a></li>
-<li><a href="#org7627ea2">function !unique (target-fields &amp;key deferrable initially-deferred)</a></li>
-<li><a href="#orgd0ca2cf">function create-table (symbol)</a></li>
-<li><a href="#org4377119">function create-all-tables ()</a></li>
-<li><a href="#org73b1908">function create-package-tables (package)</a></li>
-<li><a href="#org66749a0">variables <b>table-name</b>, <b>table-symbol</b></a></li>
+<li><a href="#org91df798">macro deftable (name &amp;body definition)</a></li>
+<li><a href="#orgc655161">function !dao-def ()</a></li>
+<li><a href="#orga089933">function !index (&amp;rest columns), !unique-index (&amp;rest columns)</a></li>
+<li><a href="#org03b9448">function !foreign (target-table columns &amp;optional target-columns &amp;key on-delete on-update deferrable initially-deferred)</a></li>
+<li><a href="#orge108df7">function !unique (target-fields &amp;key deferrable initially-deferred)</a></li>
+<li><a href="#orgbe93e6b">function create-table (symbol)</a></li>
+<li><a href="#orgc83e48f">function create-all-tables ()</a></li>
+<li><a href="#orga5de683">function create-package-tables (package)</a></li>
+<li><a href="#orgbcc618b">variables <b>table-name</b>, <b>table-symbol</b></a></li>
 </ul>
 </li>
-<li><a href="#org5822c12">Schemata</a>
+<li><a href="#org27580dd">Schemata</a>
 <ul>
-<li><a href="#org34e7e49">function create-schema (schema)</a></li>
-<li><a href="#orgd2d302c">function drop-schema (schema)</a></li>
-<li><a href="#org3b45923">function get-search-path ()</a></li>
-<li><a href="#org8d4c2e7">function set-search-path (path)</a></li>
+<li><a href="#orgba1b136">function create-schema (schema)</a></li>
+<li><a href="#orgf457354">function drop-schema (schema)</a></li>
+<li><a href="#orge9c7c9d">function get-search-path ()</a></li>
+<li><a href="#org947c5d3">function set-search-path (path)</a></li>
 </ul>
 </li>
 </ul>
@@ -390,22 +391,22 @@ restart to re-try the operation that encountered to the error.
 </p>
 
 
-<div id="outline-container-org41ad3a7" class="outline-2">
-<h2 id="org41ad3a7">Connecting</h2>
-<div class="outline-text-2" id="text-org41ad3a7">
+<div id="outline-container-org12bf2ab" class="outline-2">
+<h2 id="org12bf2ab">Connecting</h2>
+<div class="outline-text-2" id="text-org12bf2ab">
 </div>
-<div id="outline-container-org16047f6" class="outline-3">
-<h3 id="org16047f6">class database-connection</h3>
-<div class="outline-text-3" id="text-org16047f6">
+<div id="outline-container-org00e8166" class="outline-3">
+<h3 id="org00e8166">class database-connection</h3>
+<div class="outline-text-3" id="text-org00e8166">
 <p>
 Objects of this type represent database connections.
 </p>
 </div>
 </div>
 
-<div id="outline-container-org1324a15" class="outline-3">
-<h3 id="org1324a15">function connect (database user password host &amp;key (port 5432) pooled-p use-ssl)</h3>
-<div class="outline-text-3" id="text-org1324a15">
+<div id="outline-container-orgc064b1e" class="outline-3">
+<h3 id="orgc064b1e">function connect (database user password host &amp;key (port 5432) pooled-p use-ssl)</h3>
+<div class="outline-text-3" id="text-orgc064b1e">
 <p>
 → database-connection
 </p>
@@ -422,9 +423,9 @@ of <b>default-use-ssl</b>.
 </div>
 </div>
 
-<div id="outline-container-org9cbc355" class="outline-3">
-<h3 id="org9cbc355">variable <b>default-use-ssl</b></h3>
-<div class="outline-text-3" id="text-org9cbc355">
+<div id="outline-container-org68186df" class="outline-3">
+<h3 id="org68186df">variable <b>default-use-ssl</b></h3>
+<div class="outline-text-3" id="text-org68186df">
 <p>
 The default for connect's use-ssl argument. This starts at :no. If you
 set it to anything else, be sure to also load the CL+SSL library.
@@ -432,9 +433,9 @@ set it to anything else, be sure to also load the CL+SSL library.
 </div>
 </div>
 
-<div id="outline-container-orge7e09aa" class="outline-3">
-<h3 id="orge7e09aa">method disconnect (database-connection)</h3>
-<div class="outline-text-3" id="text-orge7e09aa">
+<div id="outline-container-orgd9a937c" class="outline-3">
+<h3 id="orgd9a937c">method disconnect (database-connection)</h3>
+<div class="outline-text-3" id="text-orgd9a937c">
 <p>
 Disconnects a normal database connection, or moves a pooled connection
 into the pool.
@@ -442,9 +443,9 @@ into the pool.
 </div>
 </div>
 
-<div id="outline-container-org7022b61" class="outline-3">
-<h3 id="org7022b61">function connected-p (database-connection)</h3>
-<div class="outline-text-3" id="text-org7022b61">
+<div id="outline-container-orgde9e513" class="outline-3">
+<h3 id="orgde9e513">function connected-p (database-connection)</h3>
+<div class="outline-text-3" id="text-orgde9e513">
 <p>
 → boolean
 </p>
@@ -456,9 +457,9 @@ to the server.
 </div>
 </div>
 
-<div id="outline-container-orgb357674" class="outline-3">
-<h3 id="orgb357674">method reconnect (database-connection)</h3>
-<div class="outline-text-3" id="text-orgb357674">
+<div id="outline-container-org1eacefb" class="outline-3">
+<h3 id="org1eacefb">method reconnect (database-connection)</h3>
+<div class="outline-text-3" id="text-org1eacefb">
 <p>
 Reconnect a disconnected database connection. This is not allowed for pooled
 connections ― after they are disconnected they might be in use by some other
@@ -467,9 +468,9 @@ process, and should no longer be used.
 </div>
 </div>
 
-<div id="outline-container-org1c3cf0b" class="outline-3">
-<h3 id="org1c3cf0b">variable <b>database</b></h3>
-<div class="outline-text-3" id="text-org1c3cf0b">
+<div id="outline-container-org36b95c0" class="outline-3">
+<h3 id="org36b95c0">variable <b>database</b></h3>
+<div class="outline-text-3" id="text-org36b95c0">
 <p>
 Special variable holding the current database. Most functions and macros
 operating on a database assume this binds to a connected database.
@@ -477,9 +478,9 @@ operating on a database assume this binds to a connected database.
 </div>
 </div>
 
-<div id="outline-container-org19a858b" class="outline-3">
-<h3 id="org19a858b">macro with-connection (spec &amp;body body)</h3>
-<div class="outline-text-3" id="text-org19a858b">
+<div id="outline-container-org9128424" class="outline-3">
+<h3 id="org9128424">macro with-connection (spec &amp;body body)</h3>
+<div class="outline-text-3" id="text-org9128424">
 <p>
 Evaluates the body with <b>database</b> bound to a connection as specified by
 spec, which should be list that connect can be applied to.
@@ -487,9 +488,9 @@ spec, which should be list that connect can be applied to.
 </div>
 </div>
 
-<div id="outline-container-orgf603140" class="outline-3">
-<h3 id="orgf603140">macro call-with-connection (spec thunk)</h3>
-<div class="outline-text-3" id="text-orgf603140">
+<div id="outline-container-org924da0f" class="outline-3">
+<h3 id="org924da0f">macro call-with-connection (spec thunk)</h3>
+<div class="outline-text-3" id="text-org924da0f">
 <p>
 The functional backend to with-connection. Binds <b>database</b> to a new
 connection as specified by spec, which should be a list that connect can
@@ -500,9 +501,9 @@ connection is disconnected.
 </div>
 </div>
 
-<div id="outline-container-orgaf93a1e" class="outline-3">
-<h3 id="orgaf93a1e">function connect-toplevel (database user password host &amp;key (port 5432))</h3>
-<div class="outline-text-3" id="text-orgaf93a1e">
+<div id="outline-container-orga51009d" class="outline-3">
+<h3 id="orga51009d">function connect-toplevel (database user password host &amp;key (port 5432))</h3>
+<div class="outline-text-3" id="text-orga51009d">
 <p>
 Bind the <b>database</b> to a new connection. Use this if you only need one
 connection, or if you want a connection for debugging from the REPL.
@@ -510,27 +511,27 @@ connection, or if you want a connection for debugging from the REPL.
 </div>
 </div>
 
-<div id="outline-container-org2c329fe" class="outline-3">
-<h3 id="org2c329fe">function disconnect-toplevel ()</h3>
-<div class="outline-text-3" id="text-org2c329fe">
+<div id="outline-container-org27d9f96" class="outline-3">
+<h3 id="org27d9f96">function disconnect-toplevel ()</h3>
+<div class="outline-text-3" id="text-org27d9f96">
 <p>
 Disconnect the <b>database</b>.
 </p>
 </div>
 </div>
 
-<div id="outline-container-org111e702" class="outline-3">
-<h3 id="org111e702">function clear-connection-pool ()</h3>
-<div class="outline-text-3" id="text-org111e702">
+<div id="outline-container-org8844a45" class="outline-3">
+<h3 id="org8844a45">function clear-connection-pool ()</h3>
+<div class="outline-text-3" id="text-org8844a45">
 <p>
 Disconnect and remove all connections from the connection pools.
 </p>
 </div>
 </div>
 
-<div id="outline-container-org7cfedf0" class="outline-3">
-<h3 id="org7cfedf0">variable <b>max-pool-size</b></h3>
-<div class="outline-text-3" id="text-org7cfedf0">
+<div id="outline-container-org8110919" class="outline-3">
+<h3 id="org8110919">variable <b>max-pool-size</b></h3>
+<div class="outline-text-3" id="text-org8110919">
 <p>
 Set the maximum amount of connections kept in a single connection pool, where
 a pool consists of all the stored connections with the exact same connect
@@ -540,13 +541,13 @@ arguments. Defaults to NIL, which means there is no maximum.
 </div>
 </div>
 
-<div id="outline-container-org1aee8ff" class="outline-2">
-<h2 id="org1aee8ff">Querying</h2>
-<div class="outline-text-2" id="text-org1aee8ff">
+<div id="outline-container-org6f305ee" class="outline-2">
+<h2 id="org6f305ee">Querying</h2>
+<div class="outline-text-2" id="text-org6f305ee">
 </div>
-<div id="outline-container-orgaa868cd" class="outline-3">
-<h3 id="orgaa868cd">macro query (query &amp;rest args/format)</h3>
-<div class="outline-text-3" id="text-orgaa868cd">
+<div id="outline-container-org4cc93e0" class="outline-3">
+<h3 id="org4cc93e0">macro query (query &amp;rest args/format)</h3>
+<div class="outline-text-3" id="text-org4cc93e0">
 <p>
 → result
 </p>
@@ -648,9 +649,9 @@ such as with updating or deleting queries, this is returned as a second value.
 </div>
 </div>
 
-<div id="outline-container-orgf3ecdd9" class="outline-3">
-<h3 id="orgf3ecdd9">macro execute (query &amp;rest args)</h3>
-<div class="outline-text-3" id="text-orgf3ecdd9">
+<div id="outline-container-org17818eb" class="outline-3">
+<h3 id="org17818eb">macro execute (query &amp;rest args)</h3>
+<div class="outline-text-3" id="text-org17818eb">
 <p>
 Like query called with format :none. Returns the amount of affected rows as
 its first returned value. (Also returns this amount as the second returned
@@ -659,9 +660,9 @@ value, but use of this is deprecated.)
 </div>
 </div>
 
-<div id="outline-container-org79e4e1e" class="outline-3">
-<h3 id="org79e4e1e">macro doquery (query (&amp;rest names) &amp;body body)</h3>
-<div class="outline-text-3" id="text-org79e4e1e">
+<div id="outline-container-orgb44cfc9" class="outline-3">
+<h3 id="orgb44cfc9">macro doquery (query (&amp;rest names) &amp;body body)</h3>
+<div class="outline-text-3" id="text-orgb44cfc9">
 <p>
 Execute the given query (a string or a list starting with a keyword),
 iterating over the rows in the result. The body will be executed with the
@@ -680,9 +681,9 @@ whose cdr contains the arguments. For example:
 </div>
 </div>
 
-<div id="outline-container-org63d983c" class="outline-3">
-<h3 id="org63d983c">macro prepare (query &amp;optional (format :rows))</h3>
-<div class="outline-text-3" id="text-org63d983c">
+<div id="outline-container-org1300f89" class="outline-3">
+<h3 id="org1300f89">macro prepare (query &amp;optional (format :rows))</h3>
+<div class="outline-text-3" id="text-org1300f89">
 <p>
 → function
 </p>
@@ -710,9 +711,9 @@ historical :: syntax, or with S-SQL's :type construct) to help it out.
 </div>
 </div>
 
-<div id="outline-container-org1c4872b" class="outline-3">
-<h3 id="org1c4872b">macro defprepared (name query &amp;optional (format :rows))</h3>
-<div class="outline-text-3" id="text-org1c4872b">
+<div id="outline-container-org9c4a4e0" class="outline-3">
+<h3 id="org9c4a4e0">macro defprepared (name query &amp;optional (format :rows))</h3>
+<div class="outline-text-3" id="text-org9c4a4e0">
 <p>
 This is the defun-style variant of prepare. It will define a top-level
 function for the prepared statement.
@@ -720,9 +721,9 @@ function for the prepared statement.
 </div>
 </div>
 
-<div id="outline-container-org95d9032" class="outline-3">
-<h3 id="org95d9032">macro defprepared-with-names (name (&amp;rest args) (query &amp;rest query-args) &amp;optional (format :rows))</h3>
-<div class="outline-text-3" id="text-org95d9032">
+<div id="outline-container-orgd4e448c" class="outline-3">
+<h3 id="orgd4e448c">macro defprepared-with-names (name (&amp;rest args) (query &amp;rest query-args) &amp;optional (format :rows))</h3>
+<div class="outline-text-3" id="text-orgd4e448c">
 <p>
 Like defprepared, but allows to specify names of the function arguments as
 well as arguments supplied to the query.
@@ -739,39 +740,82 @@ well as arguments supplied to the query.
 </div>
 </div>
 
-<div id="outline-container-orgbfb927e" class="outline-3">
-<h3 id="orgbfb927e">macro with-transaction ((&amp;optional name) &amp;body body)</h3>
-<div class="outline-text-3" id="text-orgbfb927e">
+<div id="outline-container-orgeb29edd" class="outline-3">
+<h3 id="orgeb29edd">macro with-transaction ((&amp;optional name isolation-level) &amp;body body)</h3>
+<div class="outline-text-3" id="text-orgeb29edd">
 <p>
 Execute the given body within a database transaction, committing it when the
-body exits normally, and aborting otherwise. An optional name can be given
-to the transaction, which can be used to force a commit or abort before the
-body unwinds.
+body exits normally, and aborting otherwise. An optional name and/or
+isolation-level can be given to the transaction. The name can be used to
+force a commit or abort before the body unwinds. The isolation-level
+will set the isolation-level used by the transaction.
+</p>
+
+<p>
+You can specify the following isolation levels in postmodern transactions:
+</p>
+
+<ul class="org-ul">
+<li>:read-committed-rw (read committed with read and write)</li>
+<li>:read-committed-ro (read committed with read only)</li>
+<li>:repeatable-read-rw (repeatable read with read and write)</li>
+<li>:repeatable-read-ro (repeatable read with read only)</li>
+<li>:serializable (serializable with reand and write)</li>
+</ul>
+
+<p>
+Sample usage where "george" is just the name given to the transaction (not
+quoted or a string) and &#x2026; simply indicates other statements would be
+expected here:
+</p>
+<div class="org-src-container">
+<pre class="src src-lisp">(with-transaction ()
+  (execute (:insert-into 'test-data :set 'value 77))
+  ...)
+
+(with-transaction (george)
+  (execute (:insert-into 'test-data :set 'value 22))
+  ...)
+
+(with-transaction (george :read-committed-rw)
+  (execute (:insert-into 'test-data :set 'value 33))
+  (query (:select '* :from 'test-data))
+  ...)
+
+(with-transaction (:serializable)
+  (execute (:insert-into 'test-data :set 'value 44))
+  ...)
+</pre>
+</div>
+
+<p>
+Further discussion of transactions and isolation levels can found
+<a href="isolation-notes.html">here</a>.
 </p>
 </div>
 </div>
 
-<div id="outline-container-orgf71c73d" class="outline-3">
-<h3 id="orgf71c73d">function commit-transaction (transaction)</h3>
-<div class="outline-text-3" id="text-orgf71c73d">
+<div id="outline-container-org0b309fc" class="outline-3">
+<h3 id="org0b309fc">function commit-transaction (transaction)</h3>
+<div class="outline-text-3" id="text-org0b309fc">
 <p>
 Commit the given transaction.
 </p>
 </div>
 </div>
 
-<div id="outline-container-orgf847006" class="outline-3">
-<h3 id="orgf847006">function abort-transaction (transaction)</h3>
-<div class="outline-text-3" id="text-orgf847006">
+<div id="outline-container-org5805244" class="outline-3">
+<h3 id="org5805244">function abort-transaction (transaction)</h3>
+<div class="outline-text-3" id="text-org5805244">
 <p>
 Roll back the given transaction.
 </p>
 </div>
 </div>
 
-<div id="outline-container-org2e4f103" class="outline-3">
-<h3 id="org2e4f103">macro with-savepoint (name &amp;body body)</h3>
-<div class="outline-text-3" id="text-org2e4f103">
+<div id="outline-container-orga8e4c4b" class="outline-3">
+<h3 id="orga8e4c4b">macro with-savepoint (name &amp;body body)</h3>
+<div class="outline-text-3" id="text-orga8e4c4b">
 <p>
 Can only be used within a transaction. Establishes a savepoint with the given
 name at the start of body, and binds the same name to a handle for that
@@ -781,27 +825,27 @@ condition is thrown, in which case it is rolled back.
 </div>
 </div>
 
-<div id="outline-container-org1e01691" class="outline-3">
-<h3 id="org1e01691">function release-savepoint (savepoint)</h3>
-<div class="outline-text-3" id="text-org1e01691">
+<div id="outline-container-orgd9a0074" class="outline-3">
+<h3 id="orgd9a0074">function release-savepoint (savepoint)</h3>
+<div class="outline-text-3" id="text-orgd9a0074">
 <p>
 Release the given savepoint.
 </p>
 </div>
 </div>
 
-<div id="outline-container-org763b22f" class="outline-3">
-<h3 id="org763b22f">function rollback-savepoint (savepoint)</h3>
-<div class="outline-text-3" id="text-org763b22f">
+<div id="outline-container-org75b1276" class="outline-3">
+<h3 id="org75b1276">function rollback-savepoint (savepoint)</h3>
+<div class="outline-text-3" id="text-org75b1276">
 <p>
 Roll back the given savepoint.
 </p>
 </div>
 </div>
 
-<div id="outline-container-org98941b1" class="outline-3">
-<h3 id="org98941b1">function commit-hooks (transaction-or-savepoint), setf (commit-hooks transaction-or-savepoint)</h3>
-<div class="outline-text-3" id="text-org98941b1">
+<div id="outline-container-orgc16cdba" class="outline-3">
+<h3 id="orgc16cdba">function commit-hooks (transaction-or-savepoint), setf (commit-hooks transaction-or-savepoint)</h3>
+<div class="outline-text-3" id="text-orgc16cdba">
 <p>
 An accessor for the transaction or savepoint's list of commit hooks, each of
 which should be a function with no required arguments. These functions will
@@ -810,9 +854,9 @@ be executed when a transaction is committed or a savepoint released.
 </div>
 </div>
 
-<div id="outline-container-orga1023a0" class="outline-3">
-<h3 id="orga1023a0">function abort-hooks (transaction-or-savepoint), setf (abort-hooks transaction-or-savepoint)</h3>
-<div class="outline-text-3" id="text-orga1023a0">
+<div id="outline-container-org630966a" class="outline-3">
+<h3 id="org630966a">function abort-hooks (transaction-or-savepoint), setf (abort-hooks transaction-or-savepoint)</h3>
+<div class="outline-text-3" id="text-org630966a">
 <p>
 An accessor for the transaction or savepoint's list of abort hooks, each of
 which should be a function with no required arguments. These functions will
@@ -823,21 +867,58 @@ abort-transaction or rollback-savepoint).
 </div>
 </div>
 
-<div id="outline-container-org2823946" class="outline-3">
-<h3 id="org2823946">macro with-logical-transaction ((&amp;optional name) &amp;body body)</h3>
-<div class="outline-text-3" id="text-org2823946">
+<div id="outline-container-org59e1b11" class="outline-3">
+<h3 id="org59e1b11">macro with-logical-transaction ((&amp;optional name isolation-level) &amp;body body)</h3>
+<div class="outline-text-3" id="text-org59e1b11">
 <p>
 Executes body within a with-transaction form if no transaction is currently
 in progress, otherwise simulates a nested transaction by executing it
 within a with-savepoint form. The transaction or savepoint is bound to name
-if one is supplied.
+if one is supplied. The isolation-level will set the isolation-level used by the transaction.
 </p>
+
+<p>
+You can specify the following isolation levels in postmodern transactions:
+</p>
+
+<ul class="org-ul">
+<li>:read-committed-rw (read committed with read and write)</li>
+<li>:read-committed-ro (read committed with read only)</li>
+<li>:repeatable-read-rw (repeatable read with read and write)</li>
+<li>:repeatable-read-ro (repeatable read with read only)</li>
+<li>:serializable (serializable with reand and write)</li>
+</ul>
+
+<p>
+Sample usage where "george" is just the name given to the transaction (not
+quoted or a string) and &#x2026; simply indicates other statements would be
+expected here:
+</p>
+
+<div class="org-src-container">
+<pre class="src src-lisp">(with-logical-transaction ()
+  (execute (:insert-into 'test-data :set 'value 77))
+  ...)
+
+(with-logical-transaction (george)
+  (execute (:insert-into 'test-data :set 'value 22))
+  ...)
+
+(with-logical-transaction (george :read-committed-rw)
+  (execute (:insert-into 'test-data :set 'value 33))
+  ...)
+
+(with-logical-transaction (:serializable)
+  (execute (:insert-into 'test-data :set 'value 44))
+  ...)
+</pre>
+</div>
 </div>
 </div>
 
-<div id="outline-container-org7f65c91" class="outline-3">
-<h3 id="org7f65c91">function abort-logical-transaction (transaction-or-savepoint)</h3>
-<div class="outline-text-3" id="text-org7f65c91">
+<div id="outline-container-org199841e" class="outline-3">
+<h3 id="org199841e">function abort-logical-transaction (transaction-or-savepoint)</h3>
+<div class="outline-text-3" id="text-org199841e">
 <p>
 Roll back the given logical transaction, regardless of whether it is an
 actual transaction or a savepoint.
@@ -845,9 +926,9 @@ actual transaction or a savepoint.
 </div>
 </div>
 
-<div id="outline-container-orgdaeb32a" class="outline-3">
-<h3 id="orgdaeb32a">function commit-logical-transaction (transaction-or-savepoint)</h3>
-<div class="outline-text-3" id="text-orgdaeb32a">
+<div id="outline-container-org8176940" class="outline-3">
+<h3 id="org8176940">function commit-logical-transaction (transaction-or-savepoint)</h3>
+<div class="outline-text-3" id="text-org8176940">
 <p>
 Commit the given logical transaction, regardless of whether it is an
 actual transaction or a savepoint.
@@ -855,9 +936,9 @@ actual transaction or a savepoint.
 </div>
 </div>
 
-<div id="outline-container-orgb767910" class="outline-3">
-<h3 id="orgb767910">variable <b>current-logical-transaction</b></h3>
-<div class="outline-text-3" id="text-orgb767910">
+<div id="outline-container-orgd106c94" class="outline-3">
+<h3 id="orgd106c94">variable <b>current-logical-transaction</b></h3>
+<div class="outline-text-3" id="text-orgd106c94">
 <p>
 This is bound to the current transaction-handle or savepoint-handle instance
 representing the innermost open logical transaction.
@@ -865,9 +946,9 @@ representing the innermost open logical transaction.
 </div>
 </div>
 
-<div id="outline-container-org8c1a03c" class="outline-3">
-<h3 id="org8c1a03c">macro ensure-transaction (&amp;body body)</h3>
-<div class="outline-text-3" id="text-org8c1a03c">
+<div id="outline-container-org7092455" class="outline-3">
+<h3 id="org7092455">macro ensure-transaction (&amp;body body)</h3>
+<div class="outline-text-3" id="text-org7092455">
 <p>
 Ensures that body is executed within a transaction, but does not begin a
 new transaction if one is already in progress.
@@ -875,9 +956,9 @@ new transaction if one is already in progress.
 </div>
 </div>
 
-<div id="outline-container-orge407acf" class="outline-3">
-<h3 id="orge407acf">macro with-schema ((namespace &amp;key :strict t :if-not-exist :create :drop-after) &amp;body body)</h3>
-<div class="outline-text-3" id="text-orge407acf">
+<div id="outline-container-org577c796" class="outline-3">
+<h3 id="org577c796">macro with-schema ((namespace &amp;key :strict t :if-not-exist :create :drop-after) &amp;body body)</h3>
+<div class="outline-text-3" id="text-org577c796">
 <p>
 Sets the current schema to namespace and executes the body. Before executing
 body the PostgreSQL's session variable search_path is set to the given
@@ -891,9 +972,9 @@ namespace is dropped from the database after the body execution.
 </div>
 </div>
 
-<div id="outline-container-orgc76d2c0" class="outline-3">
-<h3 id="orgc76d2c0">function sequence-next (sequence)</h3>
-<div class="outline-text-3" id="text-orgc76d2c0">
+<div id="outline-container-orgc89e778" class="outline-3">
+<h3 id="orgc89e778">function sequence-next (sequence)</h3>
+<div class="outline-text-3" id="text-orgc89e778">
 <p>
 → integer
 </p>
@@ -906,9 +987,9 @@ according to S-SQL rules.
 </div>
 </div>
 
-<div id="outline-container-org34a8888" class="outline-3">
-<h3 id="org34a8888">function coalesce (&amp;rest arguments)</h3>
-<div class="outline-text-3" id="text-org34a8888">
+<div id="outline-container-orga3d089c" class="outline-3">
+<h3 id="orga3d089c">function coalesce (&amp;rest arguments)</h3>
+<div class="outline-text-3" id="text-orga3d089c">
 <p>
 → value
 </p>
@@ -922,13 +1003,13 @@ when given only one argument, for transforming :nulls to NIL.
 </div>
 </div>
 
-<div id="outline-container-org868514f" class="outline-2">
-<h2 id="org868514f">Inspecting the database</h2>
-<div class="outline-text-2" id="text-org868514f">
+<div id="outline-container-orgf8bb9fa" class="outline-2">
+<h2 id="orgf8bb9fa">Inspecting the database</h2>
+<div class="outline-text-2" id="text-orgf8bb9fa">
 </div>
-<div id="outline-container-orgbbc34ae" class="outline-3">
-<h3 id="orgbbc34ae">function list-tables (&amp;optional strings-p)</h3>
-<div class="outline-text-3" id="text-orgbbc34ae">
+<div id="outline-container-org243efd1" class="outline-3">
+<h3 id="org243efd1">function list-tables (&amp;optional strings-p)</h3>
+<div class="outline-text-3" id="text-org243efd1">
 <p>
 → list
 </p>
@@ -940,9 +1021,9 @@ the names will be given as strings, otherwise as keywords.
 </div>
 </div>
 
-<div id="outline-container-org691be0f" class="outline-3">
-<h3 id="org691be0f">function table-exists-p (name)</h3>
-<div class="outline-text-3" id="text-org691be0f">
+<div id="outline-container-org1c59df2" class="outline-3">
+<h3 id="org1c59df2">function table-exists-p (name)</h3>
+<div class="outline-text-3" id="text-org1c59df2">
 <p>
 → boolean
 </p>
@@ -954,9 +1035,9 @@ string or a symbol.
 </div>
 </div>
 
-<div id="outline-container-org1f2a898" class="outline-3">
-<h3 id="org1f2a898">function table-description (name &amp;optional schema-name)</h3>
-<div class="outline-text-3" id="text-org1f2a898">
+<div id="outline-container-org21239d7" class="outline-3">
+<h3 id="org21239d7">function table-description (name &amp;optional schema-name)</h3>
+<div class="outline-text-3" id="text-org21239d7">
 <p>
 → list
 </p>
@@ -971,9 +1052,9 @@ the table are returned, regardless of their schema.
 </div>
 </div>
 
-<div id="outline-container-org77bf5e8" class="outline-3">
-<h3 id="org77bf5e8">function list-sequences (&amp;optional strings-p)</h3>
-<div class="outline-text-3" id="text-org77bf5e8">
+<div id="outline-container-orgb093db7" class="outline-3">
+<h3 id="orgb093db7">function list-sequences (&amp;optional strings-p)</h3>
+<div class="outline-text-3" id="text-orgb093db7">
 <p>
 → list
 </p>
@@ -985,9 +1066,9 @@ the names will be given as strings, otherwise as keywords.
 </div>
 </div>
 
-<div id="outline-container-org673c5cb" class="outline-3">
-<h3 id="org673c5cb">function sequence-exists-p (name)</h3>
-<div class="outline-text-3" id="text-org673c5cb">
+<div id="outline-container-org44d0c87" class="outline-3">
+<h3 id="org44d0c87">function sequence-exists-p (name)</h3>
+<div class="outline-text-3" id="text-org44d0c87">
 <p>
 → boolean
 </p>
@@ -999,9 +1080,9 @@ string or a symbol.
 </div>
 </div>
 
-<div id="outline-container-orgb23b47f" class="outline-3">
-<h3 id="orgb23b47f">function list-views (&amp;optional strings-p)</h3>
-<div class="outline-text-3" id="text-orgb23b47f">
+<div id="outline-container-orgc01d47e" class="outline-3">
+<h3 id="orgc01d47e">function list-views (&amp;optional strings-p)</h3>
+<div class="outline-text-3" id="text-orgc01d47e">
 <p>
 → list
 </p>
@@ -1013,9 +1094,9 @@ is T, the names will be returned as strings, otherwise as keywords.
 </div>
 </div>
 
-<div id="outline-container-org29e9f9b" class="outline-3">
-<h3 id="org29e9f9b">function view-exists-p (name)</h3>
-<div class="outline-text-3" id="text-org29e9f9b">
+<div id="outline-container-org9018f6c" class="outline-3">
+<h3 id="org9018f6c">function view-exists-p (name)</h3>
+<div class="outline-text-3" id="text-org9018f6c">
 <p>
 → boolean
 </p>
@@ -1027,9 +1108,9 @@ string or a symbol.
 </div>
 </div>
 
-<div id="outline-container-org604f57f" class="outline-3">
-<h3 id="org604f57f">function list-schemata ()</h3>
-<div class="outline-text-3" id="text-org604f57f">
+<div id="outline-container-org78fe14c" class="outline-3">
+<h3 id="org78fe14c">function list-schemata ()</h3>
+<div class="outline-text-3" id="text-org78fe14c">
 <p>
 → list
 </p>
@@ -1041,9 +1122,9 @@ existing schemata.
 </div>
 </div>
 
-<div id="outline-container-org5cb5498" class="outline-3">
-<h3 id="org5cb5498">function schema-exist-p (schema) NOW DEPRECATED IN FAVOR OF schema-exists-p which is more consistent with naming of other functions.</h3>
-<div class="outline-text-3" id="text-org5cb5498">
+<div id="outline-container-org9f0317b" class="outline-3">
+<h3 id="org9f0317b">function schema-exist-p (schema) NOW DEPRECATED IN FAVOR OF schema-exists-p which is more consistent with naming of other functions.</h3>
+<div class="outline-text-3" id="text-org9f0317b">
 <p>
 → boolean
 </p>
@@ -1055,9 +1136,9 @@ otherwise.
 </div>
 </div>
 
-<div id="outline-container-orgd42abc6" class="outline-3">
-<h3 id="orgd42abc6">function schema-exists-p (schema)</h3>
-<div class="outline-text-3" id="text-orgd42abc6">
+<div id="outline-container-orgbca9e67" class="outline-3">
+<h3 id="orgbca9e67">function schema-exists-p (schema)</h3>
+<div class="outline-text-3" id="text-orgbca9e67">
 <p>
 → boolean
 </p>
@@ -1069,9 +1150,9 @@ otherwise.
 </div>
 </div>
 
-<div id="outline-container-orgdb30f09" class="outline-3">
-<h3 id="orgdb30f09">function database-version ()</h3>
-<div class="outline-text-3" id="text-orgdb30f09">
+<div id="outline-container-orgae44c0f" class="outline-3">
+<h3 id="orgae44c0f">function database-version ()</h3>
+<div class="outline-text-3" id="text-orgae44c0f">
 <p>
 → string
 </p>
@@ -1082,9 +1163,9 @@ Returns the version of the current postgresql database.
 </div>
 </div>
 
-<div id="outline-container-orgb83fa4f" class="outline-3">
-<h3 id="orgb83fa4f">function num-records-in-database ()</h3>
-<div class="outline-text-3" id="text-orgb83fa4f">
+<div id="outline-container-org4e0cfdb" class="outline-3">
+<h3 id="org4e0cfdb">function num-records-in-database ()</h3>
+<div class="outline-text-3" id="text-org4e0cfdb">
 <p>
 → list
 </p>
@@ -1096,9 +1177,9 @@ records in the currently connected database.
 </div>
 </div>
 
-<div id="outline-container-orgd08e9c4" class="outline-3">
-<h3 id="orgd08e9c4">function current-database ()</h3>
-<div class="outline-text-3" id="text-orgd08e9c4">
+<div id="outline-container-orgd0f05b7" class="outline-3">
+<h3 id="orgd0f05b7">function current-database ()</h3>
+<div class="outline-text-3" id="text-orgd0f05b7">
 <p>
 → string
 </p>
@@ -1109,9 +1190,9 @@ Returns the string name of the current database.
 </div>
 </div>
 
-<div id="outline-container-orgb0e14c5" class="outline-3">
-<h3 id="orgb0e14c5">function database-exists-p (database-name)</h3>
-<div class="outline-text-3" id="text-orgb0e14c5">
+<div id="outline-container-org4bb05ac" class="outline-3">
+<h3 id="org4bb05ac">function database-exists-p (database-name)</h3>
+<div class="outline-text-3" id="text-org4bb05ac">
 <p>
 → boolean
 </p>
@@ -1122,9 +1203,9 @@ Checks to see if a particular database exists.
 </div>
 </div>
 
-<div id="outline-container-orga714e8d" class="outline-3">
-<h3 id="orga714e8d">function database-size (&amp;optional database-name)</h3>
-<div class="outline-text-3" id="text-orga714e8d">
+<div id="outline-container-org3e07ff6" class="outline-3">
+<h3 id="org3e07ff6">function database-size (&amp;optional database-name)</h3>
+<div class="outline-text-3" id="text-org3e07ff6">
 <p>
 → list
 </p>
@@ -1137,9 +1218,9 @@ provided, it will return the result for the currently connected database.
 </div>
 </div>
 
-<div id="outline-container-org3dc8479" class="outline-3">
-<h3 id="org3dc8479">function list-databases (&amp;key (order-by-size nil) (size t))</h3>
-<div class="outline-text-3" id="text-org3dc8479">
+<div id="outline-container-org2600479" class="outline-3">
+<h3 id="org2600479">function list-databases (&amp;key (order-by-size nil) (size t))</h3>
+<div class="outline-text-3" id="text-org2600479">
 <p>
 → list
 </p>
@@ -1154,9 +1235,9 @@ in a single list ordered by name. This function excludes the template databases
 </div>
 </div>
 
-<div id="outline-container-org76e3f6a" class="outline-3">
-<h3 id="org76e3f6a">function list-schemas ()</h3>
-<div class="outline-text-3" id="text-org76e3f6a">
+<div id="outline-container-orgc8d4f8c" class="outline-3">
+<h3 id="orgc8d4f8c">function list-schemas ()</h3>
+<div class="outline-text-3" id="text-orgc8d4f8c">
 <p>
 → list
 </p>
@@ -1167,9 +1248,9 @@ List schemas in the current database, excluding the pg_* system schemas.
 </div>
 </div>
 
-<div id="outline-container-orgf8ed3d2" class="outline-3">
-<h3 id="orgf8ed3d2">function list-tablespaces ()</h3>
-<div class="outline-text-3" id="text-orgf8ed3d2">
+<div id="outline-container-orged2ac89" class="outline-3">
+<h3 id="orged2ac89">function list-tablespaces ()</h3>
+<div class="outline-text-3" id="text-orged2ac89">
 <p>
 → list
 </p>
@@ -1180,9 +1261,9 @@ Lists the tablespaces in the currently connected database.
 </div>
 </div>
 
-<div id="outline-container-orga04ef47" class="outline-3">
-<h3 id="orga04ef47">function list-available-types ()</h3>
-<div class="outline-text-3" id="text-orga04ef47">
+<div id="outline-container-orgf8f1ff9" class="outline-3">
+<h3 id="orgf8f1ff9">function list-available-types ()</h3>
+<div class="outline-text-3" id="text-orgf8f1ff9">
 <p>
 → list
 </p>
@@ -1193,9 +1274,9 @@ List the available types in this postgresql version.
 </div>
 </div>
 
-<div id="outline-container-orgbfe5e00" class="outline-3">
-<h3 id="orgbfe5e00">function list-table-sizes (&amp;key (schema "public") (order-by-size nil) (size t))</h3>
-<div class="outline-text-3" id="text-orgbfe5e00">
+<div id="outline-container-org92647f7" class="outline-3">
+<h3 id="org92647f7">function list-table-sizes (&amp;key (schema "public") (order-by-size nil) (size t))</h3>
+<div class="outline-text-3" id="text-org92647f7">
 <p>
 → list
 </p>
@@ -1213,9 +1294,9 @@ result in order of size instead of by table name.
 </div>
 </div>
 
-<div id="outline-container-org0f079b0" class="outline-3">
-<h3 id="org0f079b0">function table-size (table-name)</h3>
-<div class="outline-text-3" id="text-org0f079b0">
+<div id="outline-container-org4d7e175" class="outline-3">
+<h3 id="org4d7e175">function table-size (table-name)</h3>
+<div class="outline-text-3" id="text-org4d7e175">
 <p>
 → list
 </p>
@@ -1227,9 +1308,9 @@ string or quoted.
 </div>
 </div>
 
-<div id="outline-container-orgc280c15" class="outline-3">
-<h3 id="orgc280c15">function more-table-info (table-name)</h3>
-<div class="outline-text-3" id="text-orgc280c15">
+<div id="outline-container-org1259140" class="outline-3">
+<h3 id="org1259140">function more-table-info (table-name)</h3>
+<div class="outline-text-3" id="text-org1259140">
 <p>
 → list
 </p>
@@ -1241,9 +1322,9 @@ or quoted.
 </div>
 </div>
 
-<div id="outline-container-org6250e37" class="outline-3">
-<h3 id="org6250e37">function list-columns (table-name)</h3>
-<div class="outline-text-3" id="text-org6250e37">
+<div id="outline-container-org5b8aa84" class="outline-3">
+<h3 id="org5b8aa84">function list-columns (table-name)</h3>
+<div class="outline-text-3" id="text-org5b8aa84">
 <p>
 → list
 </p>
@@ -1255,9 +1336,9 @@ from the postmodern table-description function rather than directly.
 </div>
 </div>
 
-<div id="outline-container-org15757d6" class="outline-3">
-<h3 id="org15757d6">function list-columns-with-types (table-name)</h3>
-<div class="outline-text-3" id="text-org15757d6">
+<div id="outline-container-org7ed6366" class="outline-3">
+<h3 id="org7ed6366">function list-columns-with-types (table-name)</h3>
+<div class="outline-text-3" id="text-org7ed6366">
 <p>
 → list
 </p>
@@ -1269,9 +1350,9 @@ to the pg-catalog tables.
 </div>
 </div>
 
-<div id="outline-container-orge927d6b" class="outline-3">
-<h3 id="orge927d6b">function column-exists-p (table-name column-name)</h3>
-<div class="outline-text-3" id="text-orge927d6b">
+<div id="outline-container-org4199ffb" class="outline-3">
+<h3 id="org4199ffb">function column-exists-p (table-name column-name)</h3>
+<div class="outline-text-3" id="text-org4199ffb">
 <p>
 → boolean
 </p>
@@ -1283,9 +1364,9 @@ either strings or symbols.
 </div>
 </div>
 
-<div id="outline-container-org92bd4ee" class="outline-3">
-<h3 id="org92bd4ee">function describe-views (&amp;optional (schema "public")</h3>
-<div class="outline-text-3" id="text-org92bd4ee">
+<div id="outline-container-org7b83386" class="outline-3">
+<h3 id="org7b83386">function describe-views (&amp;optional (schema "public")</h3>
+<div class="outline-text-3" id="text-org7b83386">
 <p>
 → list
 </p>
@@ -1296,9 +1377,9 @@ Describe the current views in the specified schema. Defaults to public schema.
 </div>
 </div>
 
-<div id="outline-container-org2f56533" class="outline-3">
-<h3 id="org2f56533">function list-database-functions ()</h3>
-<div class="outline-text-3" id="text-org2f56533">
+<div id="outline-container-org7bdefe3" class="outline-3">
+<h3 id="org7bdefe3">function list-database-functions ()</h3>
+<div class="outline-text-3" id="text-org7bdefe3">
 <p>
 → list
 </p>
@@ -1309,9 +1390,9 @@ Returns a list of the functions in the database from the information_schema.
 </div>
 </div>
 
-<div id="outline-container-org2b8c171" class="outline-3">
-<h3 id="org2b8c171">function list-indices (&amp;optional strings-p)</h3>
-<div class="outline-text-3" id="text-org2b8c171">
+<div id="outline-container-orgaecd074" class="outline-3">
+<h3 id="orgaecd074">function list-indices (&amp;optional strings-p)</h3>
+<div class="outline-text-3" id="text-orgaecd074">
 <p>
 → list
 </p>
@@ -1323,9 +1404,9 @@ strings-p is not true.
 </div>
 </div>
 
-<div id="outline-container-org43b5670" class="outline-3">
-<h3 id="org43b5670">function list-table-indices (table-name &amp;optional strings-p)</h3>
-<div class="outline-text-3" id="text-org43b5670">
+<div id="outline-container-org8b0bb3c" class="outline-3">
+<h3 id="org8b0bb3c">function list-table-indices (table-name &amp;optional strings-p)</h3>
+<div class="outline-text-3" id="text-org8b0bb3c">
 <p>
 → list
 </p>
@@ -1336,9 +1417,9 @@ List the index names and the related columns in a table.
 </div>
 </div>
 
-<div id="outline-container-orgf9a87c2" class="outline-3">
-<h3 id="orgf9a87c2">function list-indexed-column-and-attributes (table-name)</h3>
-<div class="outline-text-3" id="text-orgf9a87c2">
+<div id="outline-container-orgd50ec5d" class="outline-3">
+<h3 id="orgd50ec5d">function list-indexed-column-and-attributes (table-name)</h3>
+<div class="outline-text-3" id="text-orgd50ec5d">
 <p>
 → list
 </p>
@@ -1350,9 +1431,9 @@ key.
 </div>
 </div>
 
-<div id="outline-container-org04e53ef" class="outline-3">
-<h3 id="org04e53ef">function list-index-definitions (table-name)</h3>
-<div class="outline-text-3" id="text-org04e53ef">
+<div id="outline-container-org077d80b" class="outline-3">
+<h3 id="org077d80b">function list-index-definitions (table-name)</h3>
+<div class="outline-text-3" id="text-org077d80b">
 <p>
 → list
 </p>
@@ -1364,22 +1445,41 @@ the table
 </div>
 </div>
 
-<div id="outline-container-org913139b" class="outline-3">
-<h3 id="org913139b">function list-foreign-keys (table-name)</h3>
-<div class="outline-text-3" id="text-org913139b">
+<div id="outline-container-org2938392" class="outline-3">
+<h3 id="org2938392">function find-primary-key-info (table-name &amp;optional (just-key nil))</h3>
+<div class="outline-text-3" id="text-org2938392">
 <p>
 → list
 </p>
 
 <p>
-List the foreign keys in a table.
+Returns a list of two strings. First the column name of the primary
+key of the table and second the string name for the datatype. Optionally,
+just-key can be set to t and it will return just the column name of the
+primary key as a string.
 </p>
 </div>
 </div>
 
-<div id="outline-container-org08202c8" class="outline-3">
-<h3 id="org08202c8">function list-unique-or-primary-constraints (table-name)</h3>
-<div class="outline-text-3" id="text-org08202c8">
+<div id="outline-container-org854d2a3" class="outline-3">
+<h3 id="org854d2a3">function list-foreign-keys (table-name)</h3>
+<div class="outline-text-3" id="text-org854d2a3">
+<p>
+→ list
+</p>
+
+<p>
+Returns a list of sublists of foreign key info in the form of
+   '((constraint-name local-table local-table-column
+     foreign-table-name foreign-column-name))
+</p>
+</div>
+</div>
+
+
+<div id="outline-container-orgbf5f27b" class="outline-3">
+<h3 id="orgbf5f27b">function list-unique-or-primary-constraints (table-name)</h3>
+<div class="outline-text-3" id="text-orgbf5f27b">
 <p>
 → list
 </p>
@@ -1390,9 +1490,9 @@ List constraints on a table.
 </div>
 </div>
 
-<div id="outline-container-org61ccc27" class="outline-3">
-<h3 id="org61ccc27">function list-all-constraints (table-name)</h3>
-<div class="outline-text-3" id="text-org61ccc27">
+<div id="outline-container-org6efd450" class="outline-3">
+<h3 id="org6efd450">function list-all-constraints (table-name)</h3>
+<div class="outline-text-3" id="text-org6efd450">
 <p>
 → list
 </p>
@@ -1404,9 +1504,9 @@ can be either a string or quoted.
 </div>
 </div>
 
-<div id="outline-container-org6e13985" class="outline-3">
-<h3 id="org6e13985">function describe-constraint (table-name constraint-name)</h3>
-<div class="outline-text-3" id="text-org6e13985">
+<div id="outline-container-org718ae74" class="outline-3">
+<h3 id="org718ae74">function describe-constraint (table-name constraint-name)</h3>
+<div class="outline-text-3" id="text-org718ae74">
 <p>
 → list
 </p>
@@ -1418,9 +1518,9 @@ the table-name and the constraint name using the information_schema table.
 </div>
 </div>
 
-<div id="outline-container-org2a704ab" class="outline-3">
-<h3 id="org2a704ab">function describe-foreign-key-constraints ()</h3>
-<div class="outline-text-3" id="text-org2a704ab">
+<div id="outline-container-orgfb319ea" class="outline-3">
+<h3 id="orgfb319ea">function describe-foreign-key-constraints ()</h3>
+<div class="outline-text-3" id="text-orgfb319ea">
 <p>
 → list
 </p>
@@ -1431,9 +1531,9 @@ Generates a list of lists of information on the foreign key constraints
 </div>
 </div>
 
-<div id="outline-container-orga3784b7" class="outline-3">
-<h3 id="orga3784b7">function list-triggers (&amp;optional table-name)</h3>
-<div class="outline-text-3" id="text-orga3784b7">
+<div id="outline-container-org64616d3" class="outline-3">
+<h3 id="org64616d3">function list-triggers (&amp;optional table-name)</h3>
+<div class="outline-text-3" id="text-org64616d3">
 <p>
 → list
 </p>
@@ -1445,9 +1545,9 @@ can be either quoted or string.
 </div>
 </div>
 
-<div id="outline-container-orgd09029b" class="outline-3">
-<h3 id="orgd09029b">function list-detailed-triggers ()</h3>
-<div class="outline-text-3" id="text-orgd09029b">
+<div id="outline-container-orgd536f5b" class="outline-3">
+<h3 id="orgd536f5b">function list-detailed-triggers ()</h3>
+<div class="outline-text-3" id="text-orgd536f5b">
 <p>
 → list
 </p>
@@ -1458,9 +1558,9 @@ List detailed information on the triggers from the information_schema table.
 </div>
 </div>
 
-<div id="outline-container-org0c9e9f9" class="outline-3">
-<h3 id="org0c9e9f9">function list-database-users ()</h3>
-<div class="outline-text-3" id="text-org0c9e9f9">
+<div id="outline-container-org6b6447b" class="outline-3">
+<h3 id="org6b6447b">function list-database-users ()</h3>
+<div class="outline-text-3" id="text-org6b6447b">
 <p>
 → list
 </p>
@@ -1471,9 +1571,9 @@ List database users.
 </div>
 </div>
 
-<div id="outline-container-org21e6cb7" class="outline-3">
-<h3 id="org21e6cb7">function change-toplevel-database (new-database user password host)</h3>
-<div class="outline-text-3" id="text-org21e6cb7">
+<div id="outline-container-orgc5a2e78" class="outline-3">
+<h3 id="orgc5a2e78">function change-toplevel-database (new-database user password host)</h3>
+<div class="outline-text-3" id="text-orgc5a2e78">
 <p>
 → string
 </p>
@@ -1487,9 +1587,9 @@ connected database as a string.
 </div>
 </div>
 
-<div id="outline-container-org00207e6" class="outline-2">
-<h2 id="org00207e6">Database access objects</h2>
-<div class="outline-text-2" id="text-org00207e6">
+<div id="outline-container-org8e171a0" class="outline-2">
+<h2 id="org8e171a0">Database access objects</h2>
+<div class="outline-text-2" id="text-org8e171a0">
 <p>
 Postmodern contains a simple system for defining CLOS classes that
 represent rows in the database. This is not intended as a full-fledged
@@ -1499,9 +1599,9 @@ a humble SQL library like this.
 </p>
 </div>
 
-<div id="outline-container-org841b506" class="outline-3">
-<h3 id="org841b506">metaclass dao-class</h3>
-<div class="outline-text-3" id="text-org841b506">
+<div id="outline-container-orge295326" class="outline-3">
+<h3 id="orge295326">metaclass dao-class</h3>
+<div class="outline-text-3" id="text-orge295326">
 <p>
 At the heart of Postmodern's DAO system is the dao-class metaclass. It
 allows you to define classes for your database-access objects as regular
@@ -1578,9 +1678,9 @@ and specify a slot like this:
 </div>
 </div>
 
-<div id="outline-container-org01f46ef" class="outline-3">
-<h3 id="org01f46ef">method dao-keys (class)</h3>
-<div class="outline-text-3" id="text-org01f46ef">
+<div id="outline-container-orgc99ce39" class="outline-3">
+<h3 id="orgc99ce39">method dao-keys (class)</h3>
+<div class="outline-text-3" id="text-orgc99ce39">
 <p>
 → list
 </p>
@@ -1591,9 +1691,9 @@ Returns list of slot names that are the primary key of DAO class.
 </div>
 </div>
 
-<div id="outline-container-orgbddb9c7" class="outline-3">
-<h3 id="orgbddb9c7">method dao-keys (dao)</h3>
-<div class="outline-text-3" id="text-orgbddb9c7">
+<div id="outline-container-orga60662e" class="outline-3">
+<h3 id="orga60662e">method dao-keys (dao)</h3>
+<div class="outline-text-3" id="text-orga60662e">
 <p>
 → list
 </p>
@@ -1604,9 +1704,9 @@ Returns list of values that are the primary key of dao.
 </div>
 </div>
 
-<div id="outline-container-org63c8766" class="outline-3">
-<h3 id="org63c8766">method dao-exists-p (dao)</h3>
-<div class="outline-text-3" id="text-org63c8766">
+<div id="outline-container-org6d8b270" class="outline-3">
+<h3 id="org6d8b270">method dao-exists-p (dao)</h3>
+<div class="outline-text-3" id="text-org6d8b270">
 <p>
 → boolean
 </p>
@@ -1619,9 +1719,9 @@ unbound.
 </div>
 </div>
 
-<div id="outline-container-orga2273af" class="outline-3">
-<h3 id="orga2273af">method make-dao (type &amp;rest args &amp;key &amp;allow-other-keys)</h3>
-<div class="outline-text-3" id="text-orga2273af">
+<div id="outline-container-org2a05082" class="outline-3">
+<h3 id="org2a05082">method make-dao (type &amp;rest args &amp;key &amp;allow-other-keys)</h3>
+<div class="outline-text-3" id="text-org2a05082">
 <p>
 → dao
 </p>
@@ -1632,9 +1732,9 @@ Combines make-instance with insert-dao. Return the created dao.
 </div>
 </div>
 
-<div id="outline-container-orga8f1d62" class="outline-3">
-<h3 id="orga8f1d62">macro define-dao-finalization (((dao-name class) &amp;rest keyword-args) &amp;body body)</h3>
-<div class="outline-text-3" id="text-orga8f1d62">
+<div id="outline-container-orgc1573bd" class="outline-3">
+<h3 id="orgc1573bd">macro define-dao-finalization (((dao-name class) &amp;rest keyword-args) &amp;body body)</h3>
+<div class="outline-text-3" id="text-orgc1573bd">
 <p>
 Create an :around-method for make-dao. The body is executed in a lexical
 environment where dao-name is bound to a freshly created and inserted DAO.
@@ -1645,9 +1745,9 @@ slots with the type serial, which are unknown before insert-dao.
 </div>
 </div>
 
-<div id="outline-container-orgb80db1e" class="outline-3">
-<h3 id="orgb80db1e">method get-dao (type &amp;rest keys)</h3>
-<div class="outline-text-3" id="text-orgb80db1e">
+<div id="outline-container-orgdbc27b5" class="outline-3">
+<h3 id="orgdbc27b5">method get-dao (type &amp;rest keys)</h3>
+<div class="outline-text-3" id="text-orgdbc27b5">
 <p>
 → dao
 </p>
@@ -1662,9 +1762,9 @@ The same goes for select-dao and query-dao.
 </div>
 </div>
 
-<div id="outline-container-org3e66f17" class="outline-3">
-<h3 id="org3e66f17">macro select-dao (type &amp;optional (test t) &amp;rest sort)</h3>
-<div class="outline-text-3" id="text-org3e66f17">
+<div id="outline-container-org97c09c2" class="outline-3">
+<h3 id="org97c09c2">macro select-dao (type &amp;optional (test t) &amp;rest sort)</h3>
+<div class="outline-text-3" id="text-org97c09c2">
 <p>
 → list
 </p>
@@ -1686,9 +1786,9 @@ the result.
 </div>
 </div>
 
-<div id="outline-container-org01592fc" class="outline-3">
-<h3 id="org01592fc">macro do-select-dao (((type type-var) &amp;optional (test t) &amp;rest sort) &amp;body body)</h3>
-<div class="outline-text-3" id="text-org01592fc">
+<div id="outline-container-org4b1d641" class="outline-3">
+<h3 id="org4b1d641">macro do-select-dao (((type type-var) &amp;optional (test t) &amp;rest sort) &amp;body body)</h3>
+<div class="outline-text-3" id="text-org4b1d641">
 <p>
 Like select-dao, but iterates over the results rather than returning them.
 For each matching DAO, body is evaluated with type-var bound to the DAO
@@ -1702,9 +1802,9 @@ instance.
 </div>
 </div>
 
-<div id="outline-container-orgef6c4d3" class="outline-3">
-<h3 id="orgef6c4d3">macro query-dao (type query &amp;rest args)</h3>
-<div class="outline-text-3" id="text-orgef6c4d3">
+<div id="outline-container-org1c187f4" class="outline-3">
+<h3 id="org1c187f4">macro query-dao (type query &amp;rest args)</h3>
+<div class="outline-text-3" id="text-org1c187f4">
 <p>
 → list
 </p>
@@ -1719,9 +1819,9 @@ the DAO class, or be bound through with-column-writers.
 </div>
 </div>
 
-<div id="outline-container-org2946618" class="outline-3">
-<h3 id="org2946618">function do-query-dao (((type type-var) query &amp;rest args) &amp;body body)</h3>
-<div class="outline-text-3" id="text-org2946618">
+<div id="outline-container-orgfbff399" class="outline-3">
+<h3 id="orgfbff399">function do-query-dao (((type type-var) query &amp;rest args) &amp;body body)</h3>
+<div class="outline-text-3" id="text-orgfbff399">
 <p>
 → list
 </p>
@@ -1738,9 +1838,9 @@ For each matching DAO, body is evaluated with type-var bound to the instance.
 </div>
 </div>
 
-<div id="outline-container-org213b819" class="outline-3">
-<h3 id="org213b819">variable <b>ignore-unknown-columns</b></h3>
-<div class="outline-text-3" id="text-org213b819">
+<div id="outline-container-orgc109f47" class="outline-3">
+<h3 id="orgc109f47">variable <b>ignore-unknown-columns</b></h3>
+<div class="outline-text-3" id="text-orgc109f47">
 <p>
 Normally, when get-dao, select-dao, or query-dao finds a column in the database
 that's not in the DAO class, it will raise an error. Setting this variable to
@@ -1749,9 +1849,9 @@ a non-NIL will cause it to simply ignore the unknown column.
 </div>
 </div>
 
-<div id="outline-container-org112977f" class="outline-3">
-<h3 id="org112977f">method insert-dao (dao)</h3>
-<div class="outline-text-3" id="text-org112977f">
+<div id="outline-container-orgca2d6be" class="outline-3">
+<h3 id="orgca2d6be">method insert-dao (dao)</h3>
+<div class="outline-text-3" id="text-orgca2d6be">
 <p>
 → dao
 </p>
@@ -1765,9 +1865,9 @@ be failed. (This feature only works on PostgreSQL 8.2 and up.)
 </div>
 </div>
 
-<div id="outline-container-org7949047" class="outline-3">
-<h3 id="org7949047">method update-dao (dao)</h3>
-<div class="outline-text-3" id="text-org7949047">
+<div id="outline-container-org5622a60" class="outline-3">
+<h3 id="org5622a60">method update-dao (dao)</h3>
+<div class="outline-text-3" id="text-org5622a60">
 <p>
 → dao
 </p>
@@ -1780,9 +1880,9 @@ non-primary-key columns. Raises an error when no row matching the dao exists.
 </div>
 </div>
 
-<div id="outline-container-org97b3733" class="outline-3">
-<h3 id="org97b3733">function save-dao (dao)</h3>
-<div class="outline-text-3" id="text-org97b3733">
+<div id="outline-container-org8598d13" class="outline-3">
+<h3 id="org8598d13">function save-dao (dao)</h3>
+<div class="outline-text-3" id="text-org8598d13">
 <p>
 → boolean
 </p>
@@ -1807,9 +1907,9 @@ See also: upsert-dao.
 </div>
 </div>
 
-<div id="outline-container-org156dacc" class="outline-3">
-<h3 id="org156dacc">function save-dao/transaction (dao)</h3>
-<div class="outline-text-3" id="text-org156dacc">
+<div id="outline-container-org182b7bd" class="outline-3">
+<h3 id="org182b7bd">function save-dao/transaction (dao)</h3>
+<div class="outline-text-3" id="text-org182b7bd">
 <p>
 → boolean
 </p>
@@ -1825,9 +1925,9 @@ See also: upsert-dao.
 </div>
 </div>
 
-<div id="outline-container-orge4bc9c5" class="outline-3">
-<h3 id="orge4bc9c5">method upsert-dao (dao)</h3>
-<div class="outline-text-3" id="text-orge4bc9c5">
+<div id="outline-container-org715b41c" class="outline-3">
+<h3 id="org715b41c">method upsert-dao (dao)</h3>
+<div class="outline-text-3" id="text-org715b41c">
 <p>
 → dao
 </p>
@@ -1874,18 +1974,18 @@ was inserted, NIL if it was updated).
 </div>
 </div>
 
-<div id="outline-container-org539b51d" class="outline-3">
-<h3 id="org539b51d">method delete-dao (dao)</h3>
-<div class="outline-text-3" id="text-org539b51d">
+<div id="outline-container-org3580abf" class="outline-3">
+<h3 id="org3580abf">method delete-dao (dao)</h3>
+<div class="outline-text-3" id="text-org3580abf">
 <p>
 Delete the given dao from the database.
 </p>
 </div>
 </div>
 
-<div id="outline-container-org5bade60" class="outline-3">
-<h3 id="org5bade60">function dao-table-name (class)</h3>
-<div class="outline-text-3" id="text-org5bade60">
+<div id="outline-container-org82ec0d0" class="outline-3">
+<h3 id="org82ec0d0">function dao-table-name (class)</h3>
+<div class="outline-text-3" id="text-org82ec0d0">
 <p>
 → string
 </p>
@@ -1897,9 +1997,9 @@ symbol naming such a class).
 </div>
 </div>
 
-<div id="outline-container-org7e43de5" class="outline-3">
-<h3 id="org7e43de5">function dao-table-definition (class)</h3>
-<div class="outline-text-3" id="text-org7e43de5">
+<div id="outline-container-org542a0c7" class="outline-3">
+<h3 id="org542a0c7">function dao-table-definition (class)</h3>
+<div class="outline-text-3" id="text-org542a0c7">
 <p>
 → string
 </p>
@@ -1913,9 +2013,9 @@ own queries to add them.
 </div>
 </div>
 
-<div id="outline-container-org052ee19" class="outline-3">
-<h3 id="org052ee19">macro with-column-writers ((&amp;rest writers) &amp;body body)</h3>
-<div class="outline-text-3" id="text-org052ee19">
+<div id="outline-container-orgca4318c" class="outline-3">
+<h3 id="orgca4318c">macro with-column-writers ((&amp;rest writers) &amp;body body)</h3>
+<div class="outline-text-3" id="text-orgca4318c">
 <p>
 Provides control over the way get-dao, select-dao, and query-dao read values
 from the database. This is not commonly needed, but can be used to reduce the
@@ -1938,9 +2038,9 @@ about the objects, and immediately store it in the new instances.
 </div>
 </div>
 
-<div id="outline-container-org2a813a6" class="outline-2">
-<h2 id="org2a813a6">Table definition and creation</h2>
-<div class="outline-text-2" id="text-org2a813a6">
+<div id="outline-container-orge70903a" class="outline-2">
+<h2 id="orge70903a">Table definition and creation</h2>
+<div class="outline-text-2" id="text-orge70903a">
 <p>
 It can be useful to have the SQL statements needed to build an application's
 tables available from the source code, to do things like automatically
@@ -1950,9 +2050,9 @@ in table definitions.
 </p>
 </div>
 
-<div id="outline-container-org452ce06" class="outline-3">
-<h3 id="org452ce06">macro deftable (name &amp;body definition)</h3>
-<div class="outline-text-3" id="text-org452ce06">
+<div id="outline-container-org91df798" class="outline-3">
+<h3 id="org91df798">macro deftable (name &amp;body definition)</h3>
+<div class="outline-text-3" id="text-org91df798">
 <p>
 Define a table. name can be either a symbol or a (symbol string) list.
 In the first case, the table name is derived from the symbol's name by
@@ -1966,9 +2066,9 @@ and then define indices on it.
 </div>
 </div>
 
-<div id="outline-container-orga55f8be" class="outline-3">
-<h3 id="orga55f8be">function !dao-def ()</h3>
-<div class="outline-text-3" id="text-orga55f8be">
+<div id="outline-container-orgc655161" class="outline-3">
+<h3 id="orgc655161">function !dao-def ()</h3>
+<div class="outline-text-3" id="text-orgc655161">
 <p>
 Should only be used inside deftable's body. Adds the result of calling
 dao-table-definition on <b>table-symbol</b> to the definition.
@@ -1976,9 +2076,9 @@ dao-table-definition on <b>table-symbol</b> to the definition.
 </div>
 </div>
 
-<div id="outline-container-org2724621" class="outline-3">
-<h3 id="org2724621">function !index (&amp;rest columns), !unique-index (&amp;rest columns)</h3>
-<div class="outline-text-3" id="text-org2724621">
+<div id="outline-container-orga089933" class="outline-3">
+<h3 id="orga089933">function !index (&amp;rest columns), !unique-index (&amp;rest columns)</h3>
+<div class="outline-text-3" id="text-orga089933">
 <p>
 Define an index on the table being defined. The columns can be given as
 symbols or strings.
@@ -1986,9 +2086,9 @@ symbols or strings.
 </div>
 </div>
 
-<div id="outline-container-orga0e6dc9" class="outline-3">
-<h3 id="orga0e6dc9">function !foreign (target-table columns &amp;optional target-columns &amp;key on-delete on-update deferrable initially-deferred)</h3>
-<div class="outline-text-3" id="text-orga0e6dc9">
+<div id="outline-container-org03b9448" class="outline-3">
+<h3 id="org03b9448">function !foreign (target-table columns &amp;optional target-columns &amp;key on-delete on-update deferrable initially-deferred)</h3>
+<div class="outline-text-3" id="text-org03b9448">
 <p>
 Add a foreign key to the table being defined. target-table is the referenced
 table. columns is a list of column names or single name in this table, and,
@@ -2010,9 +2110,9 @@ so that they can be specified even when target-columns is not given.
 </div>
 </div>
 
-<div id="outline-container-org7627ea2" class="outline-3">
-<h3 id="org7627ea2">function !unique (target-fields &amp;key deferrable initially-deferred)</h3>
-<div class="outline-text-3" id="text-org7627ea2">
+<div id="outline-container-orge108df7" class="outline-3">
+<h3 id="orge108df7">function !unique (target-fields &amp;key deferrable initially-deferred)</h3>
+<div class="outline-text-3" id="text-orge108df7">
 <p>
 Constrains one or more columns to only contain unique (combinations of) values,
 with deferrable and initially-deferred defined as in !foreign
@@ -2020,36 +2120,36 @@ with deferrable and initially-deferred defined as in !foreign
 </div>
 </div>
 
-<div id="outline-container-orgd0ca2cf" class="outline-3">
-<h3 id="orgd0ca2cf">function create-table (symbol)</h3>
-<div class="outline-text-3" id="text-orgd0ca2cf">
+<div id="outline-container-orgbe93e6b" class="outline-3">
+<h3 id="orgbe93e6b">function create-table (symbol)</h3>
+<div class="outline-text-3" id="text-orgbe93e6b">
 <p>
 Creates the table identified by symbol by executing all forms in its definition.
 </p>
 </div>
 </div>
 
-<div id="outline-container-org4377119" class="outline-3">
-<h3 id="org4377119">function create-all-tables ()</h3>
-<div class="outline-text-3" id="text-org4377119">
+<div id="outline-container-orgc83e48f" class="outline-3">
+<h3 id="orgc83e48f">function create-all-tables ()</h3>
+<div class="outline-text-3" id="text-orgc83e48f">
 <p>
 Creates all defined tables.
 </p>
 </div>
 </div>
 
-<div id="outline-container-org73b1908" class="outline-3">
-<h3 id="org73b1908">function create-package-tables (package)</h3>
-<div class="outline-text-3" id="text-org73b1908">
+<div id="outline-container-orga5de683" class="outline-3">
+<h3 id="orga5de683">function create-package-tables (package)</h3>
+<div class="outline-text-3" id="text-orga5de683">
 <p>
 Creates all tables identified by symbols interned in the given package.
 </p>
 </div>
 </div>
 
-<div id="outline-container-org66749a0" class="outline-3">
-<h3 id="org66749a0">variables <b>table-name</b>, <b>table-symbol</b></h3>
-<div class="outline-text-3" id="text-org66749a0">
+<div id="outline-container-orgbcc618b" class="outline-3">
+<h3 id="orgbcc618b">variables <b>table-name</b>, <b>table-symbol</b></h3>
+<div class="outline-text-3" id="text-orgbcc618b">
 <p>
 These variables are bound to the relevant name and symbol while the forms of a
 table definition are evaluated. Can be used to define shorthands like the ones
@@ -2059,9 +2159,9 @@ below.
 </div>
 </div>
 
-<div id="outline-container-org5822c12" class="outline-2">
-<h2 id="org5822c12">Schemata</h2>
-<div class="outline-text-2" id="text-org5822c12">
+<div id="outline-container-org27580dd" class="outline-2">
+<h2 id="org27580dd">Schemata</h2>
+<div class="outline-text-2" id="text-org27580dd">
 <p>
 Schema allow you to separate tables into differnet name spaces. In different
 schemata two tables with the same name are allowed to exists. The tables can
@@ -2072,36 +2172,36 @@ functions allow you to create, drop schemata and to set the search path.
 </p>
 </div>
 
-<div id="outline-container-org34e7e49" class="outline-3">
-<h3 id="org34e7e49">function create-schema (schema)</h3>
-<div class="outline-text-3" id="text-org34e7e49">
+<div id="outline-container-orgba1b136" class="outline-3">
+<h3 id="orgba1b136">function create-schema (schema)</h3>
+<div class="outline-text-3" id="text-orgba1b136">
 <p>
 Creates a new schema. Raises an error if the schema is already exists.
 </p>
 </div>
 </div>
 
-<div id="outline-container-orgd2d302c" class="outline-3">
-<h3 id="orgd2d302c">function drop-schema (schema)</h3>
-<div class="outline-text-3" id="text-orgd2d302c">
+<div id="outline-container-orgf457354" class="outline-3">
+<h3 id="orgf457354">function drop-schema (schema)</h3>
+<div class="outline-text-3" id="text-orgf457354">
 <p>
 Removes a schema. Raises an error if the schema is not empty.
 </p>
 </div>
 </div>
 
-<div id="outline-container-org3b45923" class="outline-3">
-<h3 id="org3b45923">function get-search-path ()</h3>
-<div class="outline-text-3" id="text-org3b45923">
+<div id="outline-container-orge9c7c9d" class="outline-3">
+<h3 id="orge9c7c9d">function get-search-path ()</h3>
+<div class="outline-text-3" id="text-orge9c7c9d">
 <p>
 Retrieve the current search path.
 </p>
 </div>
 </div>
 
-<div id="outline-container-org8d4c2e7" class="outline-3">
-<h3 id="org8d4c2e7">function set-search-path (path)</h3>
-<div class="outline-text-3" id="text-org8d4c2e7">
+<div id="outline-container-org947c5d3" class="outline-3">
+<h3 id="org947c5d3">function set-search-path (path)</h3>
+<div class="outline-text-3" id="text-org947c5d3">
 <p>
 Sets the search path to the path. This function is used by with-schema.
 </p>
@@ -2110,7 +2210,7 @@ Sets the search path to the path. This function is used by with-schema.
 </div>
 </div>
 <div id="postamble" class="status">
-<p class="date">Created: 2018-08-11 Sat 20:00</p>
+<p class="date">Created: 2018-09-09 Sun 09:55</p>
 <p class="validation"><a href="http://validator.w3.org/check?uri=referer">Validate</a></p>
 </div>
 </body>

--- a/doc/postmodern.org
+++ b/doc/postmodern.org
@@ -178,12 +178,46 @@ well as arguments supplied to the query.
   :plists)
 #+END_SRC
 
-** macro with-transaction ((&optional name) &body body)
+** macro with-transaction ((&optional name isolation-level) &body body)
 
 Execute the given body within a database transaction, committing it when the
-body exits normally, and aborting otherwise. An optional name can be given
-to the transaction, which can be used to force a commit or abort before the
-body unwinds.
+body exits normally, and aborting otherwise. An optional name and/or
+isolation-level can be given to the transaction. The name can be used to
+force a commit or abort before the body unwinds. The isolation-level
+will set the isolation-level used by the transaction.
+
+You can specify the following isolation levels in postmodern transactions:
+
+- :read-committed-rw (read committed with read and write)
+- :read-committed-ro (read committed with read only)
+- :repeatable-read-rw (repeatable read with read and write)
+- :repeatable-read-ro (repeatable read with read only)
+- :serializable (serializable with reand and write)
+
+Sample usage where "george" is just the name given to the transaction (not
+quoted or a string) and ... simply indicates other statements would be
+expected here:
+#+BEGIN_SRC lisp
+(with-transaction ()
+  (execute (:insert-into 'test-data :set 'value 77))
+  ...)
+
+(with-transaction (george)
+  (execute (:insert-into 'test-data :set 'value 22))
+  ...)
+
+(with-transaction (george :read-committed-rw)
+  (execute (:insert-into 'test-data :set 'value 33))
+  (query (:select '* :from 'test-data))
+  ...)
+
+(with-transaction (:serializable)
+  (execute (:insert-into 'test-data :set 'value 44))
+  ...)
+#+END_SRC
+
+Further discussion of transactions and isolation levels can found
+[[file:isolation-notes.html][here]].
 
 ** function commit-transaction (transaction)
 
@@ -222,12 +256,42 @@ be executed when a transaction is aborted or a savepoint rolled back
 (whether via a non-local transfer of control or explicitly by either
 abort-transaction or rollback-savepoint).
 
-** macro with-logical-transaction ((&optional name) &body body)
+** macro with-logical-transaction ((&optional name isolation-level) &body body)
 
 Executes body within a with-transaction form if no transaction is currently
 in progress, otherwise simulates a nested transaction by executing it
 within a with-savepoint form. The transaction or savepoint is bound to name
-if one is supplied.
+if one is supplied. The isolation-level will set the isolation-level used by the transaction.
+
+You can specify the following isolation levels in postmodern transactions:
+
+- :read-committed-rw (read committed with read and write)
+- :read-committed-ro (read committed with read only)
+- :repeatable-read-rw (repeatable read with read and write)
+- :repeatable-read-ro (repeatable read with read only)
+- :serializable (serializable with reand and write)
+
+Sample usage where "george" is just the name given to the transaction (not
+quoted or a string) and ... simply indicates other statements would be
+expected here:
+
+#+BEGIN_SRC lisp
+(with-logical-transaction ()
+  (execute (:insert-into 'test-data :set 'value 77))
+  ...)
+
+(with-logical-transaction (george)
+  (execute (:insert-into 'test-data :set 'value 22))
+  ...)
+
+(with-logical-transaction (george :read-committed-rw)
+  (execute (:insert-into 'test-data :set 'value 33))
+  ...)
+
+(with-logical-transaction (:serializable)
+  (execute (:insert-into 'test-data :set 'value 44))
+  ...)
+#+END_SRC
 
 ** function abort-logical-transaction (transaction-or-savepoint)
 

--- a/doc/s-sql.org
+++ b/doc/s-sql.org
@@ -1140,6 +1140,25 @@ etc which depend on that table.
 (query (:drop-table :if-exists 'table1 :cascade))
 #+END_SRC
 
+** sql-op :truncate (&rest args)
+
+Truncates one or more tables, deleting all the rows. Optional arguments are
+
+- :only (if not specified, the table and its descendants are truncated).
+- :continue-identity (the values of sequences will not be changed. This is the default)
+- :restart-identity (the values of sequences owned by the table(s) will be restarted)
+
+Note this operator does not implement :cascade at this time. Example calls would be:
+#+BEGIN_SRC lisp
+(query (:truncate 'bigtable 'fattable))
+
+(query (:truncate 'bigtable 'fattable :only))
+
+(query (:truncate 'bigtable 'fattable :only :continue-identity))
+
+(sql (:truncate 'bigtable 'fattable :restart-identity))
+#+END_SRC
+
 ** sql-op :create-index (name &rest args)
 
 Create an index on a table. After the name of the index the keyword :on should

--- a/doc/s-sql.org
+++ b/doc/s-sql.org
@@ -1141,14 +1141,18 @@ etc which depend on that table.
 #+END_SRC
 
 ** sql-op :truncate (&rest args)
+   SCHEDULED: <2018-09-06 Thu>
 
-Truncates one or more tables, deleting all the rows. Optional arguments are
+Truncates one or more tables, deleting all the rows. Optional keyword arguments are
+allowed in the following order. Note that :continue-identity and :restart-identity
+make no sense if both are included.
 
 - :only (if not specified, the table and its descendants are truncated).
 - :continue-identity (the values of sequences will not be changed. This is the default)
 - :restart-identity (the values of sequences owned by the table(s) will be restarted)
+- :cascade (will cascade the truncation through tables using foreign keys.)
 
-Note this operator does not implement :cascade at this time. Example calls would be:
+Example calls would be:
 #+BEGIN_SRC lisp
 (query (:truncate 'bigtable 'fattable))
 
@@ -1156,7 +1160,10 @@ Note this operator does not implement :cascade at this time. Example calls would
 
 (query (:truncate 'bigtable 'fattable :only :continue-identity))
 
-(sql (:truncate 'bigtable 'fattable :restart-identity))
+(query (:truncate 'bigtable 'fattable :restart-identity))
+
+(query (:truncate 'bigtable 'fattable :only :restart-identity :cascade ))
+
 #+END_SRC
 
 ** sql-op :create-index (name &rest args)

--- a/postmodern.asd
+++ b/postmodern.asd
@@ -43,7 +43,8 @@
                             "cl-postgres/tests" "s-sql/tests")
   :components
   ((:module "postmodern/tests"
-            :components ((:file "tests"))))
+            :components ((:file "tests")
+                         (:file "test-dao"))))
   :perform (test-op (o c)
              (uiop:symbol-call :cl-postgres-tests '#:prompt-connection)
              (uiop:symbol-call :fiveam '#:run! :postmodern)))

--- a/postmodern/package.lisp
+++ b/postmodern/package.lisp
@@ -24,9 +24,11 @@
    #:sequence-next #:list-sequences #:sequence-exists-p
    #:list-tables #:table-exists-p #:table-description
    #:list-views #:view-exists-p
-   #:*current-logical-transaction* #:with-transaction #:commit-transaction #:abort-transaction
+   #:*current-logical-transaction* #:*isolation-level* #:with-transaction
+   #:commit-transaction #:abort-transaction
    #:with-savepoint #:rollback-savepoint #:release-savepoint
    #:with-logical-transaction #:ensure-transaction
+   #:ensure-transaction-with-isolation-level
    #:abort-hooks #:commit-hooks
    #:db-null #:coalesce
    #:database-version #:num-records-in-database #:current-database

--- a/postmodern/tests/test-dao.lisp
+++ b/postmodern/tests/test-dao.lisp
@@ -1,0 +1,212 @@
+(in-package :postmodern-tests)
+
+(fiveam:def-suite :postmodern-daos
+    :description "Dao suite for postmodern"
+    :in :postmodern)
+
+(fiveam:in-suite :postmodern-daos)
+
+(defclass test-data ()
+    ((id :col-type serial :initarg :id :accessor test-id)
+     (a :col-type (or (varchar 100) db-null) :initarg :a :accessor test-a)
+     (b :col-type boolean :col-default nil :initarg :b :accessor test-b)
+     (c :col-type integer :col-default 0 :initarg :c :accessor test-c)
+     (d :col-type numeric :col-default 0.0 :initarg :d :accessor test-d))
+    (:metaclass dao-class)
+    (:table-name dao-test)
+    (:keys id))
+
+(defclass test-data-short ()
+  ((id :col-type serial :initarg :id :accessor test-id)
+   (a :col-type (or (varchar 100) db-null) :initarg :a :accessor test-a))
+  (:metaclass dao-class)
+  (:table-name dao-test)
+  (:keys id))
+
+(defclass test-data-short-wrong-1 ()
+  ((id :col-type serial :initarg :id :accessor test-id)
+   (a :col-type (or numeric db-null) :initarg :a :accessor test-a))
+  (:metaclass dao-class)
+  (:table-name dao-test)
+  (:keys id))
+
+(defclass test-data-d-string ()
+    ((id :col-type serial :initarg :id :accessor test-id)
+     (a :col-type (or (varchar 100) db-null) :initarg :a :accessor test-a)
+     (b :col-type boolean :col-default nil :initarg :b :accessor test-b)
+     (c :col-type integer :col-default 0 :initarg :c :accessor test-c)
+     (d :col-type text :col-default "" :initarg :d :accessor test-d))
+    (:metaclass dao-class)
+    (:table-name dao-test)
+    (:keys id))
+
+(test dao-class
+  (with-test-connection
+    (query (:drop-table :if-exists 'dao-test :cascade))
+    (execute (dao-table-definition 'test-data))
+    (protect
+      (is (member :dao-test (list-tables)))
+      (is (null (select-dao 'test-data)))
+      (let ((dao (make-instance 'test-data :a "quux")))
+        (signals error (test-id dao))
+        (insert-dao dao)
+        (is (dao-exists-p dao))
+        (let* ((id (test-id dao))
+              (database-dao (get-dao 'test-data id)))
+          (is (not (null database-dao)))
+          (is (eql (test-id dao) (test-id database-dao)))
+          (is (string= (test-a database-dao) "quux"))
+          (setf (test-b dao) t)
+          (update-dao dao)
+          (let ((new-database-dao (get-dao 'test-data id)))
+            (is (eq (test-b new-database-dao) t))
+            (is (eq (test-b database-dao) nil))
+            (delete-dao dao))))
+      (is (not (select-dao 'test-data)))
+      (execute (:drop-table 'dao-test)))))
+
+(test save-dao
+  (with-test-connection
+    (query (:drop-table :if-exists 'dao-test :cascade))
+    (execute (dao-table-definition 'test-data))
+    (protect
+      (let ((dao (make-instance 'test-data :a "quux")))
+        (is (save-dao dao))
+        (setf (test-a dao) "bar")
+        (is (not (save-dao dao)))
+        (is (equal (test-a (get-dao 'test-data (test-id dao))) "bar"))
+        (signals database-error
+          (with-transaction () (save-dao dao)))
+        (with-transaction ()
+          (is (not (save-dao/transaction dao)))))
+      (let ((short-dao (make-instance 'test-data-short :a "first short")))
+        (save-dao short-dao)
+        (is (equalp (query (:select '* :from 'dao-test) :alists)
+                    '(((:ID . 1) (:A . "bar") (:B) (:C . 0) (:D . 0))
+                      ((:ID . 2) (:A . "first short") (:B) (:C . 0) (:D . 0))))))
+      (let ((dao-short-wrong (make-instance 'test-data-short-wrong-1 :a 12.75)))
+        (save-dao dao-short-wrong)
+        (is (equalp (query (:select '* :from 'dao-test) :alists)
+                    '(((:ID . 1) (:A . "bar") (:B) (:C . 0) (:D . 0))
+                      ((:ID . 2) (:A . "first short") (:B) (:C . 0) (:D . 0))
+                      ((:ID . 3) (:A . "12.75") (:B) (:C . 0) (:D . 0))))))
+      (let ((dao-d-string (make-instance 'test-data-d-string :a "D string" :b nil :c 14.37
+                            :d 18.78)))
+        (save-dao dao-d-string)
+        (is (equalp (query (:select '* :from 'dao-test) :alists)
+            '(((:ID . 1) (:A . "bar") (:B) (:C . 0) (:D . 0))
+              ((:ID . 2) (:A . "first short") (:B) (:C . 0) (:D . 0))
+              ((:ID . 3) (:A . "12.75") (:B) (:C . 0) (:D . 0))
+              ((:ID . 4) (:A . "D string") (:B) (:C . 14) (:D . 939/50)))))
+        (is (equal 939/50 (test-d (get-dao 'test-data-d-string
+                                           (test-id dao-d-string)))))
+        (is (equal (test-a (first (query (:select '* :from 'dao-test :where (:= 'id 1))
+                                   (:dao test-data))))
+                   "bar")))
+      (is (equal (length (query (:select '* :from 'dao-test) (:dao test-data)))
+                 4))
+      (is (equal (type-of (first (with-test-connection
+                                   (query (:select '* :from 'dao-test)
+                                          (:dao test-data)))))
+                 'TEST-DATA))
+      (is (equal (type-of (first (with-test-connection
+                                   (query (:select '* :from 'dao-test)
+                                          (:dao test-data-d-string)))))
+                 'TEST-DATA-D-STRING))
+      (let ((dao (make-instance 'test-data-d-string :a "D string" :b nil :c 14
+                            :d "Trying string")))
+        (signals error (with-transaction () (save-dao dao))))
+      (setf *ignore-unknown-columns* t)
+      (is (equal (test-a (get-dao 'test-data-short 3))
+                 "12.75"))
+      (setf *ignore-unknown-columns* nil)
+      (with-test-connection
+        (execute (:drop-table 'dao-test :cascade))))))
+
+(test query-drop-table-1
+  (with-test-connection
+    (unless (pomo:table-exists-p 'dao-test)
+      (execute (dao-table-definition 'test-data)))
+    (protect
+      (is (member :dao-test (with-test-connection (pomo:list-tables))))
+      (pomo:query (:drop-table :dao-test))
+      (is (not (member :dao-test (with-test-connection (pomo:list-tables))))))))
+
+(defclass test-oid ()
+  ((oid :col-type integer :ghost t :accessor test-oid)
+   (a :col-type string :initarg :a :accessor test-a)
+   (b :col-type string :initarg :b :accessor test-b))
+  (:metaclass dao-class)
+  (:keys a))
+
+(test dao-class-oid
+  (with-test-connection
+    (execute (concatenate 'string (dao-table-definition 'test-oid) "with (oids=true)"))
+    (protect
+      (let ((dao (make-instance 'test-oid :a "a" :b "b")))
+        (insert-dao dao)
+        (is-true (integerp (test-oid dao)))
+        (let ((back (get-dao 'test-oid "a")))
+          (is (test-oid dao) (test-oid back))
+          (setf (test-b back) "c")
+          (update-dao back))
+        (is (test-b (get-dao 'test-oid "a")) "c"))
+      (execute (:drop-table 'test-oid)))))
+
+(defclass test-col-name ()
+  ((a :col-type string :col-name aa :initarg :a :accessor test-a)
+   (b :col-type string :col-name bb :initarg :b :accessor test-b)
+   (c :col-type string              :initarg :c :accessor test-c))
+  (:metaclass dao-class)
+  (:keys a))
+
+(test dao-class-col-name
+  (with-test-connection
+    (execute "CREATE TEMPORARY TABLE test_col_name (aa text primary key,  bb text not null, c text not null)")
+    (let ((o (make-instance 'test-col-name :a "1" :b "2" :c "3")))
+      (save-dao o)
+      (let ((oo (get-dao 'test-col-name "1")))
+        (is (string= "1" (test-a oo)))
+        (is (string= "2" (test-b oo)))
+        (is (string= "3" (test-c oo)))))
+    (let ((o (get-dao 'test-col-name "1")))
+      (setf (test-b o) "b")
+      (update-dao o))
+    (is (string= "1" (test-a (get-dao 'test-col-name "1"))))
+    (is (string= "b" (test-b (get-dao 'test-col-name "1"))))
+    (is (string= "3" (test-c (get-dao 'test-col-name "1"))))))
+
+;;; For threading tests
+(defvar *dao-update-lock* (bt:make-lock))
+
+
+(defun make-class (name) (eval `(defclass ,(intern name) ()
+                                  ((id :col-type serial :initarg :id :accessor test-id)
+                                   (a :col-type (or (varchar 100) db-null) :initarg :a :accessor test-a)
+                                   (b :col-type boolean :col-default nil :initarg :b :accessor test-b)
+                                   (c :col-type integer :col-default 0 :initarg :c :accessor test-c))
+                                  (:metaclass dao-class)
+                                  (:table-name dao-test)
+                                  (:keys id))))
+
+(test make-class
+  (let ((a (make-class (write-to-string (gensym)))))
+    (is (not (equal nil (make-instance a :id 12 :a "six" :b t))))))
+
+
+(test dao-class-threads
+  (with-test-connection
+    (unless (pomo:table-exists-p 'dao-test)
+      (execute (dao-table-definition 'test-data)))
+  (let ((item (make-instance 'test-data :a "Sabra" :b t :c 0)))
+    (save-dao item)
+    (loop for x from 1 to 5 do
+         (bt:make-thread
+          (lambda ()
+            (with-test-connection
+            (loop repeat 10 do (bt:with-lock-held (*dao-update-lock*) (incf (test-c item) 1)) (save-dao item))
+            (loop repeat 10 do (bt:with-lock-held (*dao-update-lock*) (decf (test-c item) 1)) (save-dao item))))))
+    (is (eq 0 (test-c item))))))
+
+;;; Note that if you drop the table at the end of a thread test, it is almost certain that threads are still running.
+;;; As a result, the subsequent attempts to save-dao will fail. So do not

--- a/postmodern/tests/tests.lisp
+++ b/postmodern/tests/tests.lisp
@@ -9,15 +9,22 @@
 ;; currently exists. Then after loading the file, run the tests with
 ;; (fiveam:run! :postmodern)
 
-(def-suite :postmodern
+(fiveam:def-suite :postmodern
     :description "Test suite for postmodern subdirectory files")
-(in-suite :postmodern)
+
+(fiveam:in-suite :postmodern)
 
 (defmacro with-test-connection (&body body)
   `(with-connection *test-connection* ,@body))
 
 (defmacro protect (&body body)
   `(unwind-protect (progn ,@(butlast body)) ,(car (last body))))
+
+(fiveam:def-suite :postmodern-base
+    :description "Base test suite for postmodern"
+    :in :postmodern)
+
+(fiveam:in-suite :postmodern-base)
 
 (test connect-sanely
   (with-test-connection
@@ -191,116 +198,12 @@
     (ensure-transaction
       (is (eql postmodern::*transaction-level* 1)))))
 
-(defclass test-data ()
-    ((id :col-type serial :initarg :id :accessor test-id)
-     (a :col-type (or (varchar 100) db-null) :initarg :a :accessor test-a)
-     (b :col-type boolean :col-default nil :initarg :b :accessor test-b)
-     (c :col-type integer :col-default 0 :initarg :c :accessor test-c)
-     (d :col-type numeric :col-default 0.0 :initarg :d :accessor test-d))
-    (:metaclass dao-class)
-    (:table-name dao-test)
-    (:keys id))
-
-(test dao-class
-  (with-test-connection
-    (query (:drop-table :if-exists 'dao-test :cascade))
-    (execute (dao-table-definition 'test-data))
-    (protect
-      (is (member :dao-test (list-tables)))
-      (is (null (select-dao 'test-data)))
-      (let ((dao (make-instance 'test-data :a "quux")))
-        (signals error (test-id dao))
-        (insert-dao dao)
-        (is (dao-exists-p dao))
-        (let* ((id (test-id dao))
-              (database-dao (get-dao 'test-data id)))
-          (is (not (null database-dao)))
-          (is (eql (test-id dao) (test-id database-dao)))
-          (is (string= (test-a database-dao) "quux"))
-          (setf (test-b dao) t)
-          (update-dao dao)
-          (let ((new-database-dao (get-dao 'test-data id)))
-            (is (eq (test-b new-database-dao) t))
-            (is (eq (test-b database-dao) nil))
-            (delete-dao dao))))
-      (is (not (select-dao 'test-data)))
-      (execute (:drop-table 'dao-test :cascade)))))
-
-(test save-dao
-  (with-test-connection
-    (query (:drop-table :if-exists 'dao-test :cascade))
-    (execute (dao-table-definition 'test-data))
-    (protect
-      (let ((dao (make-instance 'test-data :a "quux")))
-        (is (save-dao dao))
-        (setf (test-a dao) "bar")
-        (is (not (save-dao dao)))
-        (is (equal (test-a (get-dao 'test-data (test-id dao))) "bar"))
-        (signals database-error
-          (with-transaction () (save-dao dao)))
-        (with-transaction ()
-          (is (not (save-dao/transaction dao)))))
-      (execute (:drop-table 'dao-test :cascade)))))
-
-(test query-drop-table-1
-  (with-test-connection
-    (unless (pomo:table-exists-p 'dao-test)
-      (execute (dao-table-definition 'test-data)))
-    (protect
-      (is (member :dao-test (with-test-connection (pomo:list-tables))))
-      (query (:drop-table :if-exists 'dao-test :cascade))
-      (is (not (member :dao-test (with-test-connection (pomo:list-tables))))))))
-
-(defclass test-oid ()
-  ((oid :col-type integer :ghost t :accessor test-oid)
-   (a :col-type string :initarg :a :accessor test-a)
-   (b :col-type string :initarg :b :accessor test-b))
-  (:metaclass dao-class)
-  (:keys a))
-
-(test dao-class-oid
-  (with-test-connection
-    (execute (concatenate 'string (dao-table-definition 'test-oid) "with (oids=true)"))
-    (protect
-      (let ((dao (make-instance 'test-oid :a "a" :b "b")))
-        (insert-dao dao)
-        (is-true (integerp (test-oid dao)))
-        (let ((back (get-dao 'test-oid "a")))
-          (is (test-oid dao) (test-oid back))
-          (setf (test-b back) "c")
-          (update-dao back))
-        (is (test-b (get-dao 'test-oid "a")) "c"))
-      (execute (:drop-table 'test-oid)))))
-
 (test notification
   (with-test-connection
     (execute (:listen 'foo))
     (with-test-connection
       (execute (:notify 'foo)))
     (is (cl-postgres:wait-for-notification *database*) "foo")))
-
-(defclass test-col-name ()
-  ((a :col-type string :col-name aa :initarg :a :accessor test-a)
-   (b :col-type string :col-name bb :initarg :b :accessor test-b)
-   (c :col-type string              :initarg :c :accessor test-c))
-  (:metaclass dao-class)
-  (:keys a))
-
-(test dao-class-col-name
-  (with-test-connection
-    (execute "CREATE TEMPORARY TABLE test_col_name (aa text primary key,  bb text not null, c text not null)")
-    (let ((o (make-instance 'test-col-name :a "1" :b "2" :c "3")))
-      (save-dao o)
-      (let ((oo (get-dao 'test-col-name "1")))
-        (is (string= "1" (test-a oo)))
-        (is (string= "2" (test-b oo)))
-        (is (string= "3" (test-c oo)))))
-    (let ((o (get-dao 'test-col-name "1")))
-      (setf (test-b o) "b")
-      (update-dao o))
-    (is (string= "1" (test-a (get-dao 'test-col-name "1"))))
-    (is (string= "b" (test-b (get-dao 'test-col-name "1"))))
-    (is (string= "3" (test-c (get-dao 'test-col-name "1"))))))
 
 ;; create two tables with the same name in two different
 ;; namespaces.
@@ -330,41 +233,6 @@
       (execute (:insert-into 'test-data :set 'a #()))
       (execute (:drop-table 'test-data)))
     (is (not (table-exists-p 'test-data)))))
-
-;;; For threading tests
-(defvar *dao-update-lock* (bt:make-lock))
-
-
-(defun make-class (name) (eval `(defclass ,(intern name) ()
-                                  ((id :col-type serial :initarg :id :accessor test-id)
-                                   (a :col-type (or (varchar 100) db-null) :initarg :a :accessor test-a)
-                                   (b :col-type boolean :col-default nil :initarg :b :accessor test-b)
-                                   (c :col-type integer :col-default 0 :initarg :c :accessor test-c))
-                                  (:metaclass dao-class)
-                                  (:table-name dao-test)
-                                  (:keys id))))
-
-(test make-class
-  (let ((a (make-class (write-to-string (gensym)))))
-    (is (not (equal nil (make-instance a :id 12 :a "six" :b t))))))
-
-
-(test dao-class-threads
-  (with-test-connection
-    (unless (pomo:table-exists-p 'dao-test)
-      (execute (dao-table-definition 'test-data)))
-  (let ((item (make-instance 'test-data :a "Sabra" :b t :c 0)))
-    (save-dao item)
-    (loop for x from 1 to 5 do
-         (bt:make-thread
-          (lambda ()
-            (with-test-connection
-            (loop repeat 10 do (bt:with-lock-held (*dao-update-lock*) (incf (test-c item) 1)) (save-dao item))
-            (loop repeat 10 do (bt:with-lock-held (*dao-update-lock*) (decf (test-c item) 1)) (save-dao item))))))
-    (is (eq 0 (test-c item))))))
-
-;;; Note that if you drop the table at the end of a thread test, it is almost certain that threads are still running.
-;;; As a result, the subsequent attempts to save-dao will fail. So do not
 
 (test prepared-statement-over-reconnect
   (let ((terminate-backend

--- a/s-sql/s-sql.lisp
+++ b/s-sql/s-sql.lisp
@@ -1370,14 +1370,22 @@ test. "
 (def-drop-op :drop-rule "RULE")
 
 (def-sql-op :truncate (&rest args)
-  "Note that this version of truncate does not implement :cascade. "
-  (split-on-keywords ((vars *) (only - ?) (restart-identity - ?)  (continue-identity - ?)) (cons :vars args)
+  "This query sql-op takes one or more table names and will truncate
+  those tables (deleting all the rows. The following keyword parameters
+  are optionally allowed and must be in this order.
+    :only will truncate only this table and not descendent tables.
+    :restart-identity will restart any sequences owned by the table.
+    :continue-identity will continue sequences owned by the table.
+    :cascade will cascade the truncation through tables using foreign keys."
+  (split-on-keywords ((vars *) (only - ?) (restart-identity - ?) (continue-identity - ?)(cascade - ? ))
+      (cons :vars args)
     `("TRUNCATE "
-      ,@ (when only '(" ONLY "))
-         ,@(sql-expand-list vars)
-         ,@(cond (restart-identity '(" RESTART IDENTITY "))
-                 (continue-identity `(" CONTINUE IDENTITY "))
-                 (t '(""))))))
+      ,@(when only '(" ONLY "))
+      ,@(sql-expand-list vars)
+      ,@(cond (restart-identity '(" RESTART IDENTITY "))
+              (continue-identity `(" CONTINUE IDENTITY "))
+              (t '("")))
+      ,@(when cascade '(" CASCADE ")))))
 
 (defun dequote (val)
   (if (and (consp val) (eq (car val) 'quote)) (cadr val) val))

--- a/s-sql/s-sql.lisp
+++ b/s-sql/s-sql.lisp
@@ -1369,6 +1369,16 @@ test. "
 (def-drop-op :drop-type "TYPE")
 (def-drop-op :drop-rule "RULE")
 
+(def-sql-op :truncate (&rest args)
+  "Note that this version of truncate does not implement :cascade. "
+  (split-on-keywords ((vars *) (only - ?) (restart-identity - ?)  (continue-identity - ?)) (cons :vars args)
+    `("TRUNCATE "
+      ,@ (when only '(" ONLY "))
+         ,@(sql-expand-list vars)
+         ,@(cond (restart-identity '(" RESTART IDENTITY "))
+                 (continue-identity `(" CONTINUE IDENTITY "))
+                 (t '(""))))))
+
 (defun dequote (val)
   (if (and (consp val) (eq (car val) 'quote)) (cadr val) val))
 

--- a/s-sql/tests/tests.lisp
+++ b/s-sql/tests/tests.lisp
@@ -1234,7 +1234,16 @@ To sum the column len of all films and group the results by kind:"
                                                                    :where (:= 'memid 'mems.memid))))))
                  "DELETE FROM cd.members AS mems WHERE (not (EXISTS (SELECT 1 FROM cd.bookings WHERE (memid = mems.memid))))")))
 
-
+(test truncate
+  "Testing Truncate"
+  (is (equal (sql (:truncate 'bigtable 'fattable))
+             "TRUNCATE bigtable, fattable"))
+  (is (equal (sql (:truncate 'bigtable 'fattable :only))
+             "TRUNCATE  ONLY bigtable, fattable"))
+  (is (equal (sql (:truncate 'bigtable 'fattable :only :continue-identity))
+             "TRUNCATE  ONLY bigtable, fattable CONTINUE IDENTITY "))
+  (is (equal (sql (:truncate 'bigtable 'fattable :only :restart-identity))
+             "TRUNCATE  ONLY bigtable, fattable RESTART IDENTITY ")))
 #|
 
 

--- a/s-sql/tests/tests.lisp
+++ b/s-sql/tests/tests.lisp
@@ -1243,7 +1243,13 @@ To sum the column len of all films and group the results by kind:"
   (is (equal (sql (:truncate 'bigtable 'fattable :only :continue-identity))
              "TRUNCATE  ONLY bigtable, fattable CONTINUE IDENTITY "))
   (is (equal (sql (:truncate 'bigtable 'fattable :only :restart-identity))
-             "TRUNCATE  ONLY bigtable, fattable RESTART IDENTITY ")))
+             "TRUNCATE  ONLY bigtable, fattable RESTART IDENTITY "))
+  (is (equal (sql (:truncate 'bigtable 'fattable :only :restart-identity :cascade ))
+             "TRUNCATE  ONLY bigtable, fattable RESTART IDENTITY  CASCADE "))
+  (is (equal (sql (:truncate 'bigtable 'fattable :only :continue-identity :cascade ))
+             "TRUNCATE  ONLY bigtable, fattable CONTINUE IDENTITY  CASCADE "))
+  (is (equal (sql (:truncate 'bigtable 'fattable :continue-identity :cascade ))
+             "TRUNCATE bigtable, fattable CONTINUE IDENTITY  CASCADE ")))
 #|
 
 


### PR DESCRIPTION
Isolation level functionality now directly in with-transaction and with-logical transaction macros. This is a substantial change from the previous implementation attempt that was reverted last week.

Also added the ability to truncate tables (delete all rows).

Dao tests have been separated into a separate file in preparation for more testing and functionality.