### PR TITLE
Adding a dependency on split-sequence and def-sql-op now generates findable doc-strings

### DIFF
--- a/postmodern.asd
+++ b/postmodern.asd
@@ -21,6 +21,7 @@
                "cl-postgres"
                "s-sql"
                "global-vars"
+               "split-sequence"
                (:feature :postmodern-use-mop "closer-mop")
                (:feature :postmodern-thread-safe "bordeaux-threads"))
   :components

--- a/s-sql/s-sql.lisp
+++ b/s-sql/s-sql.lisp
@@ -399,9 +399,14 @@ should be the keyword identifying the operator, arglist a lambda list
 to apply to the arguments, and body something that produces a list of
 strings and forms that evaluate to strings."
   (let ((args-name (gensym)))
-    `(defmethod expand-sql-op ((op (eql ,name)) ,args-name)
-       (destructuring-bind ,arglist ,args-name
-         ,@body))))
+    (if (stringp (car body))
+        `(defmethod expand-sql-op ((op (eql ,name)) ,args-name)
+           ,(car body)
+           (destructuring-bind ,arglist ,args-name
+             ,@(cdr body)))
+        `(defmethod expand-sql-op ((op (eql ,name)) ,args-name)
+           (destructuring-bind ,arglist ,args-name
+             ,@body)))))
 
 (defun make-expander (arity name)
   "Generates an appropriate expander function for a given operator


### PR DESCRIPTION
A utility function to split-fully qualified table names requires split-sequence. Adding the dependency fixes the build failures.

Also def-sql-op now generates findable docstrings. Previously the docstring was getting generated outside the generated method.