### PR TITLE
DEF-SQL-OP: Use Alexandria's parse-body

### DIFF
--- a/s-sql.asd
+++ b/s-sql.asd
@@ -8,7 +8,8 @@
   :author "Marijn Haverbeke <marijnh@gmail.com>"
   :maintainer "Sabra Crolleton <sabra.crolleton@gmail.com>"
   :license "zlib"
-  :depends-on ("cl-postgres")
+  :depends-on ("cl-postgres"
+               "alexandria")
   :components
   ((:module "s-sql"
     :components ((:file "s-sql"))))

--- a/s-sql/s-sql.lisp
+++ b/s-sql/s-sql.lisp
@@ -398,15 +398,15 @@ nothing behind it.")
 should be the keyword identifying the operator, arglist a lambda list
 to apply to the arguments, and body something that produces a list of
 strings and forms that evaluate to strings."
-  (let ((args-name (gensym)))
-    (if (stringp (car body))
-        `(defmethod expand-sql-op ((op (eql ,name)) ,args-name)
-           ,(car body)
-           (destructuring-bind ,arglist ,args-name
-             ,@(cdr body)))
-        `(defmethod expand-sql-op ((op (eql ,name)) ,args-name)
-           (destructuring-bind ,arglist ,args-name
-             ,@body)))))
+  (alexandria:with-unique-names (args-name op)
+    (multiple-value-bind (body decls docstring)
+        (alexandria:parse-body body :documentation t)
+      `(defmethod expand-sql-op ((,op (eql ,name)) ,args-name)
+         ,@(when docstring
+             (list docstring))
+         ,@decls
+         (destructuring-bind ,arglist ,args-name
+           ,@body)))))
 
 (defun make-expander (arity name)
   "Generates an appropriate expander function for a given operator


### PR DESCRIPTION
Checking if is more the CAR of the body is a documentation
string is not enough to determine if we are looking at a docstring. If
the string is the only element of the body then it is part of the method
body. Leverage ALEXANDRIA:PARSE-BODY to extract the documentation string and
any declarations in DEF-SQL-OP.

Another defect on DEF-SQL-OP's implementation is the Unwanted variable
capture of OP. Gensym it.

Although I'm adding a new dependency, ALEXANDRIA, I don't think is an issue as it is ubiquitous in the CL ecosystem.