### PR TITLE
Use symbol format for sql operators

### DIFF
--- a/s-sql/s-sql.lisp
+++ b/s-sql/s-sql.lisp
@@ -1,3 +1,4 @@
+;;; -*- Mode: Lisp; Base: 10; Package: CL-USER -*-
 (defpackage :s-sql
   (:use :common-lisp)
   (:export #:smallint
@@ -461,7 +462,7 @@ string."
 (register-sql-operators :unary :not)
 (register-sql-operators :n-ary :+ :* :% :& :|\|| :|\|\|| :and :or :union (:union-all "union all"))
 (register-sql-operators :n-or-unary :- :~)
-(register-sql-operators :2+-ary  := :/ :!= :<> :< :> :<= :>= :^ :~* :!~ :!~* :like :ilike :->> :#> :#>>
+(register-sql-operators :2+-ary  := :/ :!= :<> :< :> :<= :>= :^ :~* :!~ :!~* :like :ilike :->> :|#>| :|#>>|
                         :intersect (:intersect-all "intersect all")
                         :except (:except-all "except all"))
 ;; PostGIS operators


### PR DESCRIPTION
Genera's macro reader does not seem to intern symbols beginning with # if in string form. Surround the symbol with |...| instead.