### PR TITLE
add restart on name-service-error

### DIFF
--- a/cl-postgres/public.lisp
+++ b/cl-postgres/public.lisp
@@ -173,6 +173,7 @@ if it isn't."
       #+ccl (ccl:socket-error (e) (add-restart e))
       #+allegro(excl:socket-error (e) (add-restart e))
       #+cl-postgres.features:sbcl-available(sb-bsd-sockets:socket-error (e) (add-restart e))
+      #+cl-postgres.features:sbcl-available(sb-bsd-sockets:name-service-error (e) (add-restart e))
       (stream-error (e) (add-restart e))))
     (values))
 


### PR DESCRIPTION
I'd like to use restart ```:reconnect``` on ```sb-bsd-sockets:name-service-error``` condition.
```name-service-error``` is not a subclass of ```socket-error```.
but it may happen on network access.