### PR TITLE
Resolve issues 178, 179 with prepared statement names and reconnects

### DIFF
--- a/cl-postgres.asd
+++ b/cl-postgres.asd
@@ -15,7 +15,7 @@
   :maintainer "Sabra Crolleton <sabra.crolleton@gmail.com>"
   :license "zlib"
   :depends-on ("md5"
-               (:feature (:or :sbcl :allegro :ccl :genera :armedbear) "usocket")
+               (:feature (:or :sbcl :allegro :ccl :genera :armedbear :cmucl) "usocket")
                (:feature :sbcl (:require :sb-bsd-sockets)))
   :components
   ((:module "cl-postgres"

--- a/cl-postgres/errors.lisp
+++ b/cl-postgres/errors.lisp
@@ -77,6 +77,44 @@ extract the constraint name."
         (cl-postgres-error:foreign-key-violation (extract-quoted-part message 1))
         (cl-postgres-error:check-violation (extract-quoted-part message 1))))))
 
+(defun database-error-invalid-sql-statement-name (err)
+  "Given a database-error for an invalid-sql-statement-name, will extract the
+ name of the prepared statement from the error message."
+  (labels ((extract-quoted-part (string n)
+             "Extracts the Nth quoted substring from STRING."
+             (let* ((start-quote-inst (* 2 n))
+                    (start-quote-pos (position-nth #\" string start-quote-inst))
+                    (end-quote-pos (position #\" string :start (1+ start-quote-pos))))
+               (subseq string (1+ start-quote-pos) end-quote-pos)))
+           (position-nth (item seq n)
+             "Finds the position of the zero-indexed Nth ITEM in SEQ."
+             (loop :with pos = -1 :repeat (1+ n)
+                   :do (setf pos (position item seq :start (1+ pos)))
+                :finally (return pos))))
+    (let* ((message (database-error-message err)))
+           (typecase err
+             (cl-postgres-error:invalid-sql-statement-name
+              (extract-quoted-part message 0))))))
+
+(defun database-error-syntax-error-or-access-violation (err)
+  "Given a database-error for an invalid-sql-statement-name, will extract the
+ name of the prepared statement from the error message."
+  (labels ((extract-quoted-part (string n)
+             "Extracts the Nth quoted substring from STRING."
+             (let* ((start-quote-inst (* 2 n))
+                    (start-quote-pos (position-nth #\" string start-quote-inst))
+                    (end-quote-pos (position #\" string :start (1+ start-quote-pos))))
+               (subseq string (1+ start-quote-pos) end-quote-pos)))
+           (position-nth (item seq n)
+             "Finds the position of the zero-indexed Nth ITEM in SEQ."
+             (loop :with pos = -1 :repeat (1+ n)
+                   :do (setf pos (position item seq :start (1+ pos)))
+                :finally (return pos))))
+    (let* ((message (database-error-message err)))
+           (typecase err
+             (cl-postgres-error:duplicate-prepared-statement
+              (extract-quoted-part message 0))))))
+
 (define-condition database-connection-error (database-error) ()
   (:documentation "Conditions of this type are signalled when an error
 occurs that breaks the connection socket. They offer a :reconnect

--- a/cl-postgres/errors.lisp
+++ b/cl-postgres/errors.lisp
@@ -77,9 +77,8 @@ extract the constraint name."
         (cl-postgres-error:foreign-key-violation (extract-quoted-part message 1))
         (cl-postgres-error:check-violation (extract-quoted-part message 1))))))
 
-(defun database-error-invalid-sql-statement-name (err)
-  "Given a database-error for an invalid-sql-statement-name, will extract the
- name of the prepared statement from the error message."
+(defun database-error-extract-name (err)
+  "Given a database-error, will extract the critical name from the error message."
   (labels ((extract-quoted-part (string n)
              "Extracts the Nth quoted substring from STRING."
              (let* ((start-quote-inst (* 2 n))
@@ -94,24 +93,7 @@ extract the constraint name."
     (let* ((message (database-error-message err)))
            (typecase err
              (cl-postgres-error:invalid-sql-statement-name
-              (extract-quoted-part message 0))))))
-
-(defun database-error-syntax-error-or-access-violation (err)
-  "Given a database-error for an invalid-sql-statement-name, will extract the
- name of the prepared statement from the error message."
-  (labels ((extract-quoted-part (string n)
-             "Extracts the Nth quoted substring from STRING."
-             (let* ((start-quote-inst (* 2 n))
-                    (start-quote-pos (position-nth #\" string start-quote-inst))
-                    (end-quote-pos (position #\" string :start (1+ start-quote-pos))))
-               (subseq string (1+ start-quote-pos) end-quote-pos)))
-           (position-nth (item seq n)
-             "Finds the position of the zero-indexed Nth ITEM in SEQ."
-             (loop :with pos = -1 :repeat (1+ n)
-                   :do (setf pos (position item seq :start (1+ pos)))
-                :finally (return pos))))
-    (let* ((message (database-error-message err)))
-           (typecase err
+              (extract-quoted-part message 0))
              (cl-postgres-error:duplicate-prepared-statement
               (extract-quoted-part message 0))))))
 

--- a/cl-postgres/package.lisp
+++ b/cl-postgres/package.lisp
@@ -8,8 +8,7 @@
            #:database-error-query
            #:database-error-cause
            #:database-error-constraint-name
-           #:database-error-invalid-sql-statement-name
-           #:database-error-syntax-error-or-access-violation
+           #:database-error-extract-name
            #:database-connection
            #:database-connection-error
            #:database-socket-error
@@ -219,8 +218,7 @@
            #:+fdw-handler+
            #:+index-am-handler+
            #:+tsm-handler+
-           #:+anyrange+
-           ))
+           #:+anyrange+))
 
 (in-package :cl-postgres)
 

--- a/cl-postgres/package.lisp
+++ b/cl-postgres/package.lisp
@@ -8,6 +8,8 @@
            #:database-error-query
            #:database-error-cause
            #:database-error-constraint-name
+           #:database-error-invalid-sql-statement-name
+           #:database-error-syntax-error-or-access-violation
            #:database-connection
            #:database-connection-error
            #:database-socket-error

--- a/cl-postgres/public.lisp
+++ b/cl-postgres/public.lisp
@@ -289,17 +289,7 @@ there is an equal query of the same name, return nil."
        (using-connection connection
          (send-parse (connection-socket connection) name query)
          (values)))))
-#|
-(defun prepare-query (connection name query)
-  "Prepare a query string and store it under the given name."
-  (check-type query string)
-  (check-type name string)
-  (unless (pomo:prepared-statement-exists-p name)
-    (with-reconnect-restart connection
-     (using-connection connection
-       (send-parse (connection-socket connection) name query)
-       (values)))))
-|#
+
 (defun unprepare-query (connection name)
   "Close the prepared query given by name by closing the session connection.
 Does not remove the query from the meta slot in connection"
@@ -310,8 +300,8 @@ Does not remove the query from the meta slot in connection"
       (values))))
 
 (defun exec-prepared (connection name parameters &optional (row-reader 'ignore-row-reader))
-  "Execute a previously prepared query with the given parameters,
-apply a row-reader to the result."
+  "Execute a previously prepared query with the given parameters, apply a
+row-reader to the result."
   (check-type name string)
   (check-type parameters list)
   (with-reconnect-restart connection

--- a/cl-postgres/public.lisp
+++ b/cl-postgres/public.lisp
@@ -273,7 +273,8 @@ result."
       (values))))
 
 (defun unprepare-query (connection name)
-  "Close the prepared query given by name."
+  "Close the prepared query given by name by closing the session connection.
+Does not remove the query from the meta slot in connection"
   (check-type name string)
   (with-reconnect-restart connection
     (using-connection connection

--- a/doc/cl-postgres.html
+++ b/doc/cl-postgres.html
@@ -294,6 +294,7 @@ for the JavaScript code in this tag.
 <li><a href="#orge0e3083">method database-error-query (database-error)</a></li>
 <li><a href="#orgcaf14a3">method database-error-cause (database-error)</a></li>
 <li><a href="#org721f27f">function database-error-constraint-name (database-error)</a></li>
+<li><a href="#org721f27f">function database-error-extract-name (database-error)</a></li>
 <li><a href="#orgea749ec">condition database-connection-error</a></li>
 <li><a href="#org37e5d1b">condition postgresql-notification</a></li>
 <li><a href="#orge62533e">method postgresql-notification-channel (postgresql-notification)</a></li>
@@ -1051,6 +1052,17 @@ condition.
 <p>
 For integrity-violation errors, returns the name of the constraint that was
 violated (or nil if no constraint was found.)
+</p>
+</div>
+<h3 id="">function database-error-extract-name (database-error)</h3>
+<div class="outline-text-3" id="">
+<p>
+→ string
+</p>
+
+<p>
+For various errors, returns the name provided by the error message
+ (or nil if no such name was found.)
 </p>
 </div>
 </div>

--- a/doc/cl-postgres.org
+++ b/doc/cl-postgres.org
@@ -366,6 +366,12 @@ condition.
 For integrity-violation errors, returns the name of the constraint that was
 violated (or nil if no constraint was found.)
 
+** function database-error-extract-name (database-error)
+→ string
+
+For various errors, returns the name provided by the error message
+ (or nil if no such name was found.)
+
 ** condition database-connection-error
 
 Subtype of database-error. An error of this type (or one of its subclasses)

--- a/doc/postmodern.html
+++ b/doc/postmodern.html
@@ -3,7 +3,7 @@
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 <head>
-<!-- 2018-10-07 Sun 09:22 -->
+<!-- 2018-12-02 Sun 21:42 -->
 <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Postmodern Reference Manual</title>
@@ -234,144 +234,160 @@ for the JavaScript code in this tag.
 <h2>Table of Contents</h2>
 <div id="text-table-of-contents">
 <ul>
-<li><a href="#org7dfb78b">Connecting</a>
+<li><a href="#orgf66e105">Connecting</a>
 <ul>
-<li><a href="#orga63657c">class database-connection</a></li>
-<li><a href="#org821a95f">function connect (database user password host &amp;key (port 5432) pooled-p use-ssl)</a></li>
-<li><a href="#org941ff95">variable <b>default-use-ssl</b></a></li>
-<li><a href="#orgf98dcfd">method disconnect (database-connection)</a></li>
-<li><a href="#orga071e5f">function connected-p (database-connection)</a></li>
-<li><a href="#orgd2c58d7">method reconnect (database-connection)</a></li>
-<li><a href="#org158c9c7">variable <b>database</b></a></li>
-<li><a href="#org8174608">macro with-connection (spec &amp;body body)</a></li>
-<li><a href="#org69b3ae4">macro call-with-connection (spec thunk)</a></li>
-<li><a href="#org67493b2">function connect-toplevel (database user password host &amp;key (port 5432))</a></li>
-<li><a href="#org59db24f">function disconnect-toplevel ()</a></li>
-<li><a href="#org4530e0f">function clear-connection-pool ()</a></li>
-<li><a href="#org2687ef0">variable <b>max-pool-size</b></a></li>
-<li><a href="#org612e14c">function list-connections ()</a></li>
+<li><a href="#org34e37cb">class database-connection</a></li>
+<li><a href="#org2599f48">function connect (database user password host &amp;key (port 5432) pooled-p use-ssl)</a></li>
+<li><a href="#org1873a98">variable <b>default-use-ssl</b></a></li>
+<li><a href="#org411ab4f">method disconnect (database-connection)</a></li>
+<li><a href="#orga7c92e9">function connected-p (database-connection)</a></li>
+<li><a href="#org431b6b2">method reconnect (database-connection)</a></li>
+<li><a href="#org8b8ed8c">variable <b>database</b></a></li>
+<li><a href="#orga735780">macro with-connection (spec &amp;body body)</a></li>
+<li><a href="#org067ca14">macro call-with-connection (spec thunk)</a></li>
+<li><a href="#orgc862d91">function connect-toplevel (database user password host &amp;key (port 5432))</a></li>
+<li><a href="#orge5c0fe9">function disconnect-toplevel ()</a></li>
+<li><a href="#org3b24d01">function clear-connection-pool ()</a></li>
+<li><a href="#org2c9b24f">variable <b>max-pool-size</b></a></li>
+<li><a href="#org62d76d7">function list-connections ()</a></li>
 </ul>
 </li>
-<li><a href="#org80773b7">Querying</a>
+<li><a href="#org22b6458">Querying</a>
 <ul>
-<li><a href="#orge14b0be">macro query (query &amp;rest args/format)</a></li>
-<li><a href="#org142947e">macro execute (query &amp;rest args)</a></li>
-<li><a href="#org52903ad">macro doquery (query (&amp;rest names) &amp;body body)</a></li>
-<li><a href="#org5b799fd">macro prepare (query &amp;optional (format :rows))</a></li>
-<li><a href="#org0d5aefd">macro defprepared (name query &amp;optional (format :rows))</a></li>
-<li><a href="#orgde9a7b1">macro defprepared-with-names (name (&amp;rest args) (query &amp;rest query-args) &amp;optional (format :rows))</a></li>
-<li><a href="#org93a26a3">macro with-transaction ((&amp;optional name isolation-level) &amp;body body)</a></li>
-<li><a href="#org7231d7b">function commit-transaction (transaction)</a></li>
-<li><a href="#orge81fb52">function abort-transaction (transaction)</a></li>
-<li><a href="#org75fb86e">macro with-savepoint (name &amp;body body)</a></li>
-<li><a href="#orgb5e832a">function release-savepoint (savepoint)</a></li>
-<li><a href="#org4e16a77">function rollback-savepoint (savepoint)</a></li>
-<li><a href="#orged76165">function commit-hooks (transaction-or-savepoint), setf (commit-hooks transaction-or-savepoint)</a></li>
-<li><a href="#org8daf98c">function abort-hooks (transaction-or-savepoint), setf (abort-hooks transaction-or-savepoint)</a></li>
-<li><a href="#org6f623d3">macro with-logical-transaction ((&amp;optional name isolation-level) &amp;body body)</a></li>
-<li><a href="#org33a9c80">function abort-logical-transaction (transaction-or-savepoint)</a></li>
-<li><a href="#org6c6e7c7">function commit-logical-transaction (transaction-or-savepoint)</a></li>
-<li><a href="#org291bf07">variable <b>current-logical-transaction</b></a></li>
-<li><a href="#orgfd6b1c7">macro ensure-transaction (&amp;body body)</a></li>
-<li><a href="#org2b3281a">macro with-schema ((namespace &amp;key :strict t :if-not-exist :create :drop-after) &amp;body body)</a></li>
-<li><a href="#org791a215">function sequence-next (sequence)</a></li>
-<li><a href="#orgf57413a">function coalesce (&amp;rest arguments)</a></li>
+<li><a href="#org237f749">macro query (query &amp;rest args/format)</a></li>
+<li><a href="#org29b2aca">macro execute (query &amp;rest args)</a></li>
+<li><a href="#orgae66984">macro doquery (query (&amp;rest names) &amp;body body)</a></li>
+<li><a href="#org82051a3">macro prepare (query &amp;optional (format :rows))</a></li>
+<li><a href="#orgdefdde9">macro defprepared (name query &amp;optional (format :rows))</a></li>
+<li><a href="#org9bafcb6">macro defprepared-with-names (name (&amp;rest args) (query &amp;rest query-args) &amp;optional (format :rows))</a></li>
+<li><a href="#orgc9a5ce2">macro with-transaction ((&amp;optional name isolation-level) &amp;body body)</a></li>
+<li><a href="#org7694a92">function commit-transaction (transaction)</a></li>
+<li><a href="#org19a0ecc">function abort-transaction (transaction)</a></li>
+<li><a href="#orgc3f5567">macro with-savepoint (name &amp;body body)</a></li>
+<li><a href="#org3d07197">function release-savepoint (savepoint)</a></li>
+<li><a href="#org2100928">function rollback-savepoint (savepoint)</a></li>
+<li><a href="#org1a014bb">function commit-hooks (transaction-or-savepoint), setf (commit-hooks transaction-or-savepoint)</a></li>
+<li><a href="#org674dd51">function abort-hooks (transaction-or-savepoint), setf (abort-hooks transaction-or-savepoint)</a></li>
+<li><a href="#org3457278">macro with-logical-transaction ((&amp;optional name isolation-level) &amp;body body)</a></li>
+<li><a href="#org35b31e1">function abort-logical-transaction (transaction-or-savepoint)</a></li>
+<li><a href="#orgd16e9ff">function commit-logical-transaction (transaction-or-savepoint)</a></li>
+<li><a href="#org54ff3d0">variable <b>current-logical-transaction</b></a></li>
+<li><a href="#org12026bb">macro ensure-transaction (&amp;body body)</a></li>
+<li><a href="#orgccb4e38">macro with-schema ((namespace &amp;key :strict t :if-not-exist :create :drop-after) &amp;body body)</a></li>
+<li><a href="#org97963e6">function sequence-next (sequence)</a></li>
+<li><a href="#org11d4bb2">function coalesce (&amp;rest arguments)</a></li>
 </ul>
 </li>
-<li><a href="#org26769df">Inspecting the database</a>
+<li><a href="#orgdbfe01c">Helper functions for Prepared Statements</a>
 <ul>
-<li><a href="#orgd322176">function list-tables (&amp;optional strings-p)</a></li>
-<li><a href="#orga08ec84">function list-tables-in-schema (&amp;optional strings-p)</a></li>
-<li><a href="#org13296a5">function table-exists-p (name)</a></li>
-<li><a href="#org8e04ed0">function table-description (name &amp;optional schema-name)</a></li>
-<li><a href="#org06c5d40">function list-sequences (&amp;optional strings-p)</a></li>
-<li><a href="#orgf676cb8">function sequence-exists-p (name)</a></li>
-<li><a href="#org1b8655d">function list-views (&amp;optional strings-p)</a></li>
-<li><a href="#org3e46672">function view-exists-p (name)</a></li>
-<li><a href="#orgcf3d5d7">function list-schemata ()</a></li>
-<li><a href="#org2dfd8dd">function schema-exist-p (schema) NOW DEPRECATED IN FAVOR OF schema-exists-p which is more consistent with naming of other functions.</a></li>
-<li><a href="#org03ba99f">function schema-exists-p (schema)</a></li>
-<li><a href="#org76675e8">function database-version ()</a></li>
-<li><a href="#orgc06d5ac">function num-records-in-database ()</a></li>
-<li><a href="#org7a44810">function current-database ()</a></li>
-<li><a href="#org7ed9671">function database-exists-p (database-name)</a></li>
-<li><a href="#org08b4b57">function database-size (&amp;optional database-name)</a></li>
-<li><a href="#org73f5fc2">function list-databases (&amp;key (order-by-size nil) (size t))</a></li>
-<li><a href="#orgacb0cf3">function list-schemas ()</a></li>
-<li><a href="#org4eda1b1">function list-tablespaces ()</a></li>
-<li><a href="#org55bbdf0">function list-available-types ()</a></li>
-<li><a href="#orgdd097b2">function list-table-sizes (&amp;key (schema "public") (order-by-size nil) (size t))</a></li>
-<li><a href="#orgb5a656c">function table-size (table-name)</a></li>
-<li><a href="#org0bae73e">function more-table-info (table-name)</a></li>
-<li><a href="#org599bc78">function list-columns (table-name)</a></li>
-<li><a href="#org3c51a57">function list-columns-with-types (table-name)</a></li>
-<li><a href="#org859a984">function column-exists-p (table-name column-name)</a></li>
-<li><a href="#org3708a2d">function describe-views (&amp;optional (schema "public")</a></li>
-<li><a href="#org081137b">function list-database-functions ()</a></li>
-<li><a href="#org6ee5c4b">function list-indices (&amp;optional strings-p)</a></li>
-<li><a href="#orgc37a008">function list-table-indices (table-name &amp;optional strings-p)</a></li>
-<li><a href="#org642b2ed">function index-exists-p (name)</a></li>
-<li><a href="#org49151df">function list-indexed-column-and-attributes (table-name)</a></li>
-<li><a href="#org3512b6e">function list-index-definitions (table-name)</a></li>
-<li><a href="#org90e958c">function find-primary-key-info (table-name &amp;optional (just-key nil))</a></li>
-<li><a href="#org84abae1">function list-foreign-keys (table-name)</a></li>
-<li><a href="#orgae78241">function list-unique-or-primary-constraints (table-name)</a></li>
-<li><a href="#orgadeff0c">function list-all-constraints (table-name)</a></li>
-<li><a href="#org08e7036">function describe-constraint (table-name constraint-name)</a></li>
-<li><a href="#org5b723fb">function describe-foreign-key-constraints ()</a></li>
-<li><a href="#org45c066b">function list-triggers (&amp;optional table-name)</a></li>
-<li><a href="#orge052147">function list-detailed-triggers ()</a></li>
-<li><a href="#org255eb0c">function list-database-users ()</a></li>
-<li><a href="#org2a52736">function list-available-extensions ()</a></li>
-<li><a href="#org8795eb4">function list-installed-extensions ()</a></li>
-<li><a href="#org7ae9179">function change-toplevel-database (new-database user password host)</a></li>
+<li><a href="#orga8b063f">function prepared-statement-exists-p (name)</a></li>
+<li><a href="#org4481499">function list-prepared-statements()</a></li>
+<li><a href="#orgbb3d460">function drop-prepared-statement (statement-name &amp;key (location :both) (database <b>database</b>))</a></li>
+<li><a href="#orgd0cfaff">function list-postmodern-prepared-statements (&amp;optional (names-only nil))</a></li>
+<li><a href="#org5774eb3">function find-postgresql-prepared-statement (name)</a></li>
+<li><a href="#org33f703f">function find-postmodern-prepared-statement (name)</a></li>
+<li><a href="#org2a05d5f">function reset-prepared-statement (condition)</a></li>
+<li><a href="#org5ede7d6">function overwrite-prepared-statement (condition)</a></li>
+<li><a href="#orgab31aeb">function get-pid ()</a></li>
+<li><a href="#org6a503be">function get-pid-from-postmodern ()</a></li>
+<li><a href="#orgf1bbc04">function cancel-backend (pid)</a></li>
+<li><a href="#org80deb98">function terminate-backend (pid)</a></li>
 </ul>
 </li>
-<li><a href="#org05d41fe">Database access objects</a>
+<li><a href="#org10d1208">Inspecting the database</a>
 <ul>
-<li><a href="#org2167fd0">metaclass dao-class</a></li>
-<li><a href="#org7062ca8">method dao-keys (class)</a></li>
-<li><a href="#orgb4cb6ea">method dao-keys (dao)</a></li>
-<li><a href="#org155944b">method dao-exists-p (dao)</a></li>
-<li><a href="#orga5eaaa8">method make-dao (type &amp;rest args &amp;key &amp;allow-other-keys)</a></li>
-<li><a href="#orgb413e74">macro define-dao-finalization (((dao-name class) &amp;rest keyword-args) &amp;body body)</a></li>
-<li><a href="#orgf1c832d">method get-dao (type &amp;rest keys)</a></li>
-<li><a href="#orgda16e4e">macro select-dao (type &amp;optional (test t) &amp;rest sort)</a></li>
-<li><a href="#org3a1c3d4">macro do-select-dao (((type type-var) &amp;optional (test t) &amp;rest sort) &amp;body body)</a></li>
-<li><a href="#orge8a667c">macro query-dao (type query &amp;rest args)</a></li>
-<li><a href="#orgfdae6ee">function do-query-dao (((type type-var) query &amp;rest args) &amp;body body)</a></li>
-<li><a href="#orgf8ae586">variable <b>ignore-unknown-columns</b></a></li>
-<li><a href="#org2f657bb">method insert-dao (dao)</a></li>
-<li><a href="#orged00616">method update-dao (dao)</a></li>
-<li><a href="#org4157b73">function save-dao (dao)</a></li>
-<li><a href="#org0e6d5d2">function save-dao/transaction (dao)</a></li>
-<li><a href="#orgb3bae9a">method upsert-dao (dao)</a></li>
-<li><a href="#org3ea645d">method delete-dao (dao)</a></li>
-<li><a href="#org2a00107">function dao-table-name (class)</a></li>
-<li><a href="#orgd40cdef">function dao-table-definition (class)</a></li>
-<li><a href="#orgc476df2">macro with-column-writers ((&amp;rest writers) &amp;body body)</a></li>
+<li><a href="#org8fddc62">function list-tables (&amp;optional strings-p)</a></li>
+<li><a href="#orgdca6607">function list-tables-in-schema (&amp;optional strings-p)</a></li>
+<li><a href="#org74138e3">function table-exists-p (name)</a></li>
+<li><a href="#orgbad33e6">function table-description (name &amp;optional schema-name)</a></li>
+<li><a href="#orgc2eef12">function list-sequences (&amp;optional strings-p)</a></li>
+<li><a href="#org660e7ae">function sequence-exists-p (name)</a></li>
+<li><a href="#org2a4608e">function list-views (&amp;optional strings-p)</a></li>
+<li><a href="#orgb34e5aa">function view-exists-p (name)</a></li>
+<li><a href="#orga2172c1">function list-schemata ()</a></li>
+<li><a href="#orgb5e1283">function schema-exist-p (schema) NOW DEPRECATED IN FAVOR OF schema-exists-p which is more consistent with naming of other functions.</a></li>
+<li><a href="#org6639ae3">function schema-exists-p (schema)</a></li>
+<li><a href="#org6bca315">function database-version ()</a></li>
+<li><a href="#org0911489">function num-records-in-database ()</a></li>
+<li><a href="#org25b904d">function current-database ()</a></li>
+<li><a href="#org40e3952">function database-exists-p (database-name)</a></li>
+<li><a href="#org9e1497f">function database-size (&amp;optional database-name)</a></li>
+<li><a href="#orge79193a">function list-databases (&amp;key (order-by-size nil) (size t))</a></li>
+<li><a href="#org7e815cc">function list-schemas ()</a></li>
+<li><a href="#orgcbe1dc2">function list-tablespaces ()</a></li>
+<li><a href="#org8e5bc67">function list-available-types ()</a></li>
+<li><a href="#org237b868">function list-table-sizes (&amp;key (schema "public") (order-by-size nil) (size t))</a></li>
+<li><a href="#org0a067c7">function table-size (table-name)</a></li>
+<li><a href="#orgbcb7bff">function more-table-info (table-name)</a></li>
+<li><a href="#org280fbb0">function list-columns (table-name)</a></li>
+<li><a href="#orgcbba043">function list-columns-with-types (table-name)</a></li>
+<li><a href="#org635750e">function column-exists-p (table-name column-name)</a></li>
+<li><a href="#orgbf64476">function describe-views (&amp;optional (schema "public")</a></li>
+<li><a href="#org740d461">function list-database-functions ()</a></li>
+<li><a href="#org652957e">function list-indices (&amp;optional strings-p)</a></li>
+<li><a href="#org2858574">function list-table-indices (table-name &amp;optional strings-p)</a></li>
+<li><a href="#org5a5d422">function index-exists-p (name)</a></li>
+<li><a href="#orge8a15b6">function list-indexed-column-and-attributes (table-name)</a></li>
+<li><a href="#org89f148b">function list-index-definitions (table-name)</a></li>
+<li><a href="#orgeada611">function find-primary-key-info (table-name &amp;optional (just-key nil))</a></li>
+<li><a href="#org24325c9">function list-foreign-keys (table-name)</a></li>
+<li><a href="#orgdcea10c">function list-unique-or-primary-constraints (table-name)</a></li>
+<li><a href="#org61cc6ea">function list-all-constraints (table-name)</a></li>
+<li><a href="#org19eb477">function describe-constraint (table-name constraint-name)</a></li>
+<li><a href="#org7e2c10b">function describe-foreign-key-constraints ()</a></li>
+<li><a href="#org8d54386">function list-triggers (&amp;optional table-name)</a></li>
+<li><a href="#org67eac16">function list-detailed-triggers ()</a></li>
+<li><a href="#org0168937">function list-database-users ()</a></li>
+<li><a href="#org0f8fdad">function list-available-extensions ()</a></li>
+<li><a href="#org61a1133">function list-installed-extensions ()</a></li>
+<li><a href="#orgccaa0d4">function change-toplevel-database (new-database user password host)</a></li>
 </ul>
 </li>
-<li><a href="#org7b386e0">Table definition and creation</a>
+<li><a href="#orgd97efd3">Database access objects</a>
 <ul>
-<li><a href="#org35f071b">macro deftable (name &amp;body definition)</a></li>
-<li><a href="#orgbf03822">function !dao-def ()</a></li>
-<li><a href="#org19622a3">function !index (&amp;rest columns), !unique-index (&amp;rest columns)</a></li>
-<li><a href="#org2d93b97">function !foreign (target-table columns &amp;optional target-columns &amp;key on-delete on-update deferrable initially-deferred)</a></li>
-<li><a href="#orgb288681">function !unique (target-fields &amp;key deferrable initially-deferred)</a></li>
-<li><a href="#orga0bef91">function create-table (symbol)</a></li>
-<li><a href="#orga7a15fc">function create-all-tables ()</a></li>
-<li><a href="#orgaaeca8f">function create-package-tables (package)</a></li>
-<li><a href="#org6aeb940">variables <b>table-name</b>, <b>table-symbol</b></a></li>
+<li><a href="#org3e7d292">metaclass dao-class</a></li>
+<li><a href="#orgc7123a9">method dao-keys (class)</a></li>
+<li><a href="#org3c6db0c">method dao-keys (dao)</a></li>
+<li><a href="#org27e1e0f">method dao-exists-p (dao)</a></li>
+<li><a href="#orga61b131">method make-dao (type &amp;rest args &amp;key &amp;allow-other-keys)</a></li>
+<li><a href="#orgb3ef560">macro define-dao-finalization (((dao-name class) &amp;rest keyword-args) &amp;body body)</a></li>
+<li><a href="#orgce7d413">method get-dao (type &amp;rest keys)</a></li>
+<li><a href="#org5acd26e">macro select-dao (type &amp;optional (test t) &amp;rest sort)</a></li>
+<li><a href="#orgae8d7f2">macro do-select-dao (((type type-var) &amp;optional (test t) &amp;rest sort) &amp;body body)</a></li>
+<li><a href="#org057bc79">macro query-dao (type query &amp;rest args)</a></li>
+<li><a href="#orgb46a620">function do-query-dao (((type type-var) query &amp;rest args) &amp;body body)</a></li>
+<li><a href="#orgc548f24">variable <b>ignore-unknown-columns</b></a></li>
+<li><a href="#orgd50b062">method insert-dao (dao)</a></li>
+<li><a href="#org12447ba">method update-dao (dao)</a></li>
+<li><a href="#org7e41df1">function save-dao (dao)</a></li>
+<li><a href="#org87f82a4">function save-dao/transaction (dao)</a></li>
+<li><a href="#org1c078c7">method upsert-dao (dao)</a></li>
+<li><a href="#orgec5b546">method delete-dao (dao)</a></li>
+<li><a href="#orge1dec5a">function dao-table-name (class)</a></li>
+<li><a href="#orgb0a7d53">function dao-table-definition (class)</a></li>
+<li><a href="#org0a62e5e">macro with-column-writers ((&amp;rest writers) &amp;body body)</a></li>
 </ul>
 </li>
-<li><a href="#org046928e">Schemata</a>
+<li><a href="#orgeed3abc">Table definition and creation</a>
 <ul>
-<li><a href="#orga59a991">function create-schema (schema)</a></li>
-<li><a href="#org17d1a35">function drop-schema (schema)</a></li>
-<li><a href="#orge4e3a1e">function get-search-path ()</a></li>
-<li><a href="#orgbf702ed">function set-search-path (path)</a></li>
-<li><a href="#org10e8075">function split-fully-qualified-table-name (name)</a></li>
+<li><a href="#orgbda5696">macro deftable (name &amp;body definition)</a></li>
+<li><a href="#orge7e4389">function !dao-def ()</a></li>
+<li><a href="#orga2c4bf6">function !index (&amp;rest columns), !unique-index (&amp;rest columns)</a></li>
+<li><a href="#org6097983">function !foreign (target-table columns &amp;optional target-columns &amp;key on-delete on-update deferrable initially-deferred)</a></li>
+<li><a href="#org62be441">function !unique (target-fields &amp;key deferrable initially-deferred)</a></li>
+<li><a href="#orga931660">function create-table (symbol)</a></li>
+<li><a href="#orge480d8a">function create-all-tables ()</a></li>
+<li><a href="#orgdd79715">function create-package-tables (package)</a></li>
+<li><a href="#orgfd826c0">variables <b>table-name</b>, <b>table-symbol</b></a></li>
+</ul>
+</li>
+<li><a href="#org26dbf4a">Schemata</a>
+<ul>
+<li><a href="#org90fd2a6">function create-schema (schema)</a></li>
+<li><a href="#orgf2a0940">function drop-schema (schema)</a></li>
+<li><a href="#org8bc0bc9">function get-search-path ()</a></li>
+<li><a href="#org515af3e">function set-search-path (path)</a></li>
+<li><a href="#org42dfec3">function split-fully-qualified-table-name (name)</a></li>
 </ul>
 </li>
 </ul>
@@ -396,23 +412,22 @@ raised as subtypes of database-connection-error, providing a :reconnect
 restart to re-try the operation that encountered to the error.
 </p>
 
-
-<div id="outline-container-org7dfb78b" class="outline-2">
-<h2 id="org7dfb78b">Connecting</h2>
-<div class="outline-text-2" id="text-org7dfb78b">
+<div id="outline-container-orgf66e105" class="outline-2">
+<h2 id="orgf66e105">Connecting</h2>
+<div class="outline-text-2" id="text-orgf66e105">
 </div>
-<div id="outline-container-orga63657c" class="outline-3">
-<h3 id="orga63657c">class database-connection</h3>
-<div class="outline-text-3" id="text-orga63657c">
+<div id="outline-container-org34e37cb" class="outline-3">
+<h3 id="org34e37cb">class database-connection</h3>
+<div class="outline-text-3" id="text-org34e37cb">
 <p>
 Objects of this type represent database connections.
 </p>
 </div>
 </div>
 
-<div id="outline-container-org821a95f" class="outline-3">
-<h3 id="org821a95f">function connect (database user password host &amp;key (port 5432) pooled-p use-ssl)</h3>
-<div class="outline-text-3" id="text-org821a95f">
+<div id="outline-container-org2599f48" class="outline-3">
+<h3 id="org2599f48">function connect (database user password host &amp;key (port 5432) pooled-p use-ssl)</h3>
+<div class="outline-text-3" id="text-org2599f48">
 <p>
 → database-connection
 </p>
@@ -429,9 +444,9 @@ of <b>default-use-ssl</b>.
 </div>
 </div>
 
-<div id="outline-container-org941ff95" class="outline-3">
-<h3 id="org941ff95">variable <b>default-use-ssl</b></h3>
-<div class="outline-text-3" id="text-org941ff95">
+<div id="outline-container-org1873a98" class="outline-3">
+<h3 id="org1873a98">variable <b>default-use-ssl</b></h3>
+<div class="outline-text-3" id="text-org1873a98">
 <p>
 The default for connect's use-ssl argument. This starts at :no. If you
 set it to anything else, be sure to also load the CL+SSL library.
@@ -439,9 +454,9 @@ set it to anything else, be sure to also load the CL+SSL library.
 </div>
 </div>
 
-<div id="outline-container-orgf98dcfd" class="outline-3">
-<h3 id="orgf98dcfd">method disconnect (database-connection)</h3>
-<div class="outline-text-3" id="text-orgf98dcfd">
+<div id="outline-container-org411ab4f" class="outline-3">
+<h3 id="org411ab4f">method disconnect (database-connection)</h3>
+<div class="outline-text-3" id="text-org411ab4f">
 <p>
 Disconnects a normal database connection, or moves a pooled connection
 into the pool.
@@ -449,9 +464,9 @@ into the pool.
 </div>
 </div>
 
-<div id="outline-container-orga071e5f" class="outline-3">
-<h3 id="orga071e5f">function connected-p (database-connection)</h3>
-<div class="outline-text-3" id="text-orga071e5f">
+<div id="outline-container-orga7c92e9" class="outline-3">
+<h3 id="orga7c92e9">function connected-p (database-connection)</h3>
+<div class="outline-text-3" id="text-orga7c92e9">
 <p>
 → boolean
 </p>
@@ -463,9 +478,9 @@ to the server.
 </div>
 </div>
 
-<div id="outline-container-orgd2c58d7" class="outline-3">
-<h3 id="orgd2c58d7">method reconnect (database-connection)</h3>
-<div class="outline-text-3" id="text-orgd2c58d7">
+<div id="outline-container-org431b6b2" class="outline-3">
+<h3 id="org431b6b2">method reconnect (database-connection)</h3>
+<div class="outline-text-3" id="text-org431b6b2">
 <p>
 Reconnect a disconnected database connection. This is not allowed for pooled
 connections ― after they are disconnected they might be in use by some other
@@ -474,9 +489,9 @@ process, and should no longer be used.
 </div>
 </div>
 
-<div id="outline-container-org158c9c7" class="outline-3">
-<h3 id="org158c9c7">variable <b>database</b></h3>
-<div class="outline-text-3" id="text-org158c9c7">
+<div id="outline-container-org8b8ed8c" class="outline-3">
+<h3 id="org8b8ed8c">variable <b>database</b></h3>
+<div class="outline-text-3" id="text-org8b8ed8c">
 <p>
 Special variable holding the current database. Most functions and macros
 operating on a database assume this binds to a connected database.
@@ -484,9 +499,9 @@ operating on a database assume this binds to a connected database.
 </div>
 </div>
 
-<div id="outline-container-org8174608" class="outline-3">
-<h3 id="org8174608">macro with-connection (spec &amp;body body)</h3>
-<div class="outline-text-3" id="text-org8174608">
+<div id="outline-container-orga735780" class="outline-3">
+<h3 id="orga735780">macro with-connection (spec &amp;body body)</h3>
+<div class="outline-text-3" id="text-orga735780">
 <p>
 Evaluates the body with <b>database</b> bound to a connection as specified by
 spec, which should be list that connect can be applied to.
@@ -494,9 +509,9 @@ spec, which should be list that connect can be applied to.
 </div>
 </div>
 
-<div id="outline-container-org69b3ae4" class="outline-3">
-<h3 id="org69b3ae4">macro call-with-connection (spec thunk)</h3>
-<div class="outline-text-3" id="text-org69b3ae4">
+<div id="outline-container-org067ca14" class="outline-3">
+<h3 id="org067ca14">macro call-with-connection (spec thunk)</h3>
+<div class="outline-text-3" id="text-org067ca14">
 <p>
 The functional backend to with-connection. Binds <b>database</b> to a new
 connection as specified by spec, which should be a list that connect can
@@ -507,9 +522,9 @@ connection is disconnected.
 </div>
 </div>
 
-<div id="outline-container-org67493b2" class="outline-3">
-<h3 id="org67493b2">function connect-toplevel (database user password host &amp;key (port 5432))</h3>
-<div class="outline-text-3" id="text-org67493b2">
+<div id="outline-container-orgc862d91" class="outline-3">
+<h3 id="orgc862d91">function connect-toplevel (database user password host &amp;key (port 5432))</h3>
+<div class="outline-text-3" id="text-orgc862d91">
 <p>
 Bind the <b>database</b> to a new connection. Use this if you only need one
 connection, or if you want a connection for debugging from the REPL.
@@ -517,27 +532,27 @@ connection, or if you want a connection for debugging from the REPL.
 </div>
 </div>
 
-<div id="outline-container-org59db24f" class="outline-3">
-<h3 id="org59db24f">function disconnect-toplevel ()</h3>
-<div class="outline-text-3" id="text-org59db24f">
+<div id="outline-container-orge5c0fe9" class="outline-3">
+<h3 id="orge5c0fe9">function disconnect-toplevel ()</h3>
+<div class="outline-text-3" id="text-orge5c0fe9">
 <p>
 Disconnect the <b>database</b>.
 </p>
 </div>
 </div>
 
-<div id="outline-container-org4530e0f" class="outline-3">
-<h3 id="org4530e0f">function clear-connection-pool ()</h3>
-<div class="outline-text-3" id="text-org4530e0f">
+<div id="outline-container-org3b24d01" class="outline-3">
+<h3 id="org3b24d01">function clear-connection-pool ()</h3>
+<div class="outline-text-3" id="text-org3b24d01">
 <p>
 Disconnect and remove all connections from the connection pools.
 </p>
 </div>
 </div>
 
-<div id="outline-container-org2687ef0" class="outline-3">
-<h3 id="org2687ef0">variable <b>max-pool-size</b></h3>
-<div class="outline-text-3" id="text-org2687ef0">
+<div id="outline-container-org2c9b24f" class="outline-3">
+<h3 id="org2c9b24f">variable <b>max-pool-size</b></h3>
+<div class="outline-text-3" id="text-org2c9b24f">
 <p>
 Set the maximum amount of connections kept in a single connection pool, where
 a pool consists of all the stored connections with the exact same connect
@@ -546,9 +561,9 @@ arguments. Defaults to NIL, which means there is no maximum.
 </div>
 </div>
 
-<div id="outline-container-org612e14c" class="outline-3">
-<h3 id="org612e14c">function list-connections ()</h3>
-<div class="outline-text-3" id="text-org612e14c">
+<div id="outline-container-org62d76d7" class="outline-3">
+<h3 id="org62d76d7">function list-connections ()</h3>
+<div class="outline-text-3" id="text-org62d76d7">
 <p>
 → list
 </p>
@@ -559,13 +574,13 @@ List the current postgresql connections to the currently connected database.
 </div>
 </div>
 </div>
-<div id="outline-container-org80773b7" class="outline-2">
-<h2 id="org80773b7">Querying</h2>
-<div class="outline-text-2" id="text-org80773b7">
+<div id="outline-container-org22b6458" class="outline-2">
+<h2 id="org22b6458">Querying</h2>
+<div class="outline-text-2" id="text-org22b6458">
 </div>
-<div id="outline-container-orge14b0be" class="outline-3">
-<h3 id="orge14b0be">macro query (query &amp;rest args/format)</h3>
-<div class="outline-text-3" id="text-orge14b0be">
+<div id="outline-container-org237f749" class="outline-3">
+<h3 id="org237f749">macro query (query &amp;rest args/format)</h3>
+<div class="outline-text-3" id="text-org237f749">
 <p>
 → result
 </p>
@@ -667,9 +682,9 @@ such as with updating or deleting queries, this is returned as a second value.
 </div>
 </div>
 
-<div id="outline-container-org142947e" class="outline-3">
-<h3 id="org142947e">macro execute (query &amp;rest args)</h3>
-<div class="outline-text-3" id="text-org142947e">
+<div id="outline-container-org29b2aca" class="outline-3">
+<h3 id="org29b2aca">macro execute (query &amp;rest args)</h3>
+<div class="outline-text-3" id="text-org29b2aca">
 <p>
 Like query called with format :none. Returns the amount of affected rows as
 its first returned value. (Also returns this amount as the second returned
@@ -678,9 +693,9 @@ value, but use of this is deprecated.)
 </div>
 </div>
 
-<div id="outline-container-org52903ad" class="outline-3">
-<h3 id="org52903ad">macro doquery (query (&amp;rest names) &amp;body body)</h3>
-<div class="outline-text-3" id="text-org52903ad">
+<div id="outline-container-orgae66984" class="outline-3">
+<h3 id="orgae66984">macro doquery (query (&amp;rest names) &amp;body body)</h3>
+<div class="outline-text-3" id="text-orgae66984">
 <p>
 Execute the given query (a string or a list starting with a keyword),
 iterating over the rows in the result. The body will be executed with the
@@ -699,9 +714,9 @@ whose cdr contains the arguments. For example:
 </div>
 </div>
 
-<div id="outline-container-org5b799fd" class="outline-3">
-<h3 id="org5b799fd">macro prepare (query &amp;optional (format :rows))</h3>
-<div class="outline-text-3" id="text-org5b799fd">
+<div id="outline-container-org82051a3" class="outline-3">
+<h3 id="org82051a3">macro prepare (query &amp;optional (format :rows))</h3>
+<div class="outline-text-3" id="text-org82051a3">
 <p>
 → function
 </p>
@@ -729,19 +744,24 @@ historical :: syntax, or with S-SQL's :type construct) to help it out.
 </div>
 </div>
 
-<div id="outline-container-org0d5aefd" class="outline-3">
-<h3 id="org0d5aefd">macro defprepared (name query &amp;optional (format :rows))</h3>
-<div class="outline-text-3" id="text-org0d5aefd">
+<div id="outline-container-orgdefdde9" class="outline-3">
+<h3 id="orgdefdde9">macro defprepared (name query &amp;optional (format :rows))</h3>
+<div class="outline-text-3" id="text-orgdefdde9">
 <p>
-This is the defun-style variant of prepare. It will define a top-level
-function for the prepared statement.
+→ function
+</p>
+
+<p>
+This is the macro-style variant of prepare. It is like prepare, but gives
+the function a name which now becomes a top-level function for the
+prepared statement. The name should not be quoted or a string.
 </p>
 </div>
 </div>
 
-<div id="outline-container-orgde9a7b1" class="outline-3">
-<h3 id="orgde9a7b1">macro defprepared-with-names (name (&amp;rest args) (query &amp;rest query-args) &amp;optional (format :rows))</h3>
-<div class="outline-text-3" id="text-orgde9a7b1">
+<div id="outline-container-org9bafcb6" class="outline-3">
+<h3 id="org9bafcb6">macro defprepared-with-names (name (&amp;rest args) (query &amp;rest query-args) &amp;optional (format :rows))</h3>
+<div class="outline-text-3" id="text-org9bafcb6">
 <p>
 Like defprepared, but allows to specify names of the function arguments as
 well as arguments supplied to the query.
@@ -758,9 +778,9 @@ well as arguments supplied to the query.
 </div>
 </div>
 
-<div id="outline-container-org93a26a3" class="outline-3">
-<h3 id="org93a26a3">macro with-transaction ((&amp;optional name isolation-level) &amp;body body)</h3>
-<div class="outline-text-3" id="text-org93a26a3">
+<div id="outline-container-orgc9a5ce2" class="outline-3">
+<h3 id="orgc9a5ce2">macro with-transaction ((&amp;optional name isolation-level) &amp;body body)</h3>
+<div class="outline-text-3" id="text-orgc9a5ce2">
 <p>
 Execute the given body within a database transaction, committing it when the
 body exits normally, and aborting otherwise. An optional name and/or
@@ -813,27 +833,27 @@ Further discussion of transactions and isolation levels can found
 </div>
 </div>
 
-<div id="outline-container-org7231d7b" class="outline-3">
-<h3 id="org7231d7b">function commit-transaction (transaction)</h3>
-<div class="outline-text-3" id="text-org7231d7b">
+<div id="outline-container-org7694a92" class="outline-3">
+<h3 id="org7694a92">function commit-transaction (transaction)</h3>
+<div class="outline-text-3" id="text-org7694a92">
 <p>
 Commit the given transaction.
 </p>
 </div>
 </div>
 
-<div id="outline-container-orge81fb52" class="outline-3">
-<h3 id="orge81fb52">function abort-transaction (transaction)</h3>
-<div class="outline-text-3" id="text-orge81fb52">
+<div id="outline-container-org19a0ecc" class="outline-3">
+<h3 id="org19a0ecc">function abort-transaction (transaction)</h3>
+<div class="outline-text-3" id="text-org19a0ecc">
 <p>
 Roll back the given transaction.
 </p>
 </div>
 </div>
 
-<div id="outline-container-org75fb86e" class="outline-3">
-<h3 id="org75fb86e">macro with-savepoint (name &amp;body body)</h3>
-<div class="outline-text-3" id="text-org75fb86e">
+<div id="outline-container-orgc3f5567" class="outline-3">
+<h3 id="orgc3f5567">macro with-savepoint (name &amp;body body)</h3>
+<div class="outline-text-3" id="text-orgc3f5567">
 <p>
 Can only be used within a transaction. Establishes a savepoint with the given
 name at the start of body, and binds the same name to a handle for that
@@ -843,27 +863,27 @@ condition is thrown, in which case it is rolled back.
 </div>
 </div>
 
-<div id="outline-container-orgb5e832a" class="outline-3">
-<h3 id="orgb5e832a">function release-savepoint (savepoint)</h3>
-<div class="outline-text-3" id="text-orgb5e832a">
+<div id="outline-container-org3d07197" class="outline-3">
+<h3 id="org3d07197">function release-savepoint (savepoint)</h3>
+<div class="outline-text-3" id="text-org3d07197">
 <p>
 Release the given savepoint.
 </p>
 </div>
 </div>
 
-<div id="outline-container-org4e16a77" class="outline-3">
-<h3 id="org4e16a77">function rollback-savepoint (savepoint)</h3>
-<div class="outline-text-3" id="text-org4e16a77">
+<div id="outline-container-org2100928" class="outline-3">
+<h3 id="org2100928">function rollback-savepoint (savepoint)</h3>
+<div class="outline-text-3" id="text-org2100928">
 <p>
 Roll back the given savepoint.
 </p>
 </div>
 </div>
 
-<div id="outline-container-orged76165" class="outline-3">
-<h3 id="orged76165">function commit-hooks (transaction-or-savepoint), setf (commit-hooks transaction-or-savepoint)</h3>
-<div class="outline-text-3" id="text-orged76165">
+<div id="outline-container-org1a014bb" class="outline-3">
+<h3 id="org1a014bb">function commit-hooks (transaction-or-savepoint), setf (commit-hooks transaction-or-savepoint)</h3>
+<div class="outline-text-3" id="text-org1a014bb">
 <p>
 An accessor for the transaction or savepoint's list of commit hooks, each of
 which should be a function with no required arguments. These functions will
@@ -872,9 +892,9 @@ be executed when a transaction is committed or a savepoint released.
 </div>
 </div>
 
-<div id="outline-container-org8daf98c" class="outline-3">
-<h3 id="org8daf98c">function abort-hooks (transaction-or-savepoint), setf (abort-hooks transaction-or-savepoint)</h3>
-<div class="outline-text-3" id="text-org8daf98c">
+<div id="outline-container-org674dd51" class="outline-3">
+<h3 id="org674dd51">function abort-hooks (transaction-or-savepoint), setf (abort-hooks transaction-or-savepoint)</h3>
+<div class="outline-text-3" id="text-org674dd51">
 <p>
 An accessor for the transaction or savepoint's list of abort hooks, each of
 which should be a function with no required arguments. These functions will
@@ -885,9 +905,9 @@ abort-transaction or rollback-savepoint).
 </div>
 </div>
 
-<div id="outline-container-org6f623d3" class="outline-3">
-<h3 id="org6f623d3">macro with-logical-transaction ((&amp;optional name isolation-level) &amp;body body)</h3>
-<div class="outline-text-3" id="text-org6f623d3">
+<div id="outline-container-org3457278" class="outline-3">
+<h3 id="org3457278">macro with-logical-transaction ((&amp;optional name isolation-level) &amp;body body)</h3>
+<div class="outline-text-3" id="text-org3457278">
 <p>
 Executes body within a with-transaction form if no transaction is currently
 in progress, otherwise simulates a nested transaction by executing it
@@ -934,9 +954,9 @@ expected here:
 </div>
 </div>
 
-<div id="outline-container-org33a9c80" class="outline-3">
-<h3 id="org33a9c80">function abort-logical-transaction (transaction-or-savepoint)</h3>
-<div class="outline-text-3" id="text-org33a9c80">
+<div id="outline-container-org35b31e1" class="outline-3">
+<h3 id="org35b31e1">function abort-logical-transaction (transaction-or-savepoint)</h3>
+<div class="outline-text-3" id="text-org35b31e1">
 <p>
 Roll back the given logical transaction, regardless of whether it is an
 actual transaction or a savepoint.
@@ -944,9 +964,9 @@ actual transaction or a savepoint.
 </div>
 </div>
 
-<div id="outline-container-org6c6e7c7" class="outline-3">
-<h3 id="org6c6e7c7">function commit-logical-transaction (transaction-or-savepoint)</h3>
-<div class="outline-text-3" id="text-org6c6e7c7">
+<div id="outline-container-orgd16e9ff" class="outline-3">
+<h3 id="orgd16e9ff">function commit-logical-transaction (transaction-or-savepoint)</h3>
+<div class="outline-text-3" id="text-orgd16e9ff">
 <p>
 Commit the given logical transaction, regardless of whether it is an
 actual transaction or a savepoint.
@@ -954,9 +974,9 @@ actual transaction or a savepoint.
 </div>
 </div>
 
-<div id="outline-container-org291bf07" class="outline-3">
-<h3 id="org291bf07">variable <b>current-logical-transaction</b></h3>
-<div class="outline-text-3" id="text-org291bf07">
+<div id="outline-container-org54ff3d0" class="outline-3">
+<h3 id="org54ff3d0">variable <b>current-logical-transaction</b></h3>
+<div class="outline-text-3" id="text-org54ff3d0">
 <p>
 This is bound to the current transaction-handle or savepoint-handle instance
 representing the innermost open logical transaction.
@@ -964,9 +984,9 @@ representing the innermost open logical transaction.
 </div>
 </div>
 
-<div id="outline-container-orgfd6b1c7" class="outline-3">
-<h3 id="orgfd6b1c7">macro ensure-transaction (&amp;body body)</h3>
-<div class="outline-text-3" id="text-orgfd6b1c7">
+<div id="outline-container-org12026bb" class="outline-3">
+<h3 id="org12026bb">macro ensure-transaction (&amp;body body)</h3>
+<div class="outline-text-3" id="text-org12026bb">
 <p>
 Ensures that body is executed within a transaction, but does not begin a
 new transaction if one is already in progress.
@@ -974,9 +994,9 @@ new transaction if one is already in progress.
 </div>
 </div>
 
-<div id="outline-container-org2b3281a" class="outline-3">
-<h3 id="org2b3281a">macro with-schema ((namespace &amp;key :strict t :if-not-exist :create :drop-after) &amp;body body)</h3>
-<div class="outline-text-3" id="text-org2b3281a">
+<div id="outline-container-orgccb4e38" class="outline-3">
+<h3 id="orgccb4e38">macro with-schema ((namespace &amp;key :strict t :if-not-exist :create :drop-after) &amp;body body)</h3>
+<div class="outline-text-3" id="text-orgccb4e38">
 <p>
 Sets the current schema to namespace and executes the body. Before executing
 body the PostgreSQL's session variable search_path is set to the given
@@ -990,9 +1010,9 @@ namespace is dropped from the database after the body execution.
 </div>
 </div>
 
-<div id="outline-container-org791a215" class="outline-3">
-<h3 id="org791a215">function sequence-next (sequence)</h3>
-<div class="outline-text-3" id="text-org791a215">
+<div id="outline-container-org97963e6" class="outline-3">
+<h3 id="org97963e6">function sequence-next (sequence)</h3>
+<div class="outline-text-3" id="text-org97963e6">
 <p>
 → integer
 </p>
@@ -1005,9 +1025,9 @@ according to S-SQL rules.
 </div>
 </div>
 
-<div id="outline-container-orgf57413a" class="outline-3">
-<h3 id="orgf57413a">function coalesce (&amp;rest arguments)</h3>
-<div class="outline-text-3" id="text-orgf57413a">
+<div id="outline-container-org11d4bb2" class="outline-3">
+<h3 id="org11d4bb2">function coalesce (&amp;rest arguments)</h3>
+<div class="outline-text-3" id="text-org11d4bb2">
 <p>
 → value
 </p>
@@ -1021,13 +1041,190 @@ when given only one argument, for transforming :nulls to NIL.
 </div>
 </div>
 
-<div id="outline-container-org26769df" class="outline-2">
-<h2 id="org26769df">Inspecting the database</h2>
-<div class="outline-text-2" id="text-org26769df">
+
+<div id="outline-container-orgdbfe01c" class="outline-2">
+<h2 id="orgdbfe01c">Helper functions for Prepared Statements</h2>
+<div class="outline-text-2" id="text-orgdbfe01c">
 </div>
-<div id="outline-container-orgd322176" class="outline-3">
-<h3 id="orgd322176">function list-tables (&amp;optional strings-p)</h3>
-<div class="outline-text-3" id="text-orgd322176">
+<div id="outline-container-orga8b063f" class="outline-3">
+<h3 id="orga8b063f">function prepared-statement-exists-p (name)</h3>
+<div class="outline-text-3" id="text-orga8b063f">
+<p>
+→ boolean
+This returns t if the prepared statement exists in the current
+postgresql session, otherwise nil.
+</p>
+</div>
+</div>
+
+<div id="outline-container-org4481499" class="outline-3">
+<h3 id="org4481499">function list-prepared-statements()</h3>
+<div class="outline-text-3" id="text-org4481499">
+<p>
+→ list
+</p>
+
+<p>
+This is syntactic sugar. It runs a query that lists the prepared statements in
+the session in which the function is run.
+</p>
+</div>
+</div>
+
+<div id="outline-container-orgbb3d460" class="outline-3">
+<h3 id="orgbb3d460">function drop-prepared-statement (statement-name &amp;key (location :both) (database <b>database</b>))</h3>
+<div class="outline-text-3" id="text-orgbb3d460">
+<p>
+Prepared statements are stored both in the meta slot in the postmodern
+connection and in postgresql session information. If you know the prepared
+statement name, you can delete the prepared statement from both locations (the
+default behavior), just from postmodern (passing :postmodern to the location
+key parameter) or just from postgresql (passing :postgresql to the location
+key parameter). If you pass the name 'All' as the statement name, it will
+delete all prepared statements.
+</p>
+</div>
+</div>
+
+<div id="outline-container-orgd0cfaff" class="outline-3">
+<h3 id="orgd0cfaff">function list-postmodern-prepared-statements (&amp;optional (names-only nil))</h3>
+<div class="outline-text-3" id="text-orgd0cfaff">
+<p>
+→ list
+</p>
+
+<p>
+List the prepared statements that postmodern has put in the meta slot in
+the connection. It will return a list of alists of form:
+  ((:NAME . \"SNY24\")
+  (:STATEMENT . \"(SELECT name, salary FROM employee WHERE (city = $1))\")
+  (:PREPARE-TIME . #&lt;TIMESTAMP 25-11-2018T15:36:43,385&gt;)
+  (:PARAMETER-TYPES . \"{text}\") (:FROM-SQL)
+</p>
+
+<p>
+If the names-only parameter is set to t, it will only return a list of
+the names of the prepared statements.
+</p>
+</div>
+</div>
+
+<div id="outline-container-org5774eb3" class="outline-3">
+<h3 id="org5774eb3">function find-postgresql-prepared-statement (name)</h3>
+<div class="outline-text-3" id="text-org5774eb3">
+<p>
+→ string
+</p>
+
+<p>
+Returns the specified named prepared statement (if any) that postgresql has for this
+session.
+</p>
+</div>
+</div>
+
+<div id="outline-container-org33f703f" class="outline-3">
+<h3 id="org33f703f">function find-postmodern-prepared-statement (name)</h3>
+<div class="outline-text-3" id="text-org33f703f">
+<p>
+→ string
+</p>
+
+<p>
+Returns the specified named prepared statement (if any) that postmodern has
+put in the meta slot in the connection. Note that this is the statement itself,
+not the name.
+</p>
+</div>
+</div>
+
+<div id="outline-container-org2a05d5f" class="outline-3">
+<h3 id="org2a05d5f">function reset-prepared-statement (condition)</h3>
+<div class="outline-text-3" id="text-org2a05d5f">
+<p>
+→ restart
+</p>
+
+<p>
+If you have received an invalid-prepared-statement error but the prepared
+statement is still in the meta slot in the postmodern connection, this will
+try to regenerate the prepared statement at the database connection level
+and restart the connection.
+</p>
+</div>
+</div>
+
+<div id="outline-container-org5ede7d6" class="outline-3">
+<h3 id="org5ede7d6">function overwrite-prepared-statement (condition)</h3>
+<div class="outline-text-3" id="text-org5ede7d6">
+<p>
+→ restart
+</p>
+
+<p>
+If you have received an invalid-prepared-statement error but the prepared
+statement is still in the meta slot in the postmodern connection,
+this will try to regenerate the prepared statement at the database
+connection level and restart the connection.
+</p>
+</div>
+</div>
+
+<div id="outline-container-orgab31aeb" class="outline-3">
+<h3 id="orgab31aeb">function get-pid ()</h3>
+<div class="outline-text-3" id="text-orgab31aeb">
+<p>
+→ integer
+</p>
+
+<p>
+Get the process id used by postgresql for this connection.
+</p>
+</div>
+</div>
+
+<div id="outline-container-org6a503be" class="outline-3">
+<h3 id="org6a503be">function get-pid-from-postmodern ()</h3>
+<div class="outline-text-3" id="text-org6a503be">
+<p>
+→ integer
+</p>
+
+<p>
+Get the process id used by postgresql for this connection,
+but get it from the postmodern connection parameters.
+</p>
+</div>
+</div>
+
+<div id="outline-container-orgf1bbc04" class="outline-3">
+<h3 id="orgf1bbc04">function cancel-backend (pid)</h3>
+<div class="outline-text-3" id="text-orgf1bbc04">
+<p>
+Polite way of terminating a query at the database (as opposed to calling close-database).
+Slower than (terminate-backend pid) and does not always work.
+</p>
+</div>
+</div>
+
+<div id="outline-container-org80deb98" class="outline-3">
+<h3 id="org80deb98">function terminate-backend (pid)</h3>
+<div class="outline-text-3" id="text-org80deb98">
+<p>
+Less polite way of terminating at the database (as opposed to calling close-database).
+Faster than (cancel-backend pid) and more reliable.
+</p>
+</div>
+</div>
+</div>
+
+<div id="outline-container-org10d1208" class="outline-2">
+<h2 id="org10d1208">Inspecting the database</h2>
+<div class="outline-text-2" id="text-org10d1208">
+</div>
+<div id="outline-container-org8fddc62" class="outline-3">
+<h3 id="org8fddc62">function list-tables (&amp;optional strings-p)</h3>
+<div class="outline-text-3" id="text-org8fddc62">
 <p>
 → list
 </p>
@@ -1039,9 +1236,9 @@ the names will be given as strings, otherwise as keywords.
 </div>
 </div>
 
-<div id="outline-container-orga08ec84" class="outline-3">
-<h3 id="orga08ec84">function list-tables-in-schema (&amp;optional strings-p)</h3>
-<div class="outline-text-3" id="text-orga08ec84">
+<div id="outline-container-orgdca6607" class="outline-3">
+<h3 id="orgdca6607">function list-tables-in-schema (&amp;optional strings-p)</h3>
+<div class="outline-text-3" id="text-orgdca6607">
 <p>
 → list
 </p>
@@ -1052,9 +1249,9 @@ When strings-p is T,the names will be given as strings, otherwise as keywords.
 </p>
 </div>
 </div>
-<div id="outline-container-org13296a5" class="outline-3">
-<h3 id="org13296a5">function table-exists-p (name)</h3>
-<div class="outline-text-3" id="text-org13296a5">
+<div id="outline-container-org74138e3" class="outline-3">
+<h3 id="org74138e3">function table-exists-p (name)</h3>
+<div class="outline-text-3" id="text-org74138e3">
 <p>
 → boolean
 </p>
@@ -1067,9 +1264,9 @@ or 'database.schema.table
 </div>
 </div>
 
-<div id="outline-container-org8e04ed0" class="outline-3">
-<h3 id="org8e04ed0">function table-description (name &amp;optional schema-name)</h3>
-<div class="outline-text-3" id="text-org8e04ed0">
+<div id="outline-container-orgbad33e6" class="outline-3">
+<h3 id="orgbad33e6">function table-description (name &amp;optional schema-name)</h3>
+<div class="outline-text-3" id="text-orgbad33e6">
 <p>
 → list
 </p>
@@ -1084,9 +1281,9 @@ the table are returned, regardless of their schema.
 </div>
 </div>
 
-<div id="outline-container-org06c5d40" class="outline-3">
-<h3 id="org06c5d40">function list-sequences (&amp;optional strings-p)</h3>
-<div class="outline-text-3" id="text-org06c5d40">
+<div id="outline-container-orgc2eef12" class="outline-3">
+<h3 id="orgc2eef12">function list-sequences (&amp;optional strings-p)</h3>
+<div class="outline-text-3" id="text-orgc2eef12">
 <p>
 → list
 </p>
@@ -1098,9 +1295,9 @@ the names will be given as strings, otherwise as keywords.
 </div>
 </div>
 
-<div id="outline-container-orgf676cb8" class="outline-3">
-<h3 id="orgf676cb8">function sequence-exists-p (name)</h3>
-<div class="outline-text-3" id="text-orgf676cb8">
+<div id="outline-container-org660e7ae" class="outline-3">
+<h3 id="org660e7ae">function sequence-exists-p (name)</h3>
+<div class="outline-text-3" id="text-org660e7ae">
 <p>
 → boolean
 </p>
@@ -1112,9 +1309,9 @@ string or a symbol.
 </div>
 </div>
 
-<div id="outline-container-org1b8655d" class="outline-3">
-<h3 id="org1b8655d">function list-views (&amp;optional strings-p)</h3>
-<div class="outline-text-3" id="text-org1b8655d">
+<div id="outline-container-org2a4608e" class="outline-3">
+<h3 id="org2a4608e">function list-views (&amp;optional strings-p)</h3>
+<div class="outline-text-3" id="text-org2a4608e">
 <p>
 → list
 </p>
@@ -1126,9 +1323,9 @@ is T, the names will be returned as strings, otherwise as keywords.
 </div>
 </div>
 
-<div id="outline-container-org3e46672" class="outline-3">
-<h3 id="org3e46672">function view-exists-p (name)</h3>
-<div class="outline-text-3" id="text-org3e46672">
+<div id="outline-container-orgb34e5aa" class="outline-3">
+<h3 id="orgb34e5aa">function view-exists-p (name)</h3>
+<div class="outline-text-3" id="text-orgb34e5aa">
 <p>
 → boolean
 </p>
@@ -1140,9 +1337,9 @@ string or a symbol.
 </div>
 </div>
 
-<div id="outline-container-orgcf3d5d7" class="outline-3">
-<h3 id="orgcf3d5d7">function list-schemata ()</h3>
-<div class="outline-text-3" id="text-orgcf3d5d7">
+<div id="outline-container-orga2172c1" class="outline-3">
+<h3 id="orga2172c1">function list-schemata ()</h3>
+<div class="outline-text-3" id="text-orga2172c1">
 <p>
 → list
 </p>
@@ -1154,9 +1351,9 @@ existing schemata.
 </div>
 </div>
 
-<div id="outline-container-org2dfd8dd" class="outline-3">
-<h3 id="org2dfd8dd">function schema-exist-p (schema) NOW DEPRECATED IN FAVOR OF schema-exists-p which is more consistent with naming of other functions.</h3>
-<div class="outline-text-3" id="text-org2dfd8dd">
+<div id="outline-container-orgb5e1283" class="outline-3">
+<h3 id="orgb5e1283">function schema-exist-p (schema) NOW DEPRECATED IN FAVOR OF schema-exists-p which is more consistent with naming of other functions.</h3>
+<div class="outline-text-3" id="text-orgb5e1283">
 <p>
 → boolean
 </p>
@@ -1168,9 +1365,9 @@ otherwise.
 </div>
 </div>
 
-<div id="outline-container-org03ba99f" class="outline-3">
-<h3 id="org03ba99f">function schema-exists-p (schema)</h3>
-<div class="outline-text-3" id="text-org03ba99f">
+<div id="outline-container-org6639ae3" class="outline-3">
+<h3 id="org6639ae3">function schema-exists-p (schema)</h3>
+<div class="outline-text-3" id="text-org6639ae3">
 <p>
 → boolean
 </p>
@@ -1182,9 +1379,9 @@ otherwise.
 </div>
 </div>
 
-<div id="outline-container-org76675e8" class="outline-3">
-<h3 id="org76675e8">function database-version ()</h3>
-<div class="outline-text-3" id="text-org76675e8">
+<div id="outline-container-org6bca315" class="outline-3">
+<h3 id="org6bca315">function database-version ()</h3>
+<div class="outline-text-3" id="text-org6bca315">
 <p>
 → string
 </p>
@@ -1195,9 +1392,9 @@ Returns the version of the current postgresql database.
 </div>
 </div>
 
-<div id="outline-container-orgc06d5ac" class="outline-3">
-<h3 id="orgc06d5ac">function num-records-in-database ()</h3>
-<div class="outline-text-3" id="text-orgc06d5ac">
+<div id="outline-container-org0911489" class="outline-3">
+<h3 id="org0911489">function num-records-in-database ()</h3>
+<div class="outline-text-3" id="text-org0911489">
 <p>
 → list
 </p>
@@ -1209,9 +1406,9 @@ records in the currently connected database.
 </div>
 </div>
 
-<div id="outline-container-org7a44810" class="outline-3">
-<h3 id="org7a44810">function current-database ()</h3>
-<div class="outline-text-3" id="text-org7a44810">
+<div id="outline-container-org25b904d" class="outline-3">
+<h3 id="org25b904d">function current-database ()</h3>
+<div class="outline-text-3" id="text-org25b904d">
 <p>
 → string
 </p>
@@ -1222,9 +1419,9 @@ Returns the string name of the current database.
 </div>
 </div>
 
-<div id="outline-container-org7ed9671" class="outline-3">
-<h3 id="org7ed9671">function database-exists-p (database-name)</h3>
-<div class="outline-text-3" id="text-org7ed9671">
+<div id="outline-container-org40e3952" class="outline-3">
+<h3 id="org40e3952">function database-exists-p (database-name)</h3>
+<div class="outline-text-3" id="text-org40e3952">
 <p>
 → boolean
 </p>
@@ -1235,9 +1432,9 @@ Checks to see if a particular database exists.
 </div>
 </div>
 
-<div id="outline-container-org08b4b57" class="outline-3">
-<h3 id="org08b4b57">function database-size (&amp;optional database-name)</h3>
-<div class="outline-text-3" id="text-org08b4b57">
+<div id="outline-container-org9e1497f" class="outline-3">
+<h3 id="org9e1497f">function database-size (&amp;optional database-name)</h3>
+<div class="outline-text-3" id="text-org9e1497f">
 <p>
 → list
 </p>
@@ -1250,9 +1447,9 @@ provided, it will return the result for the currently connected database.
 </div>
 </div>
 
-<div id="outline-container-org73f5fc2" class="outline-3">
-<h3 id="org73f5fc2">function list-databases (&amp;key (order-by-size nil) (size t))</h3>
-<div class="outline-text-3" id="text-org73f5fc2">
+<div id="outline-container-orge79193a" class="outline-3">
+<h3 id="orge79193a">function list-databases (&amp;key (order-by-size nil) (size t))</h3>
+<div class="outline-text-3" id="text-orge79193a">
 <p>
 → list
 </p>
@@ -1267,9 +1464,9 @@ in a single list ordered by name. This function excludes the template databases
 </div>
 </div>
 
-<div id="outline-container-orgacb0cf3" class="outline-3">
-<h3 id="orgacb0cf3">function list-schemas ()</h3>
-<div class="outline-text-3" id="text-orgacb0cf3">
+<div id="outline-container-org7e815cc" class="outline-3">
+<h3 id="org7e815cc">function list-schemas ()</h3>
+<div class="outline-text-3" id="text-org7e815cc">
 <p>
 → list
 </p>
@@ -1280,9 +1477,9 @@ List schemas in the current database, excluding the pg_* system schemas.
 </div>
 </div>
 
-<div id="outline-container-org4eda1b1" class="outline-3">
-<h3 id="org4eda1b1">function list-tablespaces ()</h3>
-<div class="outline-text-3" id="text-org4eda1b1">
+<div id="outline-container-orgcbe1dc2" class="outline-3">
+<h3 id="orgcbe1dc2">function list-tablespaces ()</h3>
+<div class="outline-text-3" id="text-orgcbe1dc2">
 <p>
 → list
 </p>
@@ -1293,9 +1490,9 @@ Lists the tablespaces in the currently connected database.
 </div>
 </div>
 
-<div id="outline-container-org55bbdf0" class="outline-3">
-<h3 id="org55bbdf0">function list-available-types ()</h3>
-<div class="outline-text-3" id="text-org55bbdf0">
+<div id="outline-container-org8e5bc67" class="outline-3">
+<h3 id="org8e5bc67">function list-available-types ()</h3>
+<div class="outline-text-3" id="text-org8e5bc67">
 <p>
 → list
 </p>
@@ -1306,9 +1503,9 @@ List the available types in this postgresql version.
 </div>
 </div>
 
-<div id="outline-container-orgdd097b2" class="outline-3">
-<h3 id="orgdd097b2">function list-table-sizes (&amp;key (schema "public") (order-by-size nil) (size t))</h3>
-<div class="outline-text-3" id="text-orgdd097b2">
+<div id="outline-container-org237b868" class="outline-3">
+<h3 id="org237b868">function list-table-sizes (&amp;key (schema "public") (order-by-size nil) (size t))</h3>
+<div class="outline-text-3" id="text-org237b868">
 <p>
 → list
 </p>
@@ -1326,9 +1523,9 @@ result in order of size instead of by table name.
 </div>
 </div>
 
-<div id="outline-container-orgb5a656c" class="outline-3">
-<h3 id="orgb5a656c">function table-size (table-name)</h3>
-<div class="outline-text-3" id="text-orgb5a656c">
+<div id="outline-container-org0a067c7" class="outline-3">
+<h3 id="org0a067c7">function table-size (table-name)</h3>
+<div class="outline-text-3" id="text-org0a067c7">
 <p>
 → list
 </p>
@@ -1340,9 +1537,9 @@ string or quoted.
 </div>
 </div>
 
-<div id="outline-container-org0bae73e" class="outline-3">
-<h3 id="org0bae73e">function more-table-info (table-name)</h3>
-<div class="outline-text-3" id="text-org0bae73e">
+<div id="outline-container-orgbcb7bff" class="outline-3">
+<h3 id="orgbcb7bff">function more-table-info (table-name)</h3>
+<div class="outline-text-3" id="text-orgbcb7bff">
 <p>
 → list
 </p>
@@ -1354,9 +1551,9 @@ or quoted.
 </div>
 </div>
 
-<div id="outline-container-org599bc78" class="outline-3">
-<h3 id="org599bc78">function list-columns (table-name)</h3>
-<div class="outline-text-3" id="text-org599bc78">
+<div id="outline-container-org280fbb0" class="outline-3">
+<h3 id="org280fbb0">function list-columns (table-name)</h3>
+<div class="outline-text-3" id="text-org280fbb0">
 <p>
 → list
 </p>
@@ -1368,9 +1565,9 @@ from the postmodern table-description function rather than directly.
 </div>
 </div>
 
-<div id="outline-container-org3c51a57" class="outline-3">
-<h3 id="org3c51a57">function list-columns-with-types (table-name)</h3>
-<div class="outline-text-3" id="text-org3c51a57">
+<div id="outline-container-orgcbba043" class="outline-3">
+<h3 id="orgcbba043">function list-columns-with-types (table-name)</h3>
+<div class="outline-text-3" id="text-orgcbba043">
 <p>
 → list
 </p>
@@ -1382,9 +1579,9 @@ to the pg-catalog tables.
 </div>
 </div>
 
-<div id="outline-container-org859a984" class="outline-3">
-<h3 id="org859a984">function column-exists-p (table-name column-name)</h3>
-<div class="outline-text-3" id="text-org859a984">
+<div id="outline-container-org635750e" class="outline-3">
+<h3 id="org635750e">function column-exists-p (table-name column-name)</h3>
+<div class="outline-text-3" id="text-org635750e">
 <p>
 → boolean
 </p>
@@ -1396,9 +1593,9 @@ either strings or symbols.
 </div>
 </div>
 
-<div id="outline-container-org3708a2d" class="outline-3">
-<h3 id="org3708a2d">function describe-views (&amp;optional (schema "public")</h3>
-<div class="outline-text-3" id="text-org3708a2d">
+<div id="outline-container-orgbf64476" class="outline-3">
+<h3 id="orgbf64476">function describe-views (&amp;optional (schema "public")</h3>
+<div class="outline-text-3" id="text-orgbf64476">
 <p>
 → list
 </p>
@@ -1409,9 +1606,9 @@ Describe the current views in the specified schema. Defaults to public schema.
 </div>
 </div>
 
-<div id="outline-container-org081137b" class="outline-3">
-<h3 id="org081137b">function list-database-functions ()</h3>
-<div class="outline-text-3" id="text-org081137b">
+<div id="outline-container-org740d461" class="outline-3">
+<h3 id="org740d461">function list-database-functions ()</h3>
+<div class="outline-text-3" id="text-org740d461">
 <p>
 → list
 </p>
@@ -1422,9 +1619,9 @@ Returns a list of the functions in the database from the information_schema.
 </div>
 </div>
 
-<div id="outline-container-org6ee5c4b" class="outline-3">
-<h3 id="org6ee5c4b">function list-indices (&amp;optional strings-p)</h3>
-<div class="outline-text-3" id="text-org6ee5c4b">
+<div id="outline-container-org652957e" class="outline-3">
+<h3 id="org652957e">function list-indices (&amp;optional strings-p)</h3>
+<div class="outline-text-3" id="text-org652957e">
 <p>
 → list
 </p>
@@ -1436,9 +1633,9 @@ strings-p is not true.
 </div>
 </div>
 
-<div id="outline-container-orgc37a008" class="outline-3">
-<h3 id="orgc37a008">function list-table-indices (table-name &amp;optional strings-p)</h3>
-<div class="outline-text-3" id="text-orgc37a008">
+<div id="outline-container-org2858574" class="outline-3">
+<h3 id="org2858574">function list-table-indices (table-name &amp;optional strings-p)</h3>
+<div class="outline-text-3" id="text-org2858574">
 <p>
 → list
 </p>
@@ -1449,9 +1646,9 @@ List the index names and the related columns in a table.
 </div>
 </div>
 
-<div id="outline-container-org642b2ed" class="outline-3">
-<h3 id="org642b2ed">function index-exists-p (name)</h3>
-<div class="outline-text-3" id="text-org642b2ed">
+<div id="outline-container-org5a5d422" class="outline-3">
+<h3 id="org5a5d422">function index-exists-p (name)</h3>
+<div class="outline-text-3" id="text-org5a5d422">
 <p>
 → boolean
 </p>
@@ -1463,9 +1660,9 @@ string or a symbol.
 </div>
 </div>
 
-<div id="outline-container-org49151df" class="outline-3">
-<h3 id="org49151df">function list-indexed-column-and-attributes (table-name)</h3>
-<div class="outline-text-3" id="text-org49151df">
+<div id="outline-container-orge8a15b6" class="outline-3">
+<h3 id="orge8a15b6">function list-indexed-column-and-attributes (table-name)</h3>
+<div class="outline-text-3" id="text-orge8a15b6">
 <p>
 → list
 </p>
@@ -1477,9 +1674,9 @@ key.
 </div>
 </div>
 
-<div id="outline-container-org3512b6e" class="outline-3">
-<h3 id="org3512b6e">function list-index-definitions (table-name)</h3>
-<div class="outline-text-3" id="text-org3512b6e">
+<div id="outline-container-org89f148b" class="outline-3">
+<h3 id="org89f148b">function list-index-definitions (table-name)</h3>
+<div class="outline-text-3" id="text-org89f148b">
 <p>
 → list
 </p>
@@ -1491,9 +1688,9 @@ the table
 </div>
 </div>
 
-<div id="outline-container-org90e958c" class="outline-3">
-<h3 id="org90e958c">function find-primary-key-info (table-name &amp;optional (just-key nil))</h3>
-<div class="outline-text-3" id="text-org90e958c">
+<div id="outline-container-orgeada611" class="outline-3">
+<h3 id="orgeada611">function find-primary-key-info (table-name &amp;optional (just-key nil))</h3>
+<div class="outline-text-3" id="text-orgeada611">
 <p>
 → list
 </p>
@@ -1507,9 +1704,9 @@ primary key as a string.
 </div>
 </div>
 
-<div id="outline-container-org84abae1" class="outline-3">
-<h3 id="org84abae1">function list-foreign-keys (table-name)</h3>
-<div class="outline-text-3" id="text-org84abae1">
+<div id="outline-container-org24325c9" class="outline-3">
+<h3 id="org24325c9">function list-foreign-keys (table-name)</h3>
+<div class="outline-text-3" id="text-org24325c9">
 <p>
 → list
 </p>
@@ -1522,9 +1719,9 @@ Returns a list of sublists of foreign key info in the form of
 </div>
 </div>
 
-<div id="outline-container-orgae78241" class="outline-3">
-<h3 id="orgae78241">function list-unique-or-primary-constraints (table-name)</h3>
-<div class="outline-text-3" id="text-orgae78241">
+<div id="outline-container-orgdcea10c" class="outline-3">
+<h3 id="orgdcea10c">function list-unique-or-primary-constraints (table-name)</h3>
+<div class="outline-text-3" id="text-orgdcea10c">
 <p>
 → list
 </p>
@@ -1535,9 +1732,9 @@ List constraints on a table.
 </div>
 </div>
 
-<div id="outline-container-orgadeff0c" class="outline-3">
-<h3 id="orgadeff0c">function list-all-constraints (table-name)</h3>
-<div class="outline-text-3" id="text-orgadeff0c">
+<div id="outline-container-org61cc6ea" class="outline-3">
+<h3 id="org61cc6ea">function list-all-constraints (table-name)</h3>
+<div class="outline-text-3" id="text-org61cc6ea">
 <p>
 → list
 </p>
@@ -1549,9 +1746,9 @@ can be either a string or quoted.
 </div>
 </div>
 
-<div id="outline-container-org08e7036" class="outline-3">
-<h3 id="org08e7036">function describe-constraint (table-name constraint-name)</h3>
-<div class="outline-text-3" id="text-org08e7036">
+<div id="outline-container-org19eb477" class="outline-3">
+<h3 id="org19eb477">function describe-constraint (table-name constraint-name)</h3>
+<div class="outline-text-3" id="text-org19eb477">
 <p>
 → list
 </p>
@@ -1563,9 +1760,9 @@ the table-name and the constraint name using the information_schema table.
 </div>
 </div>
 
-<div id="outline-container-org5b723fb" class="outline-3">
-<h3 id="org5b723fb">function describe-foreign-key-constraints ()</h3>
-<div class="outline-text-3" id="text-org5b723fb">
+<div id="outline-container-org7e2c10b" class="outline-3">
+<h3 id="org7e2c10b">function describe-foreign-key-constraints ()</h3>
+<div class="outline-text-3" id="text-org7e2c10b">
 <p>
 → list
 </p>
@@ -1576,9 +1773,9 @@ Generates a list of lists of information on the foreign key constraints
 </div>
 </div>
 
-<div id="outline-container-org45c066b" class="outline-3">
-<h3 id="org45c066b">function list-triggers (&amp;optional table-name)</h3>
-<div class="outline-text-3" id="text-org45c066b">
+<div id="outline-container-org8d54386" class="outline-3">
+<h3 id="org8d54386">function list-triggers (&amp;optional table-name)</h3>
+<div class="outline-text-3" id="text-org8d54386">
 <p>
 → list
 </p>
@@ -1590,9 +1787,9 @@ can be either quoted or string.
 </div>
 </div>
 
-<div id="outline-container-orge052147" class="outline-3">
-<h3 id="orge052147">function list-detailed-triggers ()</h3>
-<div class="outline-text-3" id="text-orge052147">
+<div id="outline-container-org67eac16" class="outline-3">
+<h3 id="org67eac16">function list-detailed-triggers ()</h3>
+<div class="outline-text-3" id="text-org67eac16">
 <p>
 → list
 </p>
@@ -1603,9 +1800,9 @@ List detailed information on the triggers from the information_schema table.
 </div>
 </div>
 
-<div id="outline-container-org255eb0c" class="outline-3">
-<h3 id="org255eb0c">function list-database-users ()</h3>
-<div class="outline-text-3" id="text-org255eb0c">
+<div id="outline-container-org0168937" class="outline-3">
+<h3 id="org0168937">function list-database-users ()</h3>
+<div class="outline-text-3" id="text-org0168937">
 <p>
 → list
 </p>
@@ -1615,9 +1812,9 @@ List database users.
 </p>
 </div>
 </div>
-<div id="outline-container-org2a52736" class="outline-3">
-<h3 id="org2a52736">function list-available-extensions ()</h3>
-<div class="outline-text-3" id="text-org2a52736">
+<div id="outline-container-org0f8fdad" class="outline-3">
+<h3 id="org0f8fdad">function list-available-extensions ()</h3>
+<div class="outline-text-3" id="text-org0f8fdad">
 <p>
 → list
 </p>
@@ -1628,9 +1825,9 @@ currently connected database. The extensions may or may not be installed.
 </p>
 </div>
 </div>
-<div id="outline-container-org8795eb4" class="outline-3">
-<h3 id="org8795eb4">function list-installed-extensions ()</h3>
-<div class="outline-text-3" id="text-org8795eb4">
+<div id="outline-container-org61a1133" class="outline-3">
+<h3 id="org61a1133">function list-installed-extensions ()</h3>
+<div class="outline-text-3" id="text-org61a1133">
 <p>
 → list
 </p>
@@ -1641,9 +1838,9 @@ connected database.
 </p>
 </div>
 </div>
-<div id="outline-container-org7ae9179" class="outline-3">
-<h3 id="org7ae9179">function change-toplevel-database (new-database user password host)</h3>
-<div class="outline-text-3" id="text-org7ae9179">
+<div id="outline-container-orgccaa0d4" class="outline-3">
+<h3 id="orgccaa0d4">function change-toplevel-database (new-database user password host)</h3>
+<div class="outline-text-3" id="text-orgccaa0d4">
 <p>
 → string
 </p>
@@ -1658,9 +1855,9 @@ connected database as a string.
 </div>
 
 
-<div id="outline-container-org05d41fe" class="outline-2">
-<h2 id="org05d41fe">Database access objects</h2>
-<div class="outline-text-2" id="text-org05d41fe">
+<div id="outline-container-orgd97efd3" class="outline-2">
+<h2 id="orgd97efd3">Database access objects</h2>
+<div class="outline-text-2" id="text-orgd97efd3">
 <p>
 Postmodern contains a simple system for defining CLOS classes that
 represent rows in the database. This is not intended as a full-fledged
@@ -1670,9 +1867,9 @@ a humble SQL library like this.
 </p>
 </div>
 
-<div id="outline-container-org2167fd0" class="outline-3">
-<h3 id="org2167fd0">metaclass dao-class</h3>
-<div class="outline-text-3" id="text-org2167fd0">
+<div id="outline-container-org3e7d292" class="outline-3">
+<h3 id="org3e7d292">metaclass dao-class</h3>
+<div class="outline-text-3" id="text-org3e7d292">
 <p>
 At the heart of Postmodern's DAO system is the dao-class metaclass. It
 allows you to define classes for your database-access objects as regular
@@ -1749,9 +1946,9 @@ and specify a slot like this:
 </div>
 </div>
 
-<div id="outline-container-org7062ca8" class="outline-3">
-<h3 id="org7062ca8">method dao-keys (class)</h3>
-<div class="outline-text-3" id="text-org7062ca8">
+<div id="outline-container-orgc7123a9" class="outline-3">
+<h3 id="orgc7123a9">method dao-keys (class)</h3>
+<div class="outline-text-3" id="text-orgc7123a9">
 <p>
 → list
 </p>
@@ -1773,9 +1970,9 @@ find-primary-key-info function.
 </div>
 </div>
 
-<div id="outline-container-orgb4cb6ea" class="outline-3">
-<h3 id="orgb4cb6ea">method dao-keys (dao)</h3>
-<div class="outline-text-3" id="text-orgb4cb6ea">
+<div id="outline-container-org3c6db0c" class="outline-3">
+<h3 id="org3c6db0c">method dao-keys (dao)</h3>
+<div class="outline-text-3" id="text-org3c6db0c">
 <p>
 → list
 </p>
@@ -1786,9 +1983,9 @@ Returns list of values that are the primary key of dao.
 </div>
 </div>
 
-<div id="outline-container-org155944b" class="outline-3">
-<h3 id="org155944b">method dao-exists-p (dao)</h3>
-<div class="outline-text-3" id="text-org155944b">
+<div id="outline-container-org27e1e0f" class="outline-3">
+<h3 id="org27e1e0f">method dao-exists-p (dao)</h3>
+<div class="outline-text-3" id="text-org27e1e0f">
 <p>
 → boolean
 </p>
@@ -1801,9 +1998,9 @@ unbound.
 </div>
 </div>
 
-<div id="outline-container-orga5eaaa8" class="outline-3">
-<h3 id="orga5eaaa8">method make-dao (type &amp;rest args &amp;key &amp;allow-other-keys)</h3>
-<div class="outline-text-3" id="text-orga5eaaa8">
+<div id="outline-container-orga61b131" class="outline-3">
+<h3 id="orga61b131">method make-dao (type &amp;rest args &amp;key &amp;allow-other-keys)</h3>
+<div class="outline-text-3" id="text-orga61b131">
 <p>
 → dao
 </p>
@@ -1814,9 +2011,9 @@ Combines make-instance with insert-dao. Return the created dao.
 </div>
 </div>
 
-<div id="outline-container-orgb413e74" class="outline-3">
-<h3 id="orgb413e74">macro define-dao-finalization (((dao-name class) &amp;rest keyword-args) &amp;body body)</h3>
-<div class="outline-text-3" id="text-orgb413e74">
+<div id="outline-container-orgb3ef560" class="outline-3">
+<h3 id="orgb3ef560">macro define-dao-finalization (((dao-name class) &amp;rest keyword-args) &amp;body body)</h3>
+<div class="outline-text-3" id="text-orgb3ef560">
 <p>
 Create an :around-method for make-dao. The body is executed in a lexical
 environment where dao-name is bound to a freshly created and inserted DAO.
@@ -1827,9 +2024,9 @@ slots with the type serial, which are unknown before insert-dao.
 </div>
 </div>
 
-<div id="outline-container-orgf1c832d" class="outline-3">
-<h3 id="orgf1c832d">method get-dao (type &amp;rest keys)</h3>
-<div class="outline-text-3" id="text-orgf1c832d">
+<div id="outline-container-orgce7d413" class="outline-3">
+<h3 id="orgce7d413">method get-dao (type &amp;rest keys)</h3>
+<div class="outline-text-3" id="text-orgce7d413">
 <p>
 → dao
 </p>
@@ -1844,9 +2041,9 @@ The same goes for select-dao and query-dao.
 </div>
 </div>
 
-<div id="outline-container-orgda16e4e" class="outline-3">
-<h3 id="orgda16e4e">macro select-dao (type &amp;optional (test t) &amp;rest sort)</h3>
-<div class="outline-text-3" id="text-orgda16e4e">
+<div id="outline-container-org5acd26e" class="outline-3">
+<h3 id="org5acd26e">macro select-dao (type &amp;optional (test t) &amp;rest sort)</h3>
+<div class="outline-text-3" id="text-org5acd26e">
 <p>
 → list
 </p>
@@ -1868,9 +2065,9 @@ the result.
 </div>
 </div>
 
-<div id="outline-container-org3a1c3d4" class="outline-3">
-<h3 id="org3a1c3d4">macro do-select-dao (((type type-var) &amp;optional (test t) &amp;rest sort) &amp;body body)</h3>
-<div class="outline-text-3" id="text-org3a1c3d4">
+<div id="outline-container-orgae8d7f2" class="outline-3">
+<h3 id="orgae8d7f2">macro do-select-dao (((type type-var) &amp;optional (test t) &amp;rest sort) &amp;body body)</h3>
+<div class="outline-text-3" id="text-orgae8d7f2">
 <p>
 Like select-dao, but iterates over the results rather than returning them.
 For each matching DAO, body is evaluated with type-var bound to the DAO
@@ -1884,9 +2081,9 @@ instance.
 </div>
 </div>
 
-<div id="outline-container-orge8a667c" class="outline-3">
-<h3 id="orge8a667c">macro query-dao (type query &amp;rest args)</h3>
-<div class="outline-text-3" id="text-orge8a667c">
+<div id="outline-container-org057bc79" class="outline-3">
+<h3 id="org057bc79">macro query-dao (type query &amp;rest args)</h3>
+<div class="outline-text-3" id="text-org057bc79">
 <p>
 → list
 </p>
@@ -1901,9 +2098,9 @@ the DAO class, or be bound through with-column-writers.
 </div>
 </div>
 
-<div id="outline-container-orgfdae6ee" class="outline-3">
-<h3 id="orgfdae6ee">function do-query-dao (((type type-var) query &amp;rest args) &amp;body body)</h3>
-<div class="outline-text-3" id="text-orgfdae6ee">
+<div id="outline-container-orgb46a620" class="outline-3">
+<h3 id="orgb46a620">function do-query-dao (((type type-var) query &amp;rest args) &amp;body body)</h3>
+<div class="outline-text-3" id="text-orgb46a620">
 <p>
 → list
 </p>
@@ -1920,9 +2117,9 @@ For each matching DAO, body is evaluated with type-var bound to the instance.
 </div>
 </div>
 
-<div id="outline-container-orgf8ae586" class="outline-3">
-<h3 id="orgf8ae586">variable <b>ignore-unknown-columns</b></h3>
-<div class="outline-text-3" id="text-orgf8ae586">
+<div id="outline-container-orgc548f24" class="outline-3">
+<h3 id="orgc548f24">variable <b>ignore-unknown-columns</b></h3>
+<div class="outline-text-3" id="text-orgc548f24">
 <p>
 Normally, when get-dao, select-dao, or query-dao finds a column in the database
 that's not in the DAO class, it will raise an error. Setting this variable to
@@ -1931,9 +2128,9 @@ a non-NIL will cause it to simply ignore the unknown column.
 </div>
 </div>
 
-<div id="outline-container-org2f657bb" class="outline-3">
-<h3 id="org2f657bb">method insert-dao (dao)</h3>
-<div class="outline-text-3" id="text-org2f657bb">
+<div id="outline-container-orgd50b062" class="outline-3">
+<h3 id="orgd50b062">method insert-dao (dao)</h3>
+<div class="outline-text-3" id="text-orgd50b062">
 <p>
 → dao
 </p>
@@ -1947,9 +2144,9 @@ be failed. (This feature only works on PostgreSQL 8.2 and up.)
 </div>
 </div>
 
-<div id="outline-container-orged00616" class="outline-3">
-<h3 id="orged00616">method update-dao (dao)</h3>
-<div class="outline-text-3" id="text-orged00616">
+<div id="outline-container-org12447ba" class="outline-3">
+<h3 id="org12447ba">method update-dao (dao)</h3>
+<div class="outline-text-3" id="text-org12447ba">
 <p>
 → dao
 </p>
@@ -1962,9 +2159,9 @@ non-primary-key columns. Raises an error when no row matching the dao exists.
 </div>
 </div>
 
-<div id="outline-container-org4157b73" class="outline-3">
-<h3 id="org4157b73">function save-dao (dao)</h3>
-<div class="outline-text-3" id="text-org4157b73">
+<div id="outline-container-org7e41df1" class="outline-3">
+<h3 id="org7e41df1">function save-dao (dao)</h3>
+<div class="outline-text-3" id="text-org7e41df1">
 <p>
 → boolean
 </p>
@@ -1989,9 +2186,9 @@ See also: upsert-dao.
 </div>
 </div>
 
-<div id="outline-container-org0e6d5d2" class="outline-3">
-<h3 id="org0e6d5d2">function save-dao/transaction (dao)</h3>
-<div class="outline-text-3" id="text-org0e6d5d2">
+<div id="outline-container-org87f82a4" class="outline-3">
+<h3 id="org87f82a4">function save-dao/transaction (dao)</h3>
+<div class="outline-text-3" id="text-org87f82a4">
 <p>
 → boolean
 </p>
@@ -2007,9 +2204,9 @@ See also: upsert-dao.
 </div>
 </div>
 
-<div id="outline-container-orgb3bae9a" class="outline-3">
-<h3 id="orgb3bae9a">method upsert-dao (dao)</h3>
-<div class="outline-text-3" id="text-orgb3bae9a">
+<div id="outline-container-org1c078c7" class="outline-3">
+<h3 id="org1c078c7">method upsert-dao (dao)</h3>
+<div class="outline-text-3" id="text-org1c078c7">
 <p>
 → dao
 </p>
@@ -2056,18 +2253,18 @@ was inserted, NIL if it was updated).
 </div>
 </div>
 
-<div id="outline-container-org3ea645d" class="outline-3">
-<h3 id="org3ea645d">method delete-dao (dao)</h3>
-<div class="outline-text-3" id="text-org3ea645d">
+<div id="outline-container-orgec5b546" class="outline-3">
+<h3 id="orgec5b546">method delete-dao (dao)</h3>
+<div class="outline-text-3" id="text-orgec5b546">
 <p>
 Delete the given dao from the database.
 </p>
 </div>
 </div>
 
-<div id="outline-container-org2a00107" class="outline-3">
-<h3 id="org2a00107">function dao-table-name (class)</h3>
-<div class="outline-text-3" id="text-org2a00107">
+<div id="outline-container-orge1dec5a" class="outline-3">
+<h3 id="orge1dec5a">function dao-table-name (class)</h3>
+<div class="outline-text-3" id="text-orge1dec5a">
 <p>
 → string
 </p>
@@ -2079,9 +2276,9 @@ symbol naming such a class).
 </div>
 </div>
 
-<div id="outline-container-orgd40cdef" class="outline-3">
-<h3 id="orgd40cdef">function dao-table-definition (class)</h3>
-<div class="outline-text-3" id="text-orgd40cdef">
+<div id="outline-container-orgb0a7d53" class="outline-3">
+<h3 id="orgb0a7d53">function dao-table-definition (class)</h3>
+<div class="outline-text-3" id="text-orgb0a7d53">
 <p>
 → string
 </p>
@@ -2095,9 +2292,9 @@ own queries to add them, in which case look to s-sql's create-table function.
 </div>
 </div>
 
-<div id="outline-container-orgc476df2" class="outline-3">
-<h3 id="orgc476df2">macro with-column-writers ((&amp;rest writers) &amp;body body)</h3>
-<div class="outline-text-3" id="text-orgc476df2">
+<div id="outline-container-org0a62e5e" class="outline-3">
+<h3 id="org0a62e5e">macro with-column-writers ((&amp;rest writers) &amp;body body)</h3>
+<div class="outline-text-3" id="text-org0a62e5e">
 <p>
 Provides control over the way get-dao, select-dao, and query-dao read values
 from the database. This is not commonly needed, but can be used to reduce the
@@ -2120,9 +2317,9 @@ about the objects, and immediately store it in the new instances.
 </div>
 </div>
 
-<div id="outline-container-org7b386e0" class="outline-2">
-<h2 id="org7b386e0">Table definition and creation</h2>
-<div class="outline-text-2" id="text-org7b386e0">
+<div id="outline-container-orgeed3abc" class="outline-2">
+<h2 id="orgeed3abc">Table definition and creation</h2>
+<div class="outline-text-2" id="text-orgeed3abc">
 <p>
 It can be useful to have the SQL statements needed to build an application's
 tables available from the source code, to do things like automatically
@@ -2132,9 +2329,9 @@ in table definitions.
 </p>
 </div>
 
-<div id="outline-container-org35f071b" class="outline-3">
-<h3 id="org35f071b">macro deftable (name &amp;body definition)</h3>
-<div class="outline-text-3" id="text-org35f071b">
+<div id="outline-container-orgbda5696" class="outline-3">
+<h3 id="orgbda5696">macro deftable (name &amp;body definition)</h3>
+<div class="outline-text-3" id="text-orgbda5696">
 <p>
 Define a table. name can be either a symbol or a (symbol string) list.
 In the first case, the table name is derived from the symbol's name by
@@ -2148,9 +2345,9 @@ and then define indices on it.
 </div>
 </div>
 
-<div id="outline-container-orgbf03822" class="outline-3">
-<h3 id="orgbf03822">function !dao-def ()</h3>
-<div class="outline-text-3" id="text-orgbf03822">
+<div id="outline-container-orge7e4389" class="outline-3">
+<h3 id="orge7e4389">function !dao-def ()</h3>
+<div class="outline-text-3" id="text-orge7e4389">
 <p>
 Should only be used inside deftable's body. Adds the result of calling
 dao-table-definition on <b>table-symbol</b> to the definition.
@@ -2158,9 +2355,9 @@ dao-table-definition on <b>table-symbol</b> to the definition.
 </div>
 </div>
 
-<div id="outline-container-org19622a3" class="outline-3">
-<h3 id="org19622a3">function !index (&amp;rest columns), !unique-index (&amp;rest columns)</h3>
-<div class="outline-text-3" id="text-org19622a3">
+<div id="outline-container-orga2c4bf6" class="outline-3">
+<h3 id="orga2c4bf6">function !index (&amp;rest columns), !unique-index (&amp;rest columns)</h3>
+<div class="outline-text-3" id="text-orga2c4bf6">
 <p>
 Define an index on the table being defined. The columns can be given as
 symbols or strings.
@@ -2168,9 +2365,9 @@ symbols or strings.
 </div>
 </div>
 
-<div id="outline-container-org2d93b97" class="outline-3">
-<h3 id="org2d93b97">function !foreign (target-table columns &amp;optional target-columns &amp;key on-delete on-update deferrable initially-deferred)</h3>
-<div class="outline-text-3" id="text-org2d93b97">
+<div id="outline-container-org6097983" class="outline-3">
+<h3 id="org6097983">function !foreign (target-table columns &amp;optional target-columns &amp;key on-delete on-update deferrable initially-deferred)</h3>
+<div class="outline-text-3" id="text-org6097983">
 <p>
 Add a foreign key to the table being defined. target-table is the referenced
 table. columns is a list of column names or single name in this table, and,
@@ -2192,9 +2389,9 @@ so that they can be specified even when target-columns is not given.
 </div>
 </div>
 
-<div id="outline-container-orgb288681" class="outline-3">
-<h3 id="orgb288681">function !unique (target-fields &amp;key deferrable initially-deferred)</h3>
-<div class="outline-text-3" id="text-orgb288681">
+<div id="outline-container-org62be441" class="outline-3">
+<h3 id="org62be441">function !unique (target-fields &amp;key deferrable initially-deferred)</h3>
+<div class="outline-text-3" id="text-org62be441">
 <p>
 Constrains one or more columns to only contain unique (combinations of) values,
 with deferrable and initially-deferred defined as in !foreign
@@ -2202,36 +2399,36 @@ with deferrable and initially-deferred defined as in !foreign
 </div>
 </div>
 
-<div id="outline-container-orga0bef91" class="outline-3">
-<h3 id="orga0bef91">function create-table (symbol)</h3>
-<div class="outline-text-3" id="text-orga0bef91">
+<div id="outline-container-orga931660" class="outline-3">
+<h3 id="orga931660">function create-table (symbol)</h3>
+<div class="outline-text-3" id="text-orga931660">
 <p>
 Creates the table identified by symbol by executing all forms in its definition.
 </p>
 </div>
 </div>
 
-<div id="outline-container-orga7a15fc" class="outline-3">
-<h3 id="orga7a15fc">function create-all-tables ()</h3>
-<div class="outline-text-3" id="text-orga7a15fc">
+<div id="outline-container-orge480d8a" class="outline-3">
+<h3 id="orge480d8a">function create-all-tables ()</h3>
+<div class="outline-text-3" id="text-orge480d8a">
 <p>
 Creates all defined tables.
 </p>
 </div>
 </div>
 
-<div id="outline-container-orgaaeca8f" class="outline-3">
-<h3 id="orgaaeca8f">function create-package-tables (package)</h3>
-<div class="outline-text-3" id="text-orgaaeca8f">
+<div id="outline-container-orgdd79715" class="outline-3">
+<h3 id="orgdd79715">function create-package-tables (package)</h3>
+<div class="outline-text-3" id="text-orgdd79715">
 <p>
 Creates all tables identified by symbols interned in the given package.
 </p>
 </div>
 </div>
 
-<div id="outline-container-org6aeb940" class="outline-3">
-<h3 id="org6aeb940">variables <b>table-name</b>, <b>table-symbol</b></h3>
-<div class="outline-text-3" id="text-org6aeb940">
+<div id="outline-container-orgfd826c0" class="outline-3">
+<h3 id="orgfd826c0">variables <b>table-name</b>, <b>table-symbol</b></h3>
+<div class="outline-text-3" id="text-orgfd826c0">
 <p>
 These variables are bound to the relevant name and symbol while the forms of a
 table definition are evaluated. Can be used to define shorthands like the ones
@@ -2241,9 +2438,9 @@ below.
 </div>
 </div>
 
-<div id="outline-container-org046928e" class="outline-2">
-<h2 id="org046928e">Schemata</h2>
-<div class="outline-text-2" id="text-org046928e">
+<div id="outline-container-org26dbf4a" class="outline-2">
+<h2 id="org26dbf4a">Schemata</h2>
+<div class="outline-text-2" id="text-org26dbf4a">
 <p>
 Schema allow you to separate tables into differnet name spaces. In different
 schemata two tables with the same name are allowed to exists. The tables can
@@ -2254,44 +2451,44 @@ functions allow you to create, drop schemata and to set the search path.
 </p>
 </div>
 
-<div id="outline-container-orga59a991" class="outline-3">
-<h3 id="orga59a991">function create-schema (schema)</h3>
-<div class="outline-text-3" id="text-orga59a991">
+<div id="outline-container-org90fd2a6" class="outline-3">
+<h3 id="org90fd2a6">function create-schema (schema)</h3>
+<div class="outline-text-3" id="text-org90fd2a6">
 <p>
 Creates a new schema. Raises an error if the schema is already exists.
 </p>
 </div>
 </div>
 
-<div id="outline-container-org17d1a35" class="outline-3">
-<h3 id="org17d1a35">function drop-schema (schema)</h3>
-<div class="outline-text-3" id="text-org17d1a35">
+<div id="outline-container-orgf2a0940" class="outline-3">
+<h3 id="orgf2a0940">function drop-schema (schema)</h3>
+<div class="outline-text-3" id="text-orgf2a0940">
 <p>
 Removes a schema. Raises an error if the schema is not empty.
 </p>
 </div>
 </div>
 
-<div id="outline-container-orge4e3a1e" class="outline-3">
-<h3 id="orge4e3a1e">function get-search-path ()</h3>
-<div class="outline-text-3" id="text-orge4e3a1e">
+<div id="outline-container-org8bc0bc9" class="outline-3">
+<h3 id="org8bc0bc9">function get-search-path ()</h3>
+<div class="outline-text-3" id="text-org8bc0bc9">
 <p>
 Retrieve the current search path.
 </p>
 </div>
 </div>
 
-<div id="outline-container-orgbf702ed" class="outline-3">
-<h3 id="orgbf702ed">function set-search-path (path)</h3>
-<div class="outline-text-3" id="text-orgbf702ed">
+<div id="outline-container-org515af3e" class="outline-3">
+<h3 id="org515af3e">function set-search-path (path)</h3>
+<div class="outline-text-3" id="text-org515af3e">
 <p>
 Sets the search path to the path. This function is used by with-schema.
 </p>
 </div>
 </div>
-<div id="outline-container-org10e8075" class="outline-3">
-<h3 id="org10e8075">function split-fully-qualified-table-name (name)</h3>
-<div class="outline-text-3" id="text-org10e8075">
+<div id="outline-container-org42dfec3" class="outline-3">
+<h3 id="org42dfec3">function split-fully-qualified-table-name (name)</h3>
+<div class="outline-text-3" id="text-org42dfec3">
 <p>
 → list
 Takes a name of the form database.schema.table or schema.table or just table
@@ -2302,7 +2499,7 @@ and returns a list in the form '(table schema database)
 </div>
 </div>
 <div id="postamble" class="status">
-<p class="date">Created: 2018-10-07 Sun 09:22</p>
+<p class="date">Created: 2018-12-02 Sun 21:42</p>
 <p class="validation"><a href="http://validator.w3.org/check?uri=referer">Validate</a></p>
 </div>
 </body>

--- a/doc/postmodern.html
+++ b/doc/postmodern.html
@@ -3,7 +3,7 @@
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 <head>
-<!-- 2018-12-02 Sun 21:42 -->
+<!-- 2018-12-06 Thu 22:10 -->
 <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Postmodern Reference Manual</title>
@@ -234,160 +234,160 @@ for the JavaScript code in this tag.
 <h2>Table of Contents</h2>
 <div id="text-table-of-contents">
 <ul>
-<li><a href="#orgf66e105">Connecting</a>
+<li><a href="#orgd68da46">Connecting</a>
 <ul>
-<li><a href="#org34e37cb">class database-connection</a></li>
-<li><a href="#org2599f48">function connect (database user password host &amp;key (port 5432) pooled-p use-ssl)</a></li>
-<li><a href="#org1873a98">variable <b>default-use-ssl</b></a></li>
-<li><a href="#org411ab4f">method disconnect (database-connection)</a></li>
-<li><a href="#orga7c92e9">function connected-p (database-connection)</a></li>
-<li><a href="#org431b6b2">method reconnect (database-connection)</a></li>
-<li><a href="#org8b8ed8c">variable <b>database</b></a></li>
-<li><a href="#orga735780">macro with-connection (spec &amp;body body)</a></li>
-<li><a href="#org067ca14">macro call-with-connection (spec thunk)</a></li>
-<li><a href="#orgc862d91">function connect-toplevel (database user password host &amp;key (port 5432))</a></li>
-<li><a href="#orge5c0fe9">function disconnect-toplevel ()</a></li>
-<li><a href="#org3b24d01">function clear-connection-pool ()</a></li>
-<li><a href="#org2c9b24f">variable <b>max-pool-size</b></a></li>
-<li><a href="#org62d76d7">function list-connections ()</a></li>
+<li><a href="#org70ba6f7">class database-connection</a></li>
+<li><a href="#org4ff7373">function connect (database user password host &amp;key (port 5432) pooled-p use-ssl)</a></li>
+<li><a href="#orgc2c1280">variable <b>default-use-ssl</b></a></li>
+<li><a href="#orgabd7d03">method disconnect (database-connection)</a></li>
+<li><a href="#orgfa42206">function connected-p (database-connection)</a></li>
+<li><a href="#orgcefdd49">method reconnect (database-connection)</a></li>
+<li><a href="#orgb2175fd">variable <b>database</b></a></li>
+<li><a href="#org4cf3ae2">macro with-connection (spec &amp;body body)</a></li>
+<li><a href="#org990d326">macro call-with-connection (spec thunk)</a></li>
+<li><a href="#org8b6bb24">function connect-toplevel (database user password host &amp;key (port 5432))</a></li>
+<li><a href="#org7d857e1">function disconnect-toplevel ()</a></li>
+<li><a href="#orgea8a5cf">function clear-connection-pool ()</a></li>
+<li><a href="#orgac9fe19">variable <b>max-pool-size</b></a></li>
+<li><a href="#org1268371">function list-connections ()</a></li>
 </ul>
 </li>
-<li><a href="#org22b6458">Querying</a>
+<li><a href="#orga46f926">Querying</a>
 <ul>
-<li><a href="#org237f749">macro query (query &amp;rest args/format)</a></li>
-<li><a href="#org29b2aca">macro execute (query &amp;rest args)</a></li>
-<li><a href="#orgae66984">macro doquery (query (&amp;rest names) &amp;body body)</a></li>
-<li><a href="#org82051a3">macro prepare (query &amp;optional (format :rows))</a></li>
-<li><a href="#orgdefdde9">macro defprepared (name query &amp;optional (format :rows))</a></li>
-<li><a href="#org9bafcb6">macro defprepared-with-names (name (&amp;rest args) (query &amp;rest query-args) &amp;optional (format :rows))</a></li>
-<li><a href="#orgc9a5ce2">macro with-transaction ((&amp;optional name isolation-level) &amp;body body)</a></li>
-<li><a href="#org7694a92">function commit-transaction (transaction)</a></li>
-<li><a href="#org19a0ecc">function abort-transaction (transaction)</a></li>
-<li><a href="#orgc3f5567">macro with-savepoint (name &amp;body body)</a></li>
-<li><a href="#org3d07197">function release-savepoint (savepoint)</a></li>
-<li><a href="#org2100928">function rollback-savepoint (savepoint)</a></li>
-<li><a href="#org1a014bb">function commit-hooks (transaction-or-savepoint), setf (commit-hooks transaction-or-savepoint)</a></li>
-<li><a href="#org674dd51">function abort-hooks (transaction-or-savepoint), setf (abort-hooks transaction-or-savepoint)</a></li>
-<li><a href="#org3457278">macro with-logical-transaction ((&amp;optional name isolation-level) &amp;body body)</a></li>
-<li><a href="#org35b31e1">function abort-logical-transaction (transaction-or-savepoint)</a></li>
-<li><a href="#orgd16e9ff">function commit-logical-transaction (transaction-or-savepoint)</a></li>
-<li><a href="#org54ff3d0">variable <b>current-logical-transaction</b></a></li>
-<li><a href="#org12026bb">macro ensure-transaction (&amp;body body)</a></li>
-<li><a href="#orgccb4e38">macro with-schema ((namespace &amp;key :strict t :if-not-exist :create :drop-after) &amp;body body)</a></li>
-<li><a href="#org97963e6">function sequence-next (sequence)</a></li>
-<li><a href="#org11d4bb2">function coalesce (&amp;rest arguments)</a></li>
+<li><a href="#orgce13f70">macro query (query &amp;rest args/format)</a></li>
+<li><a href="#orge125277">macro execute (query &amp;rest args)</a></li>
+<li><a href="#orgd8f0978">macro doquery (query (&amp;rest names) &amp;body body)</a></li>
+<li><a href="#org0d98143">macro prepare (query &amp;optional (format :rows))</a></li>
+<li><a href="#org51c9b8a">macro defprepared (name query &amp;optional (format :rows))</a></li>
+<li><a href="#org2edf231">macro defprepared-with-names (name (&amp;rest args) (query &amp;rest query-args) &amp;optional (format :rows))</a></li>
+<li><a href="#org2ca7cfd">macro with-transaction ((&amp;optional name isolation-level) &amp;body body)</a></li>
+<li><a href="#org2a334a1">function commit-transaction (transaction)</a></li>
+<li><a href="#org217c8ab">function abort-transaction (transaction)</a></li>
+<li><a href="#org142206c">macro with-savepoint (name &amp;body body)</a></li>
+<li><a href="#orge056ea9">function release-savepoint (savepoint)</a></li>
+<li><a href="#orgcf724bb">function rollback-savepoint (savepoint)</a></li>
+<li><a href="#org44e9da3">function commit-hooks (transaction-or-savepoint), setf (commit-hooks transaction-or-savepoint)</a></li>
+<li><a href="#orge586c35">function abort-hooks (transaction-or-savepoint), setf (abort-hooks transaction-or-savepoint)</a></li>
+<li><a href="#org5d15144">macro with-logical-transaction ((&amp;optional name isolation-level) &amp;body body)</a></li>
+<li><a href="#org574169f">function abort-logical-transaction (transaction-or-savepoint)</a></li>
+<li><a href="#org35e7b50">function commit-logical-transaction (transaction-or-savepoint)</a></li>
+<li><a href="#org0e63adc">variable <b>current-logical-transaction</b></a></li>
+<li><a href="#org72c4caf">macro ensure-transaction (&amp;body body)</a></li>
+<li><a href="#org1b36261">macro with-schema ((namespace &amp;key :strict t :if-not-exist :create :drop-after) &amp;body body)</a></li>
+<li><a href="#orgb0b155d">function sequence-next (sequence)</a></li>
+<li><a href="#orgc861067">function coalesce (&amp;rest arguments)</a></li>
 </ul>
 </li>
-<li><a href="#orgdbfe01c">Helper functions for Prepared Statements</a>
+<li><a href="#org2580dda">Helper functions for Prepared Statements</a>
 <ul>
-<li><a href="#orga8b063f">function prepared-statement-exists-p (name)</a></li>
-<li><a href="#org4481499">function list-prepared-statements()</a></li>
-<li><a href="#orgbb3d460">function drop-prepared-statement (statement-name &amp;key (location :both) (database <b>database</b>))</a></li>
-<li><a href="#orgd0cfaff">function list-postmodern-prepared-statements (&amp;optional (names-only nil))</a></li>
-<li><a href="#org5774eb3">function find-postgresql-prepared-statement (name)</a></li>
-<li><a href="#org33f703f">function find-postmodern-prepared-statement (name)</a></li>
-<li><a href="#org2a05d5f">function reset-prepared-statement (condition)</a></li>
-<li><a href="#org5ede7d6">function overwrite-prepared-statement (condition)</a></li>
-<li><a href="#orgab31aeb">function get-pid ()</a></li>
-<li><a href="#org6a503be">function get-pid-from-postmodern ()</a></li>
-<li><a href="#orgf1bbc04">function cancel-backend (pid)</a></li>
-<li><a href="#org80deb98">function terminate-backend (pid)</a></li>
+<li><a href="#org730cd12">function prepared-statement-exists-p (name)</a></li>
+<li><a href="#org7df9842">function list-prepared-statements(&amp;optional (names-only nil))</a></li>
+<li><a href="#orgfbdd58c">function drop-prepared-statement (statement-name &amp;key (location :both) (database <b>database</b>))</a></li>
+<li><a href="#org2156a7a">function list-postmodern-prepared-statements (&amp;optional (names-only nil))</a></li>
+<li><a href="#org57d40d9">function find-postgresql-prepared-statement (name)</a></li>
+<li><a href="#org8d04ae3">function find-postmodern-prepared-statement (name)</a></li>
+<li><a href="#orgcf1544b">function reset-prepared-statement (condition)</a></li>
+<li><a href="#org6e236d5">function overwrite-prepared-statement (condition)</a></li>
+<li><a href="#org4532d28">function get-pid ()</a></li>
+<li><a href="#orgd6d26b9">function get-pid-from-postmodern ()</a></li>
+<li><a href="#orgb01e3f4">function cancel-backend (pid)</a></li>
+<li><a href="#orgcf97180">function terminate-backend (pid)</a></li>
 </ul>
 </li>
-<li><a href="#org10d1208">Inspecting the database</a>
+<li><a href="#org50f54e2">Inspecting the database</a>
 <ul>
-<li><a href="#org8fddc62">function list-tables (&amp;optional strings-p)</a></li>
-<li><a href="#orgdca6607">function list-tables-in-schema (&amp;optional strings-p)</a></li>
-<li><a href="#org74138e3">function table-exists-p (name)</a></li>
-<li><a href="#orgbad33e6">function table-description (name &amp;optional schema-name)</a></li>
-<li><a href="#orgc2eef12">function list-sequences (&amp;optional strings-p)</a></li>
-<li><a href="#org660e7ae">function sequence-exists-p (name)</a></li>
-<li><a href="#org2a4608e">function list-views (&amp;optional strings-p)</a></li>
-<li><a href="#orgb34e5aa">function view-exists-p (name)</a></li>
-<li><a href="#orga2172c1">function list-schemata ()</a></li>
-<li><a href="#orgb5e1283">function schema-exist-p (schema) NOW DEPRECATED IN FAVOR OF schema-exists-p which is more consistent with naming of other functions.</a></li>
-<li><a href="#org6639ae3">function schema-exists-p (schema)</a></li>
-<li><a href="#org6bca315">function database-version ()</a></li>
-<li><a href="#org0911489">function num-records-in-database ()</a></li>
-<li><a href="#org25b904d">function current-database ()</a></li>
-<li><a href="#org40e3952">function database-exists-p (database-name)</a></li>
-<li><a href="#org9e1497f">function database-size (&amp;optional database-name)</a></li>
-<li><a href="#orge79193a">function list-databases (&amp;key (order-by-size nil) (size t))</a></li>
-<li><a href="#org7e815cc">function list-schemas ()</a></li>
-<li><a href="#orgcbe1dc2">function list-tablespaces ()</a></li>
-<li><a href="#org8e5bc67">function list-available-types ()</a></li>
-<li><a href="#org237b868">function list-table-sizes (&amp;key (schema "public") (order-by-size nil) (size t))</a></li>
-<li><a href="#org0a067c7">function table-size (table-name)</a></li>
-<li><a href="#orgbcb7bff">function more-table-info (table-name)</a></li>
-<li><a href="#org280fbb0">function list-columns (table-name)</a></li>
-<li><a href="#orgcbba043">function list-columns-with-types (table-name)</a></li>
-<li><a href="#org635750e">function column-exists-p (table-name column-name)</a></li>
-<li><a href="#orgbf64476">function describe-views (&amp;optional (schema "public")</a></li>
-<li><a href="#org740d461">function list-database-functions ()</a></li>
-<li><a href="#org652957e">function list-indices (&amp;optional strings-p)</a></li>
-<li><a href="#org2858574">function list-table-indices (table-name &amp;optional strings-p)</a></li>
-<li><a href="#org5a5d422">function index-exists-p (name)</a></li>
-<li><a href="#orge8a15b6">function list-indexed-column-and-attributes (table-name)</a></li>
-<li><a href="#org89f148b">function list-index-definitions (table-name)</a></li>
-<li><a href="#orgeada611">function find-primary-key-info (table-name &amp;optional (just-key nil))</a></li>
-<li><a href="#org24325c9">function list-foreign-keys (table-name)</a></li>
-<li><a href="#orgdcea10c">function list-unique-or-primary-constraints (table-name)</a></li>
-<li><a href="#org61cc6ea">function list-all-constraints (table-name)</a></li>
-<li><a href="#org19eb477">function describe-constraint (table-name constraint-name)</a></li>
-<li><a href="#org7e2c10b">function describe-foreign-key-constraints ()</a></li>
-<li><a href="#org8d54386">function list-triggers (&amp;optional table-name)</a></li>
-<li><a href="#org67eac16">function list-detailed-triggers ()</a></li>
-<li><a href="#org0168937">function list-database-users ()</a></li>
-<li><a href="#org0f8fdad">function list-available-extensions ()</a></li>
-<li><a href="#org61a1133">function list-installed-extensions ()</a></li>
-<li><a href="#orgccaa0d4">function change-toplevel-database (new-database user password host)</a></li>
+<li><a href="#org9c91a7f">function list-tables (&amp;optional strings-p)</a></li>
+<li><a href="#org394c43a">function list-tables-in-schema (&amp;optional strings-p)</a></li>
+<li><a href="#org75f07b5">function table-exists-p (name)</a></li>
+<li><a href="#org6660019">function table-description (name &amp;optional schema-name)</a></li>
+<li><a href="#orgcba924e">function list-sequences (&amp;optional strings-p)</a></li>
+<li><a href="#org7b9b575">function sequence-exists-p (name)</a></li>
+<li><a href="#org8fc42b4">function list-views (&amp;optional strings-p)</a></li>
+<li><a href="#org57e604e">function view-exists-p (name)</a></li>
+<li><a href="#org31b807b">function list-schemata ()</a></li>
+<li><a href="#orgc8e8592">function schema-exist-p (schema) NOW DEPRECATED IN FAVOR OF schema-exists-p which is more consistent with naming of other functions.</a></li>
+<li><a href="#org185524a">function schema-exists-p (schema)</a></li>
+<li><a href="#orgdfb707f">function database-version ()</a></li>
+<li><a href="#orgb01e438">function num-records-in-database ()</a></li>
+<li><a href="#org473451a">function current-database ()</a></li>
+<li><a href="#orgf0bb307">function database-exists-p (database-name)</a></li>
+<li><a href="#orga9a4653">function database-size (&amp;optional database-name)</a></li>
+<li><a href="#orgc295b9b">function list-databases (&amp;key (order-by-size nil) (size t))</a></li>
+<li><a href="#orged078bd">function list-schemas ()</a></li>
+<li><a href="#org4e18958">function list-tablespaces ()</a></li>
+<li><a href="#org82e321c">function list-available-types ()</a></li>
+<li><a href="#orgd884ec3">function list-table-sizes (&amp;key (schema "public") (order-by-size nil) (size t))</a></li>
+<li><a href="#org73d4b77">function table-size (table-name)</a></li>
+<li><a href="#org99c4912">function more-table-info (table-name)</a></li>
+<li><a href="#org5109f5d">function list-columns (table-name)</a></li>
+<li><a href="#orgcb15cd7">function list-columns-with-types (table-name)</a></li>
+<li><a href="#org9bfbe70">function column-exists-p (table-name column-name)</a></li>
+<li><a href="#org632bf48">function describe-views (&amp;optional (schema "public")</a></li>
+<li><a href="#org0062efd">function list-database-functions ()</a></li>
+<li><a href="#org6616a58">function list-indices (&amp;optional strings-p)</a></li>
+<li><a href="#org9c8fcb8">function list-table-indices (table-name &amp;optional strings-p)</a></li>
+<li><a href="#orged78706">function index-exists-p (name)</a></li>
+<li><a href="#org1aafa04">function list-indexed-column-and-attributes (table-name)</a></li>
+<li><a href="#orgc908d5e">function list-index-definitions (table-name)</a></li>
+<li><a href="#org51016c6">function find-primary-key-info (table-name &amp;optional (just-key nil))</a></li>
+<li><a href="#orgf7d46db">function list-foreign-keys (table-name)</a></li>
+<li><a href="#org9ef0101">function list-unique-or-primary-constraints (table-name)</a></li>
+<li><a href="#org23734e2">function list-all-constraints (table-name)</a></li>
+<li><a href="#orgb59a7a9">function describe-constraint (table-name constraint-name)</a></li>
+<li><a href="#org5f2f52b">function describe-foreign-key-constraints ()</a></li>
+<li><a href="#org2442647">function list-triggers (&amp;optional table-name)</a></li>
+<li><a href="#orgd915c81">function list-detailed-triggers ()</a></li>
+<li><a href="#orgdb505fa">function list-database-users ()</a></li>
+<li><a href="#orgbde46da">function list-available-extensions ()</a></li>
+<li><a href="#orgd75fa2f">function list-installed-extensions ()</a></li>
+<li><a href="#orgb849d68">function change-toplevel-database (new-database user password host)</a></li>
 </ul>
 </li>
-<li><a href="#orgd97efd3">Database access objects</a>
+<li><a href="#orgc6b3918">Database access objects</a>
 <ul>
-<li><a href="#org3e7d292">metaclass dao-class</a></li>
-<li><a href="#orgc7123a9">method dao-keys (class)</a></li>
-<li><a href="#org3c6db0c">method dao-keys (dao)</a></li>
-<li><a href="#org27e1e0f">method dao-exists-p (dao)</a></li>
-<li><a href="#orga61b131">method make-dao (type &amp;rest args &amp;key &amp;allow-other-keys)</a></li>
-<li><a href="#orgb3ef560">macro define-dao-finalization (((dao-name class) &amp;rest keyword-args) &amp;body body)</a></li>
-<li><a href="#orgce7d413">method get-dao (type &amp;rest keys)</a></li>
-<li><a href="#org5acd26e">macro select-dao (type &amp;optional (test t) &amp;rest sort)</a></li>
-<li><a href="#orgae8d7f2">macro do-select-dao (((type type-var) &amp;optional (test t) &amp;rest sort) &amp;body body)</a></li>
-<li><a href="#org057bc79">macro query-dao (type query &amp;rest args)</a></li>
-<li><a href="#orgb46a620">function do-query-dao (((type type-var) query &amp;rest args) &amp;body body)</a></li>
-<li><a href="#orgc548f24">variable <b>ignore-unknown-columns</b></a></li>
-<li><a href="#orgd50b062">method insert-dao (dao)</a></li>
-<li><a href="#org12447ba">method update-dao (dao)</a></li>
-<li><a href="#org7e41df1">function save-dao (dao)</a></li>
-<li><a href="#org87f82a4">function save-dao/transaction (dao)</a></li>
-<li><a href="#org1c078c7">method upsert-dao (dao)</a></li>
-<li><a href="#orgec5b546">method delete-dao (dao)</a></li>
-<li><a href="#orge1dec5a">function dao-table-name (class)</a></li>
-<li><a href="#orgb0a7d53">function dao-table-definition (class)</a></li>
-<li><a href="#org0a62e5e">macro with-column-writers ((&amp;rest writers) &amp;body body)</a></li>
+<li><a href="#org007b559">metaclass dao-class</a></li>
+<li><a href="#org78031d7">method dao-keys (class)</a></li>
+<li><a href="#orgb288fc7">method dao-keys (dao)</a></li>
+<li><a href="#org24eaf6f">method dao-exists-p (dao)</a></li>
+<li><a href="#orga47a748">method make-dao (type &amp;rest args &amp;key &amp;allow-other-keys)</a></li>
+<li><a href="#orge2d47f3">macro define-dao-finalization (((dao-name class) &amp;rest keyword-args) &amp;body body)</a></li>
+<li><a href="#orgbf81cbc">method get-dao (type &amp;rest keys)</a></li>
+<li><a href="#org1e525fb">macro select-dao (type &amp;optional (test t) &amp;rest sort)</a></li>
+<li><a href="#orgd79fb79">macro do-select-dao (((type type-var) &amp;optional (test t) &amp;rest sort) &amp;body body)</a></li>
+<li><a href="#orga85e21c">macro query-dao (type query &amp;rest args)</a></li>
+<li><a href="#org67037b3">function do-query-dao (((type type-var) query &amp;rest args) &amp;body body)</a></li>
+<li><a href="#orgc43848b">variable <b>ignore-unknown-columns</b></a></li>
+<li><a href="#org3a80ac0">method insert-dao (dao)</a></li>
+<li><a href="#org43e391f">method update-dao (dao)</a></li>
+<li><a href="#orgd0e20ec">function save-dao (dao)</a></li>
+<li><a href="#orge0c4e1f">function save-dao/transaction (dao)</a></li>
+<li><a href="#org8f0c6f8">method upsert-dao (dao)</a></li>
+<li><a href="#org67bf700">method delete-dao (dao)</a></li>
+<li><a href="#orge7b7c0b">function dao-table-name (class)</a></li>
+<li><a href="#orgf48f6ce">function dao-table-definition (class)</a></li>
+<li><a href="#org59172d0">macro with-column-writers ((&amp;rest writers) &amp;body body)</a></li>
 </ul>
 </li>
-<li><a href="#orgeed3abc">Table definition and creation</a>
+<li><a href="#orgeed8250">Table definition and creation</a>
 <ul>
-<li><a href="#orgbda5696">macro deftable (name &amp;body definition)</a></li>
-<li><a href="#orge7e4389">function !dao-def ()</a></li>
-<li><a href="#orga2c4bf6">function !index (&amp;rest columns), !unique-index (&amp;rest columns)</a></li>
-<li><a href="#org6097983">function !foreign (target-table columns &amp;optional target-columns &amp;key on-delete on-update deferrable initially-deferred)</a></li>
-<li><a href="#org62be441">function !unique (target-fields &amp;key deferrable initially-deferred)</a></li>
-<li><a href="#orga931660">function create-table (symbol)</a></li>
-<li><a href="#orge480d8a">function create-all-tables ()</a></li>
-<li><a href="#orgdd79715">function create-package-tables (package)</a></li>
-<li><a href="#orgfd826c0">variables <b>table-name</b>, <b>table-symbol</b></a></li>
+<li><a href="#org6855342">macro deftable (name &amp;body definition)</a></li>
+<li><a href="#orgf0d4464">function !dao-def ()</a></li>
+<li><a href="#org08a3c23">function !index (&amp;rest columns), !unique-index (&amp;rest columns)</a></li>
+<li><a href="#org043be46">function !foreign (target-table columns &amp;optional target-columns &amp;key on-delete on-update deferrable initially-deferred)</a></li>
+<li><a href="#org8c5c6b9">function !unique (target-fields &amp;key deferrable initially-deferred)</a></li>
+<li><a href="#orge4b097b">function create-table (symbol)</a></li>
+<li><a href="#org2ca2b8d">function create-all-tables ()</a></li>
+<li><a href="#org93120ba">function create-package-tables (package)</a></li>
+<li><a href="#org5b3e257">variables <b>table-name</b>, <b>table-symbol</b></a></li>
 </ul>
 </li>
-<li><a href="#org26dbf4a">Schemata</a>
+<li><a href="#org94988a4">Schemata</a>
 <ul>
-<li><a href="#org90fd2a6">function create-schema (schema)</a></li>
-<li><a href="#orgf2a0940">function drop-schema (schema)</a></li>
-<li><a href="#org8bc0bc9">function get-search-path ()</a></li>
-<li><a href="#org515af3e">function set-search-path (path)</a></li>
-<li><a href="#org42dfec3">function split-fully-qualified-table-name (name)</a></li>
+<li><a href="#orgfb8a41d">function create-schema (schema)</a></li>
+<li><a href="#orga69ac80">function drop-schema (schema)</a></li>
+<li><a href="#org2dbd10b">function get-search-path ()</a></li>
+<li><a href="#org917c9f7">function set-search-path (path)</a></li>
+<li><a href="#orgb8e5556">function split-fully-qualified-table-name (name)</a></li>
 </ul>
 </li>
 </ul>
@@ -412,22 +412,22 @@ raised as subtypes of database-connection-error, providing a :reconnect
 restart to re-try the operation that encountered to the error.
 </p>
 
-<div id="outline-container-orgf66e105" class="outline-2">
-<h2 id="orgf66e105">Connecting</h2>
-<div class="outline-text-2" id="text-orgf66e105">
+<div id="outline-container-orgd68da46" class="outline-2">
+<h2 id="orgd68da46">Connecting</h2>
+<div class="outline-text-2" id="text-orgd68da46">
 </div>
-<div id="outline-container-org34e37cb" class="outline-3">
-<h3 id="org34e37cb">class database-connection</h3>
-<div class="outline-text-3" id="text-org34e37cb">
+<div id="outline-container-org70ba6f7" class="outline-3">
+<h3 id="org70ba6f7">class database-connection</h3>
+<div class="outline-text-3" id="text-org70ba6f7">
 <p>
 Objects of this type represent database connections.
 </p>
 </div>
 </div>
 
-<div id="outline-container-org2599f48" class="outline-3">
-<h3 id="org2599f48">function connect (database user password host &amp;key (port 5432) pooled-p use-ssl)</h3>
-<div class="outline-text-3" id="text-org2599f48">
+<div id="outline-container-org4ff7373" class="outline-3">
+<h3 id="org4ff7373">function connect (database user password host &amp;key (port 5432) pooled-p use-ssl)</h3>
+<div class="outline-text-3" id="text-org4ff7373">
 <p>
 → database-connection
 </p>
@@ -444,9 +444,9 @@ of <b>default-use-ssl</b>.
 </div>
 </div>
 
-<div id="outline-container-org1873a98" class="outline-3">
-<h3 id="org1873a98">variable <b>default-use-ssl</b></h3>
-<div class="outline-text-3" id="text-org1873a98">
+<div id="outline-container-orgc2c1280" class="outline-3">
+<h3 id="orgc2c1280">variable <b>default-use-ssl</b></h3>
+<div class="outline-text-3" id="text-orgc2c1280">
 <p>
 The default for connect's use-ssl argument. This starts at :no. If you
 set it to anything else, be sure to also load the CL+SSL library.
@@ -454,9 +454,9 @@ set it to anything else, be sure to also load the CL+SSL library.
 </div>
 </div>
 
-<div id="outline-container-org411ab4f" class="outline-3">
-<h3 id="org411ab4f">method disconnect (database-connection)</h3>
-<div class="outline-text-3" id="text-org411ab4f">
+<div id="outline-container-orgabd7d03" class="outline-3">
+<h3 id="orgabd7d03">method disconnect (database-connection)</h3>
+<div class="outline-text-3" id="text-orgabd7d03">
 <p>
 Disconnects a normal database connection, or moves a pooled connection
 into the pool.
@@ -464,9 +464,9 @@ into the pool.
 </div>
 </div>
 
-<div id="outline-container-orga7c92e9" class="outline-3">
-<h3 id="orga7c92e9">function connected-p (database-connection)</h3>
-<div class="outline-text-3" id="text-orga7c92e9">
+<div id="outline-container-orgfa42206" class="outline-3">
+<h3 id="orgfa42206">function connected-p (database-connection)</h3>
+<div class="outline-text-3" id="text-orgfa42206">
 <p>
 → boolean
 </p>
@@ -478,9 +478,9 @@ to the server.
 </div>
 </div>
 
-<div id="outline-container-org431b6b2" class="outline-3">
-<h3 id="org431b6b2">method reconnect (database-connection)</h3>
-<div class="outline-text-3" id="text-org431b6b2">
+<div id="outline-container-orgcefdd49" class="outline-3">
+<h3 id="orgcefdd49">method reconnect (database-connection)</h3>
+<div class="outline-text-3" id="text-orgcefdd49">
 <p>
 Reconnect a disconnected database connection. This is not allowed for pooled
 connections ― after they are disconnected they might be in use by some other
@@ -489,9 +489,9 @@ process, and should no longer be used.
 </div>
 </div>
 
-<div id="outline-container-org8b8ed8c" class="outline-3">
-<h3 id="org8b8ed8c">variable <b>database</b></h3>
-<div class="outline-text-3" id="text-org8b8ed8c">
+<div id="outline-container-orgb2175fd" class="outline-3">
+<h3 id="orgb2175fd">variable <b>database</b></h3>
+<div class="outline-text-3" id="text-orgb2175fd">
 <p>
 Special variable holding the current database. Most functions and macros
 operating on a database assume this binds to a connected database.
@@ -499,9 +499,9 @@ operating on a database assume this binds to a connected database.
 </div>
 </div>
 
-<div id="outline-container-orga735780" class="outline-3">
-<h3 id="orga735780">macro with-connection (spec &amp;body body)</h3>
-<div class="outline-text-3" id="text-orga735780">
+<div id="outline-container-org4cf3ae2" class="outline-3">
+<h3 id="org4cf3ae2">macro with-connection (spec &amp;body body)</h3>
+<div class="outline-text-3" id="text-org4cf3ae2">
 <p>
 Evaluates the body with <b>database</b> bound to a connection as specified by
 spec, which should be list that connect can be applied to.
@@ -509,9 +509,9 @@ spec, which should be list that connect can be applied to.
 </div>
 </div>
 
-<div id="outline-container-org067ca14" class="outline-3">
-<h3 id="org067ca14">macro call-with-connection (spec thunk)</h3>
-<div class="outline-text-3" id="text-org067ca14">
+<div id="outline-container-org990d326" class="outline-3">
+<h3 id="org990d326">macro call-with-connection (spec thunk)</h3>
+<div class="outline-text-3" id="text-org990d326">
 <p>
 The functional backend to with-connection. Binds <b>database</b> to a new
 connection as specified by spec, which should be a list that connect can
@@ -522,9 +522,9 @@ connection is disconnected.
 </div>
 </div>
 
-<div id="outline-container-orgc862d91" class="outline-3">
-<h3 id="orgc862d91">function connect-toplevel (database user password host &amp;key (port 5432))</h3>
-<div class="outline-text-3" id="text-orgc862d91">
+<div id="outline-container-org8b6bb24" class="outline-3">
+<h3 id="org8b6bb24">function connect-toplevel (database user password host &amp;key (port 5432))</h3>
+<div class="outline-text-3" id="text-org8b6bb24">
 <p>
 Bind the <b>database</b> to a new connection. Use this if you only need one
 connection, or if you want a connection for debugging from the REPL.
@@ -532,27 +532,27 @@ connection, or if you want a connection for debugging from the REPL.
 </div>
 </div>
 
-<div id="outline-container-orge5c0fe9" class="outline-3">
-<h3 id="orge5c0fe9">function disconnect-toplevel ()</h3>
-<div class="outline-text-3" id="text-orge5c0fe9">
+<div id="outline-container-org7d857e1" class="outline-3">
+<h3 id="org7d857e1">function disconnect-toplevel ()</h3>
+<div class="outline-text-3" id="text-org7d857e1">
 <p>
 Disconnect the <b>database</b>.
 </p>
 </div>
 </div>
 
-<div id="outline-container-org3b24d01" class="outline-3">
-<h3 id="org3b24d01">function clear-connection-pool ()</h3>
-<div class="outline-text-3" id="text-org3b24d01">
+<div id="outline-container-orgea8a5cf" class="outline-3">
+<h3 id="orgea8a5cf">function clear-connection-pool ()</h3>
+<div class="outline-text-3" id="text-orgea8a5cf">
 <p>
 Disconnect and remove all connections from the connection pools.
 </p>
 </div>
 </div>
 
-<div id="outline-container-org2c9b24f" class="outline-3">
-<h3 id="org2c9b24f">variable <b>max-pool-size</b></h3>
-<div class="outline-text-3" id="text-org2c9b24f">
+<div id="outline-container-orgac9fe19" class="outline-3">
+<h3 id="orgac9fe19">variable <b>max-pool-size</b></h3>
+<div class="outline-text-3" id="text-orgac9fe19">
 <p>
 Set the maximum amount of connections kept in a single connection pool, where
 a pool consists of all the stored connections with the exact same connect
@@ -561,9 +561,9 @@ arguments. Defaults to NIL, which means there is no maximum.
 </div>
 </div>
 
-<div id="outline-container-org62d76d7" class="outline-3">
-<h3 id="org62d76d7">function list-connections ()</h3>
-<div class="outline-text-3" id="text-org62d76d7">
+<div id="outline-container-org1268371" class="outline-3">
+<h3 id="org1268371">function list-connections ()</h3>
+<div class="outline-text-3" id="text-org1268371">
 <p>
 → list
 </p>
@@ -574,13 +574,13 @@ List the current postgresql connections to the currently connected database.
 </div>
 </div>
 </div>
-<div id="outline-container-org22b6458" class="outline-2">
-<h2 id="org22b6458">Querying</h2>
-<div class="outline-text-2" id="text-org22b6458">
+<div id="outline-container-orga46f926" class="outline-2">
+<h2 id="orga46f926">Querying</h2>
+<div class="outline-text-2" id="text-orga46f926">
 </div>
-<div id="outline-container-org237f749" class="outline-3">
-<h3 id="org237f749">macro query (query &amp;rest args/format)</h3>
-<div class="outline-text-3" id="text-org237f749">
+<div id="outline-container-orgce13f70" class="outline-3">
+<h3 id="orgce13f70">macro query (query &amp;rest args/format)</h3>
+<div class="outline-text-3" id="text-orgce13f70">
 <p>
 → result
 </p>
@@ -682,9 +682,9 @@ such as with updating or deleting queries, this is returned as a second value.
 </div>
 </div>
 
-<div id="outline-container-org29b2aca" class="outline-3">
-<h3 id="org29b2aca">macro execute (query &amp;rest args)</h3>
-<div class="outline-text-3" id="text-org29b2aca">
+<div id="outline-container-orge125277" class="outline-3">
+<h3 id="orge125277">macro execute (query &amp;rest args)</h3>
+<div class="outline-text-3" id="text-orge125277">
 <p>
 Like query called with format :none. Returns the amount of affected rows as
 its first returned value. (Also returns this amount as the second returned
@@ -693,9 +693,9 @@ value, but use of this is deprecated.)
 </div>
 </div>
 
-<div id="outline-container-orgae66984" class="outline-3">
-<h3 id="orgae66984">macro doquery (query (&amp;rest names) &amp;body body)</h3>
-<div class="outline-text-3" id="text-orgae66984">
+<div id="outline-container-orgd8f0978" class="outline-3">
+<h3 id="orgd8f0978">macro doquery (query (&amp;rest names) &amp;body body)</h3>
+<div class="outline-text-3" id="text-orgd8f0978">
 <p>
 Execute the given query (a string or a list starting with a keyword),
 iterating over the rows in the result. The body will be executed with the
@@ -714,19 +714,20 @@ whose cdr contains the arguments. For example:
 </div>
 </div>
 
-<div id="outline-container-org82051a3" class="outline-3">
-<h3 id="org82051a3">macro prepare (query &amp;optional (format :rows))</h3>
-<div class="outline-text-3" id="text-org82051a3">
+<div id="outline-container-org0d98143" class="outline-3">
+<h3 id="org0d98143">macro prepare (query &amp;optional (format :rows))</h3>
+<div class="outline-text-3" id="text-org0d98143">
 <p>
 → function
 </p>
 
 <p>
-Creates a function that can be used as the interface to a prepared statement.
-The given query (either a string or an S-SQL form) may contain placeholders,
-which look like $1, $2, etc. The resulting function takes one argument for
-every placeholder in the query, executes the prepared query, and returns the
-result in the format specified. (Allowed formats are the same as for query.)
+Wraps a query into a function that can be used as the interface to a prepared
+statement. The given query (either a string or an S-SQL form) may contain
+placeholders, which look like $1, $2, etc. The resulting function takes one
+argument for every placeholder in the query, executes the prepared query,
+and returns the result in the format specified. (Allowed formats are the
+same as for query.)
 </p>
 
 <p>
@@ -741,12 +742,20 @@ type of the arguments in a statement. In that case you should add type
 declarations (either with the PostgreSQL's CAST SQL-conforming syntax or
 historical :: syntax, or with S-SQL's :type construct) to help it out.
 </p>
+
+<p>
+Note that it will attempt to automatically reconnect if
+database-connection-error, or admin-shutdown. It will reset prepared
+statements triggering an invalid-sql-statement-name error. It will
+overwrite old prepared statements triggering a duplicate-prepared-statement
+error.
+</p>
 </div>
 </div>
 
-<div id="outline-container-orgdefdde9" class="outline-3">
-<h3 id="orgdefdde9">macro defprepared (name query &amp;optional (format :rows))</h3>
-<div class="outline-text-3" id="text-orgdefdde9">
+<div id="outline-container-org51c9b8a" class="outline-3">
+<h3 id="org51c9b8a">macro defprepared (name query &amp;optional (format :rows))</h3>
+<div class="outline-text-3" id="text-org51c9b8a">
 <p>
 → function
 </p>
@@ -759,9 +768,9 @@ prepared statement. The name should not be quoted or a string.
 </div>
 </div>
 
-<div id="outline-container-org9bafcb6" class="outline-3">
-<h3 id="org9bafcb6">macro defprepared-with-names (name (&amp;rest args) (query &amp;rest query-args) &amp;optional (format :rows))</h3>
-<div class="outline-text-3" id="text-org9bafcb6">
+<div id="outline-container-org2edf231" class="outline-3">
+<h3 id="org2edf231">macro defprepared-with-names (name (&amp;rest args) (query &amp;rest query-args) &amp;optional (format :rows))</h3>
+<div class="outline-text-3" id="text-org2edf231">
 <p>
 Like defprepared, but allows to specify names of the function arguments as
 well as arguments supplied to the query.
@@ -778,9 +787,9 @@ well as arguments supplied to the query.
 </div>
 </div>
 
-<div id="outline-container-orgc9a5ce2" class="outline-3">
-<h3 id="orgc9a5ce2">macro with-transaction ((&amp;optional name isolation-level) &amp;body body)</h3>
-<div class="outline-text-3" id="text-orgc9a5ce2">
+<div id="outline-container-org2ca7cfd" class="outline-3">
+<h3 id="org2ca7cfd">macro with-transaction ((&amp;optional name isolation-level) &amp;body body)</h3>
+<div class="outline-text-3" id="text-org2ca7cfd">
 <p>
 Execute the given body within a database transaction, committing it when the
 body exits normally, and aborting otherwise. An optional name and/or
@@ -833,27 +842,27 @@ Further discussion of transactions and isolation levels can found
 </div>
 </div>
 
-<div id="outline-container-org7694a92" class="outline-3">
-<h3 id="org7694a92">function commit-transaction (transaction)</h3>
-<div class="outline-text-3" id="text-org7694a92">
+<div id="outline-container-org2a334a1" class="outline-3">
+<h3 id="org2a334a1">function commit-transaction (transaction)</h3>
+<div class="outline-text-3" id="text-org2a334a1">
 <p>
 Commit the given transaction.
 </p>
 </div>
 </div>
 
-<div id="outline-container-org19a0ecc" class="outline-3">
-<h3 id="org19a0ecc">function abort-transaction (transaction)</h3>
-<div class="outline-text-3" id="text-org19a0ecc">
+<div id="outline-container-org217c8ab" class="outline-3">
+<h3 id="org217c8ab">function abort-transaction (transaction)</h3>
+<div class="outline-text-3" id="text-org217c8ab">
 <p>
 Roll back the given transaction.
 </p>
 </div>
 </div>
 
-<div id="outline-container-orgc3f5567" class="outline-3">
-<h3 id="orgc3f5567">macro with-savepoint (name &amp;body body)</h3>
-<div class="outline-text-3" id="text-orgc3f5567">
+<div id="outline-container-org142206c" class="outline-3">
+<h3 id="org142206c">macro with-savepoint (name &amp;body body)</h3>
+<div class="outline-text-3" id="text-org142206c">
 <p>
 Can only be used within a transaction. Establishes a savepoint with the given
 name at the start of body, and binds the same name to a handle for that
@@ -863,27 +872,27 @@ condition is thrown, in which case it is rolled back.
 </div>
 </div>
 
-<div id="outline-container-org3d07197" class="outline-3">
-<h3 id="org3d07197">function release-savepoint (savepoint)</h3>
-<div class="outline-text-3" id="text-org3d07197">
+<div id="outline-container-orge056ea9" class="outline-3">
+<h3 id="orge056ea9">function release-savepoint (savepoint)</h3>
+<div class="outline-text-3" id="text-orge056ea9">
 <p>
 Release the given savepoint.
 </p>
 </div>
 </div>
 
-<div id="outline-container-org2100928" class="outline-3">
-<h3 id="org2100928">function rollback-savepoint (savepoint)</h3>
-<div class="outline-text-3" id="text-org2100928">
+<div id="outline-container-orgcf724bb" class="outline-3">
+<h3 id="orgcf724bb">function rollback-savepoint (savepoint)</h3>
+<div class="outline-text-3" id="text-orgcf724bb">
 <p>
 Roll back the given savepoint.
 </p>
 </div>
 </div>
 
-<div id="outline-container-org1a014bb" class="outline-3">
-<h3 id="org1a014bb">function commit-hooks (transaction-or-savepoint), setf (commit-hooks transaction-or-savepoint)</h3>
-<div class="outline-text-3" id="text-org1a014bb">
+<div id="outline-container-org44e9da3" class="outline-3">
+<h3 id="org44e9da3">function commit-hooks (transaction-or-savepoint), setf (commit-hooks transaction-or-savepoint)</h3>
+<div class="outline-text-3" id="text-org44e9da3">
 <p>
 An accessor for the transaction or savepoint's list of commit hooks, each of
 which should be a function with no required arguments. These functions will
@@ -892,9 +901,9 @@ be executed when a transaction is committed or a savepoint released.
 </div>
 </div>
 
-<div id="outline-container-org674dd51" class="outline-3">
-<h3 id="org674dd51">function abort-hooks (transaction-or-savepoint), setf (abort-hooks transaction-or-savepoint)</h3>
-<div class="outline-text-3" id="text-org674dd51">
+<div id="outline-container-orge586c35" class="outline-3">
+<h3 id="orge586c35">function abort-hooks (transaction-or-savepoint), setf (abort-hooks transaction-or-savepoint)</h3>
+<div class="outline-text-3" id="text-orge586c35">
 <p>
 An accessor for the transaction or savepoint's list of abort hooks, each of
 which should be a function with no required arguments. These functions will
@@ -905,9 +914,9 @@ abort-transaction or rollback-savepoint).
 </div>
 </div>
 
-<div id="outline-container-org3457278" class="outline-3">
-<h3 id="org3457278">macro with-logical-transaction ((&amp;optional name isolation-level) &amp;body body)</h3>
-<div class="outline-text-3" id="text-org3457278">
+<div id="outline-container-org5d15144" class="outline-3">
+<h3 id="org5d15144">macro with-logical-transaction ((&amp;optional name isolation-level) &amp;body body)</h3>
+<div class="outline-text-3" id="text-org5d15144">
 <p>
 Executes body within a with-transaction form if no transaction is currently
 in progress, otherwise simulates a nested transaction by executing it
@@ -954,9 +963,9 @@ expected here:
 </div>
 </div>
 
-<div id="outline-container-org35b31e1" class="outline-3">
-<h3 id="org35b31e1">function abort-logical-transaction (transaction-or-savepoint)</h3>
-<div class="outline-text-3" id="text-org35b31e1">
+<div id="outline-container-org574169f" class="outline-3">
+<h3 id="org574169f">function abort-logical-transaction (transaction-or-savepoint)</h3>
+<div class="outline-text-3" id="text-org574169f">
 <p>
 Roll back the given logical transaction, regardless of whether it is an
 actual transaction or a savepoint.
@@ -964,9 +973,9 @@ actual transaction or a savepoint.
 </div>
 </div>
 
-<div id="outline-container-orgd16e9ff" class="outline-3">
-<h3 id="orgd16e9ff">function commit-logical-transaction (transaction-or-savepoint)</h3>
-<div class="outline-text-3" id="text-orgd16e9ff">
+<div id="outline-container-org35e7b50" class="outline-3">
+<h3 id="org35e7b50">function commit-logical-transaction (transaction-or-savepoint)</h3>
+<div class="outline-text-3" id="text-org35e7b50">
 <p>
 Commit the given logical transaction, regardless of whether it is an
 actual transaction or a savepoint.
@@ -974,9 +983,9 @@ actual transaction or a savepoint.
 </div>
 </div>
 
-<div id="outline-container-org54ff3d0" class="outline-3">
-<h3 id="org54ff3d0">variable <b>current-logical-transaction</b></h3>
-<div class="outline-text-3" id="text-org54ff3d0">
+<div id="outline-container-org0e63adc" class="outline-3">
+<h3 id="org0e63adc">variable <b>current-logical-transaction</b></h3>
+<div class="outline-text-3" id="text-org0e63adc">
 <p>
 This is bound to the current transaction-handle or savepoint-handle instance
 representing the innermost open logical transaction.
@@ -984,9 +993,9 @@ representing the innermost open logical transaction.
 </div>
 </div>
 
-<div id="outline-container-org12026bb" class="outline-3">
-<h3 id="org12026bb">macro ensure-transaction (&amp;body body)</h3>
-<div class="outline-text-3" id="text-org12026bb">
+<div id="outline-container-org72c4caf" class="outline-3">
+<h3 id="org72c4caf">macro ensure-transaction (&amp;body body)</h3>
+<div class="outline-text-3" id="text-org72c4caf">
 <p>
 Ensures that body is executed within a transaction, but does not begin a
 new transaction if one is already in progress.
@@ -994,9 +1003,9 @@ new transaction if one is already in progress.
 </div>
 </div>
 
-<div id="outline-container-orgccb4e38" class="outline-3">
-<h3 id="orgccb4e38">macro with-schema ((namespace &amp;key :strict t :if-not-exist :create :drop-after) &amp;body body)</h3>
-<div class="outline-text-3" id="text-orgccb4e38">
+<div id="outline-container-org1b36261" class="outline-3">
+<h3 id="org1b36261">macro with-schema ((namespace &amp;key :strict t :if-not-exist :create :drop-after) &amp;body body)</h3>
+<div class="outline-text-3" id="text-org1b36261">
 <p>
 Sets the current schema to namespace and executes the body. Before executing
 body the PostgreSQL's session variable search_path is set to the given
@@ -1010,9 +1019,9 @@ namespace is dropped from the database after the body execution.
 </div>
 </div>
 
-<div id="outline-container-org97963e6" class="outline-3">
-<h3 id="org97963e6">function sequence-next (sequence)</h3>
-<div class="outline-text-3" id="text-org97963e6">
+<div id="outline-container-orgb0b155d" class="outline-3">
+<h3 id="orgb0b155d">function sequence-next (sequence)</h3>
+<div class="outline-text-3" id="text-orgb0b155d">
 <p>
 → integer
 </p>
@@ -1025,9 +1034,9 @@ according to S-SQL rules.
 </div>
 </div>
 
-<div id="outline-container-org11d4bb2" class="outline-3">
-<h3 id="org11d4bb2">function coalesce (&amp;rest arguments)</h3>
-<div class="outline-text-3" id="text-org11d4bb2">
+<div id="outline-container-orgc861067" class="outline-3">
+<h3 id="orgc861067">function coalesce (&amp;rest arguments)</h3>
+<div class="outline-text-3" id="text-orgc861067">
 <p>
 → value
 </p>
@@ -1042,13 +1051,13 @@ when given only one argument, for transforming :nulls to NIL.
 </div>
 
 
-<div id="outline-container-orgdbfe01c" class="outline-2">
-<h2 id="orgdbfe01c">Helper functions for Prepared Statements</h2>
-<div class="outline-text-2" id="text-orgdbfe01c">
+<div id="outline-container-org2580dda" class="outline-2">
+<h2 id="org2580dda">Helper functions for Prepared Statements</h2>
+<div class="outline-text-2" id="text-org2580dda">
 </div>
-<div id="outline-container-orga8b063f" class="outline-3">
-<h3 id="orga8b063f">function prepared-statement-exists-p (name)</h3>
-<div class="outline-text-3" id="text-orga8b063f">
+<div id="outline-container-org730cd12" class="outline-3">
+<h3 id="org730cd12">function prepared-statement-exists-p (name)</h3>
+<div class="outline-text-3" id="text-org730cd12">
 <p>
 → boolean
 This returns t if the prepared statement exists in the current
@@ -1057,23 +1066,24 @@ postgresql session, otherwise nil.
 </div>
 </div>
 
-<div id="outline-container-org4481499" class="outline-3">
-<h3 id="org4481499">function list-prepared-statements()</h3>
-<div class="outline-text-3" id="text-org4481499">
+<div id="outline-container-org7df9842" class="outline-3">
+<h3 id="org7df9842">function list-prepared-statements(&amp;optional (names-only nil))</h3>
+<div class="outline-text-3" id="text-org7df9842">
 <p>
 → list
 </p>
 
 <p>
 This is syntactic sugar. It runs a query that lists the prepared statements in
-the session in which the function is run.
+the session in which the function is run. If the names-only parameter is set
+to t, it will only return a list of the names of the prepared statements.
 </p>
 </div>
 </div>
 
-<div id="outline-container-orgbb3d460" class="outline-3">
-<h3 id="orgbb3d460">function drop-prepared-statement (statement-name &amp;key (location :both) (database <b>database</b>))</h3>
-<div class="outline-text-3" id="text-orgbb3d460">
+<div id="outline-container-orgfbdd58c" class="outline-3">
+<h3 id="orgfbdd58c">function drop-prepared-statement (statement-name &amp;key (location :both) (database <b>database</b>))</h3>
+<div class="outline-text-3" id="text-orgfbdd58c">
 <p>
 Prepared statements are stored both in the meta slot in the postmodern
 connection and in postgresql session information. If you know the prepared
@@ -1086,9 +1096,9 @@ delete all prepared statements.
 </div>
 </div>
 
-<div id="outline-container-orgd0cfaff" class="outline-3">
-<h3 id="orgd0cfaff">function list-postmodern-prepared-statements (&amp;optional (names-only nil))</h3>
-<div class="outline-text-3" id="text-orgd0cfaff">
+<div id="outline-container-org2156a7a" class="outline-3">
+<h3 id="org2156a7a">function list-postmodern-prepared-statements (&amp;optional (names-only nil))</h3>
+<div class="outline-text-3" id="text-org2156a7a">
 <p>
 → list
 </p>
@@ -1109,9 +1119,9 @@ the names of the prepared statements.
 </div>
 </div>
 
-<div id="outline-container-org5774eb3" class="outline-3">
-<h3 id="org5774eb3">function find-postgresql-prepared-statement (name)</h3>
-<div class="outline-text-3" id="text-org5774eb3">
+<div id="outline-container-org57d40d9" class="outline-3">
+<h3 id="org57d40d9">function find-postgresql-prepared-statement (name)</h3>
+<div class="outline-text-3" id="text-org57d40d9">
 <p>
 → string
 </p>
@@ -1123,9 +1133,9 @@ session.
 </div>
 </div>
 
-<div id="outline-container-org33f703f" class="outline-3">
-<h3 id="org33f703f">function find-postmodern-prepared-statement (name)</h3>
-<div class="outline-text-3" id="text-org33f703f">
+<div id="outline-container-org8d04ae3" class="outline-3">
+<h3 id="org8d04ae3">function find-postmodern-prepared-statement (name)</h3>
+<div class="outline-text-3" id="text-org8d04ae3">
 <p>
 → string
 </p>
@@ -1138,9 +1148,9 @@ not the name.
 </div>
 </div>
 
-<div id="outline-container-org2a05d5f" class="outline-3">
-<h3 id="org2a05d5f">function reset-prepared-statement (condition)</h3>
-<div class="outline-text-3" id="text-org2a05d5f">
+<div id="outline-container-orgcf1544b" class="outline-3">
+<h3 id="orgcf1544b">function reset-prepared-statement (condition)</h3>
+<div class="outline-text-3" id="text-orgcf1544b">
 <p>
 → restart
 </p>
@@ -1154,9 +1164,9 @@ and restart the connection.
 </div>
 </div>
 
-<div id="outline-container-org5ede7d6" class="outline-3">
-<h3 id="org5ede7d6">function overwrite-prepared-statement (condition)</h3>
-<div class="outline-text-3" id="text-org5ede7d6">
+<div id="outline-container-org6e236d5" class="outline-3">
+<h3 id="org6e236d5">function overwrite-prepared-statement (condition)</h3>
+<div class="outline-text-3" id="text-org6e236d5">
 <p>
 → restart
 </p>
@@ -1170,9 +1180,9 @@ connection level and restart the connection.
 </div>
 </div>
 
-<div id="outline-container-orgab31aeb" class="outline-3">
-<h3 id="orgab31aeb">function get-pid ()</h3>
-<div class="outline-text-3" id="text-orgab31aeb">
+<div id="outline-container-org4532d28" class="outline-3">
+<h3 id="org4532d28">function get-pid ()</h3>
+<div class="outline-text-3" id="text-org4532d28">
 <p>
 → integer
 </p>
@@ -1183,9 +1193,9 @@ Get the process id used by postgresql for this connection.
 </div>
 </div>
 
-<div id="outline-container-org6a503be" class="outline-3">
-<h3 id="org6a503be">function get-pid-from-postmodern ()</h3>
-<div class="outline-text-3" id="text-org6a503be">
+<div id="outline-container-orgd6d26b9" class="outline-3">
+<h3 id="orgd6d26b9">function get-pid-from-postmodern ()</h3>
+<div class="outline-text-3" id="text-orgd6d26b9">
 <p>
 → integer
 </p>
@@ -1197,9 +1207,9 @@ but get it from the postmodern connection parameters.
 </div>
 </div>
 
-<div id="outline-container-orgf1bbc04" class="outline-3">
-<h3 id="orgf1bbc04">function cancel-backend (pid)</h3>
-<div class="outline-text-3" id="text-orgf1bbc04">
+<div id="outline-container-orgb01e3f4" class="outline-3">
+<h3 id="orgb01e3f4">function cancel-backend (pid)</h3>
+<div class="outline-text-3" id="text-orgb01e3f4">
 <p>
 Polite way of terminating a query at the database (as opposed to calling close-database).
 Slower than (terminate-backend pid) and does not always work.
@@ -1207,9 +1217,9 @@ Slower than (terminate-backend pid) and does not always work.
 </div>
 </div>
 
-<div id="outline-container-org80deb98" class="outline-3">
-<h3 id="org80deb98">function terminate-backend (pid)</h3>
-<div class="outline-text-3" id="text-org80deb98">
+<div id="outline-container-orgcf97180" class="outline-3">
+<h3 id="orgcf97180">function terminate-backend (pid)</h3>
+<div class="outline-text-3" id="text-orgcf97180">
 <p>
 Less polite way of terminating at the database (as opposed to calling close-database).
 Faster than (cancel-backend pid) and more reliable.
@@ -1218,13 +1228,13 @@ Faster than (cancel-backend pid) and more reliable.
 </div>
 </div>
 
-<div id="outline-container-org10d1208" class="outline-2">
-<h2 id="org10d1208">Inspecting the database</h2>
-<div class="outline-text-2" id="text-org10d1208">
+<div id="outline-container-org50f54e2" class="outline-2">
+<h2 id="org50f54e2">Inspecting the database</h2>
+<div class="outline-text-2" id="text-org50f54e2">
 </div>
-<div id="outline-container-org8fddc62" class="outline-3">
-<h3 id="org8fddc62">function list-tables (&amp;optional strings-p)</h3>
-<div class="outline-text-3" id="text-org8fddc62">
+<div id="outline-container-org9c91a7f" class="outline-3">
+<h3 id="org9c91a7f">function list-tables (&amp;optional strings-p)</h3>
+<div class="outline-text-3" id="text-org9c91a7f">
 <p>
 → list
 </p>
@@ -1236,9 +1246,9 @@ the names will be given as strings, otherwise as keywords.
 </div>
 </div>
 
-<div id="outline-container-orgdca6607" class="outline-3">
-<h3 id="orgdca6607">function list-tables-in-schema (&amp;optional strings-p)</h3>
-<div class="outline-text-3" id="text-orgdca6607">
+<div id="outline-container-org394c43a" class="outline-3">
+<h3 id="org394c43a">function list-tables-in-schema (&amp;optional strings-p)</h3>
+<div class="outline-text-3" id="text-org394c43a">
 <p>
 → list
 </p>
@@ -1249,9 +1259,9 @@ When strings-p is T,the names will be given as strings, otherwise as keywords.
 </p>
 </div>
 </div>
-<div id="outline-container-org74138e3" class="outline-3">
-<h3 id="org74138e3">function table-exists-p (name)</h3>
-<div class="outline-text-3" id="text-org74138e3">
+<div id="outline-container-org75f07b5" class="outline-3">
+<h3 id="org75f07b5">function table-exists-p (name)</h3>
+<div class="outline-text-3" id="text-org75f07b5">
 <p>
 → boolean
 </p>
@@ -1264,9 +1274,9 @@ or 'database.schema.table
 </div>
 </div>
 
-<div id="outline-container-orgbad33e6" class="outline-3">
-<h3 id="orgbad33e6">function table-description (name &amp;optional schema-name)</h3>
-<div class="outline-text-3" id="text-orgbad33e6">
+<div id="outline-container-org6660019" class="outline-3">
+<h3 id="org6660019">function table-description (name &amp;optional schema-name)</h3>
+<div class="outline-text-3" id="text-org6660019">
 <p>
 → list
 </p>
@@ -1281,9 +1291,9 @@ the table are returned, regardless of their schema.
 </div>
 </div>
 
-<div id="outline-container-orgc2eef12" class="outline-3">
-<h3 id="orgc2eef12">function list-sequences (&amp;optional strings-p)</h3>
-<div class="outline-text-3" id="text-orgc2eef12">
+<div id="outline-container-orgcba924e" class="outline-3">
+<h3 id="orgcba924e">function list-sequences (&amp;optional strings-p)</h3>
+<div class="outline-text-3" id="text-orgcba924e">
 <p>
 → list
 </p>
@@ -1295,9 +1305,9 @@ the names will be given as strings, otherwise as keywords.
 </div>
 </div>
 
-<div id="outline-container-org660e7ae" class="outline-3">
-<h3 id="org660e7ae">function sequence-exists-p (name)</h3>
-<div class="outline-text-3" id="text-org660e7ae">
+<div id="outline-container-org7b9b575" class="outline-3">
+<h3 id="org7b9b575">function sequence-exists-p (name)</h3>
+<div class="outline-text-3" id="text-org7b9b575">
 <p>
 → boolean
 </p>
@@ -1309,9 +1319,9 @@ string or a symbol.
 </div>
 </div>
 
-<div id="outline-container-org2a4608e" class="outline-3">
-<h3 id="org2a4608e">function list-views (&amp;optional strings-p)</h3>
-<div class="outline-text-3" id="text-org2a4608e">
+<div id="outline-container-org8fc42b4" class="outline-3">
+<h3 id="org8fc42b4">function list-views (&amp;optional strings-p)</h3>
+<div class="outline-text-3" id="text-org8fc42b4">
 <p>
 → list
 </p>
@@ -1323,9 +1333,9 @@ is T, the names will be returned as strings, otherwise as keywords.
 </div>
 </div>
 
-<div id="outline-container-orgb34e5aa" class="outline-3">
-<h3 id="orgb34e5aa">function view-exists-p (name)</h3>
-<div class="outline-text-3" id="text-orgb34e5aa">
+<div id="outline-container-org57e604e" class="outline-3">
+<h3 id="org57e604e">function view-exists-p (name)</h3>
+<div class="outline-text-3" id="text-org57e604e">
 <p>
 → boolean
 </p>
@@ -1337,9 +1347,9 @@ string or a symbol.
 </div>
 </div>
 
-<div id="outline-container-orga2172c1" class="outline-3">
-<h3 id="orga2172c1">function list-schemata ()</h3>
-<div class="outline-text-3" id="text-orga2172c1">
+<div id="outline-container-org31b807b" class="outline-3">
+<h3 id="org31b807b">function list-schemata ()</h3>
+<div class="outline-text-3" id="text-org31b807b">
 <p>
 → list
 </p>
@@ -1351,9 +1361,9 @@ existing schemata.
 </div>
 </div>
 
-<div id="outline-container-orgb5e1283" class="outline-3">
-<h3 id="orgb5e1283">function schema-exist-p (schema) NOW DEPRECATED IN FAVOR OF schema-exists-p which is more consistent with naming of other functions.</h3>
-<div class="outline-text-3" id="text-orgb5e1283">
+<div id="outline-container-orgc8e8592" class="outline-3">
+<h3 id="orgc8e8592">function schema-exist-p (schema) NOW DEPRECATED IN FAVOR OF schema-exists-p which is more consistent with naming of other functions.</h3>
+<div class="outline-text-3" id="text-orgc8e8592">
 <p>
 → boolean
 </p>
@@ -1365,9 +1375,9 @@ otherwise.
 </div>
 </div>
 
-<div id="outline-container-org6639ae3" class="outline-3">
-<h3 id="org6639ae3">function schema-exists-p (schema)</h3>
-<div class="outline-text-3" id="text-org6639ae3">
+<div id="outline-container-org185524a" class="outline-3">
+<h3 id="org185524a">function schema-exists-p (schema)</h3>
+<div class="outline-text-3" id="text-org185524a">
 <p>
 → boolean
 </p>
@@ -1379,9 +1389,9 @@ otherwise.
 </div>
 </div>
 
-<div id="outline-container-org6bca315" class="outline-3">
-<h3 id="org6bca315">function database-version ()</h3>
-<div class="outline-text-3" id="text-org6bca315">
+<div id="outline-container-orgdfb707f" class="outline-3">
+<h3 id="orgdfb707f">function database-version ()</h3>
+<div class="outline-text-3" id="text-orgdfb707f">
 <p>
 → string
 </p>
@@ -1392,9 +1402,9 @@ Returns the version of the current postgresql database.
 </div>
 </div>
 
-<div id="outline-container-org0911489" class="outline-3">
-<h3 id="org0911489">function num-records-in-database ()</h3>
-<div class="outline-text-3" id="text-org0911489">
+<div id="outline-container-orgb01e438" class="outline-3">
+<h3 id="orgb01e438">function num-records-in-database ()</h3>
+<div class="outline-text-3" id="text-orgb01e438">
 <p>
 → list
 </p>
@@ -1406,9 +1416,9 @@ records in the currently connected database.
 </div>
 </div>
 
-<div id="outline-container-org25b904d" class="outline-3">
-<h3 id="org25b904d">function current-database ()</h3>
-<div class="outline-text-3" id="text-org25b904d">
+<div id="outline-container-org473451a" class="outline-3">
+<h3 id="org473451a">function current-database ()</h3>
+<div class="outline-text-3" id="text-org473451a">
 <p>
 → string
 </p>
@@ -1419,9 +1429,9 @@ Returns the string name of the current database.
 </div>
 </div>
 
-<div id="outline-container-org40e3952" class="outline-3">
-<h3 id="org40e3952">function database-exists-p (database-name)</h3>
-<div class="outline-text-3" id="text-org40e3952">
+<div id="outline-container-orgf0bb307" class="outline-3">
+<h3 id="orgf0bb307">function database-exists-p (database-name)</h3>
+<div class="outline-text-3" id="text-orgf0bb307">
 <p>
 → boolean
 </p>
@@ -1432,9 +1442,9 @@ Checks to see if a particular database exists.
 </div>
 </div>
 
-<div id="outline-container-org9e1497f" class="outline-3">
-<h3 id="org9e1497f">function database-size (&amp;optional database-name)</h3>
-<div class="outline-text-3" id="text-org9e1497f">
+<div id="outline-container-orga9a4653" class="outline-3">
+<h3 id="orga9a4653">function database-size (&amp;optional database-name)</h3>
+<div class="outline-text-3" id="text-orga9a4653">
 <p>
 → list
 </p>
@@ -1447,9 +1457,9 @@ provided, it will return the result for the currently connected database.
 </div>
 </div>
 
-<div id="outline-container-orge79193a" class="outline-3">
-<h3 id="orge79193a">function list-databases (&amp;key (order-by-size nil) (size t))</h3>
-<div class="outline-text-3" id="text-orge79193a">
+<div id="outline-container-orgc295b9b" class="outline-3">
+<h3 id="orgc295b9b">function list-databases (&amp;key (order-by-size nil) (size t))</h3>
+<div class="outline-text-3" id="text-orgc295b9b">
 <p>
 → list
 </p>
@@ -1464,9 +1474,9 @@ in a single list ordered by name. This function excludes the template databases
 </div>
 </div>
 
-<div id="outline-container-org7e815cc" class="outline-3">
-<h3 id="org7e815cc">function list-schemas ()</h3>
-<div class="outline-text-3" id="text-org7e815cc">
+<div id="outline-container-orged078bd" class="outline-3">
+<h3 id="orged078bd">function list-schemas ()</h3>
+<div class="outline-text-3" id="text-orged078bd">
 <p>
 → list
 </p>
@@ -1477,9 +1487,9 @@ List schemas in the current database, excluding the pg_* system schemas.
 </div>
 </div>
 
-<div id="outline-container-orgcbe1dc2" class="outline-3">
-<h3 id="orgcbe1dc2">function list-tablespaces ()</h3>
-<div class="outline-text-3" id="text-orgcbe1dc2">
+<div id="outline-container-org4e18958" class="outline-3">
+<h3 id="org4e18958">function list-tablespaces ()</h3>
+<div class="outline-text-3" id="text-org4e18958">
 <p>
 → list
 </p>
@@ -1490,9 +1500,9 @@ Lists the tablespaces in the currently connected database.
 </div>
 </div>
 
-<div id="outline-container-org8e5bc67" class="outline-3">
-<h3 id="org8e5bc67">function list-available-types ()</h3>
-<div class="outline-text-3" id="text-org8e5bc67">
+<div id="outline-container-org82e321c" class="outline-3">
+<h3 id="org82e321c">function list-available-types ()</h3>
+<div class="outline-text-3" id="text-org82e321c">
 <p>
 → list
 </p>
@@ -1503,9 +1513,9 @@ List the available types in this postgresql version.
 </div>
 </div>
 
-<div id="outline-container-org237b868" class="outline-3">
-<h3 id="org237b868">function list-table-sizes (&amp;key (schema "public") (order-by-size nil) (size t))</h3>
-<div class="outline-text-3" id="text-org237b868">
+<div id="outline-container-orgd884ec3" class="outline-3">
+<h3 id="orgd884ec3">function list-table-sizes (&amp;key (schema "public") (order-by-size nil) (size t))</h3>
+<div class="outline-text-3" id="text-orgd884ec3">
 <p>
 → list
 </p>
@@ -1523,9 +1533,9 @@ result in order of size instead of by table name.
 </div>
 </div>
 
-<div id="outline-container-org0a067c7" class="outline-3">
-<h3 id="org0a067c7">function table-size (table-name)</h3>
-<div class="outline-text-3" id="text-org0a067c7">
+<div id="outline-container-org73d4b77" class="outline-3">
+<h3 id="org73d4b77">function table-size (table-name)</h3>
+<div class="outline-text-3" id="text-org73d4b77">
 <p>
 → list
 </p>
@@ -1537,9 +1547,9 @@ string or quoted.
 </div>
 </div>
 
-<div id="outline-container-orgbcb7bff" class="outline-3">
-<h3 id="orgbcb7bff">function more-table-info (table-name)</h3>
-<div class="outline-text-3" id="text-orgbcb7bff">
+<div id="outline-container-org99c4912" class="outline-3">
+<h3 id="org99c4912">function more-table-info (table-name)</h3>
+<div class="outline-text-3" id="text-org99c4912">
 <p>
 → list
 </p>
@@ -1551,9 +1561,9 @@ or quoted.
 </div>
 </div>
 
-<div id="outline-container-org280fbb0" class="outline-3">
-<h3 id="org280fbb0">function list-columns (table-name)</h3>
-<div class="outline-text-3" id="text-org280fbb0">
+<div id="outline-container-org5109f5d" class="outline-3">
+<h3 id="org5109f5d">function list-columns (table-name)</h3>
+<div class="outline-text-3" id="text-org5109f5d">
 <p>
 → list
 </p>
@@ -1565,9 +1575,9 @@ from the postmodern table-description function rather than directly.
 </div>
 </div>
 
-<div id="outline-container-orgcbba043" class="outline-3">
-<h3 id="orgcbba043">function list-columns-with-types (table-name)</h3>
-<div class="outline-text-3" id="text-orgcbba043">
+<div id="outline-container-orgcb15cd7" class="outline-3">
+<h3 id="orgcb15cd7">function list-columns-with-types (table-name)</h3>
+<div class="outline-text-3" id="text-orgcb15cd7">
 <p>
 → list
 </p>
@@ -1579,9 +1589,9 @@ to the pg-catalog tables.
 </div>
 </div>
 
-<div id="outline-container-org635750e" class="outline-3">
-<h3 id="org635750e">function column-exists-p (table-name column-name)</h3>
-<div class="outline-text-3" id="text-org635750e">
+<div id="outline-container-org9bfbe70" class="outline-3">
+<h3 id="org9bfbe70">function column-exists-p (table-name column-name)</h3>
+<div class="outline-text-3" id="text-org9bfbe70">
 <p>
 → boolean
 </p>
@@ -1593,9 +1603,9 @@ either strings or symbols.
 </div>
 </div>
 
-<div id="outline-container-orgbf64476" class="outline-3">
-<h3 id="orgbf64476">function describe-views (&amp;optional (schema "public")</h3>
-<div class="outline-text-3" id="text-orgbf64476">
+<div id="outline-container-org632bf48" class="outline-3">
+<h3 id="org632bf48">function describe-views (&amp;optional (schema "public")</h3>
+<div class="outline-text-3" id="text-org632bf48">
 <p>
 → list
 </p>
@@ -1606,9 +1616,9 @@ Describe the current views in the specified schema. Defaults to public schema.
 </div>
 </div>
 
-<div id="outline-container-org740d461" class="outline-3">
-<h3 id="org740d461">function list-database-functions ()</h3>
-<div class="outline-text-3" id="text-org740d461">
+<div id="outline-container-org0062efd" class="outline-3">
+<h3 id="org0062efd">function list-database-functions ()</h3>
+<div class="outline-text-3" id="text-org0062efd">
 <p>
 → list
 </p>
@@ -1619,9 +1629,9 @@ Returns a list of the functions in the database from the information_schema.
 </div>
 </div>
 
-<div id="outline-container-org652957e" class="outline-3">
-<h3 id="org652957e">function list-indices (&amp;optional strings-p)</h3>
-<div class="outline-text-3" id="text-org652957e">
+<div id="outline-container-org6616a58" class="outline-3">
+<h3 id="org6616a58">function list-indices (&amp;optional strings-p)</h3>
+<div class="outline-text-3" id="text-org6616a58">
 <p>
 → list
 </p>
@@ -1633,9 +1643,9 @@ strings-p is not true.
 </div>
 </div>
 
-<div id="outline-container-org2858574" class="outline-3">
-<h3 id="org2858574">function list-table-indices (table-name &amp;optional strings-p)</h3>
-<div class="outline-text-3" id="text-org2858574">
+<div id="outline-container-org9c8fcb8" class="outline-3">
+<h3 id="org9c8fcb8">function list-table-indices (table-name &amp;optional strings-p)</h3>
+<div class="outline-text-3" id="text-org9c8fcb8">
 <p>
 → list
 </p>
@@ -1646,9 +1656,9 @@ List the index names and the related columns in a table.
 </div>
 </div>
 
-<div id="outline-container-org5a5d422" class="outline-3">
-<h3 id="org5a5d422">function index-exists-p (name)</h3>
-<div class="outline-text-3" id="text-org5a5d422">
+<div id="outline-container-orged78706" class="outline-3">
+<h3 id="orged78706">function index-exists-p (name)</h3>
+<div class="outline-text-3" id="text-orged78706">
 <p>
 → boolean
 </p>
@@ -1660,9 +1670,9 @@ string or a symbol.
 </div>
 </div>
 
-<div id="outline-container-orge8a15b6" class="outline-3">
-<h3 id="orge8a15b6">function list-indexed-column-and-attributes (table-name)</h3>
-<div class="outline-text-3" id="text-orge8a15b6">
+<div id="outline-container-org1aafa04" class="outline-3">
+<h3 id="org1aafa04">function list-indexed-column-and-attributes (table-name)</h3>
+<div class="outline-text-3" id="text-org1aafa04">
 <p>
 → list
 </p>
@@ -1674,9 +1684,9 @@ key.
 </div>
 </div>
 
-<div id="outline-container-org89f148b" class="outline-3">
-<h3 id="org89f148b">function list-index-definitions (table-name)</h3>
-<div class="outline-text-3" id="text-org89f148b">
+<div id="outline-container-orgc908d5e" class="outline-3">
+<h3 id="orgc908d5e">function list-index-definitions (table-name)</h3>
+<div class="outline-text-3" id="text-orgc908d5e">
 <p>
 → list
 </p>
@@ -1688,9 +1698,9 @@ the table
 </div>
 </div>
 
-<div id="outline-container-orgeada611" class="outline-3">
-<h3 id="orgeada611">function find-primary-key-info (table-name &amp;optional (just-key nil))</h3>
-<div class="outline-text-3" id="text-orgeada611">
+<div id="outline-container-org51016c6" class="outline-3">
+<h3 id="org51016c6">function find-primary-key-info (table-name &amp;optional (just-key nil))</h3>
+<div class="outline-text-3" id="text-org51016c6">
 <p>
 → list
 </p>
@@ -1704,9 +1714,9 @@ primary key as a string.
 </div>
 </div>
 
-<div id="outline-container-org24325c9" class="outline-3">
-<h3 id="org24325c9">function list-foreign-keys (table-name)</h3>
-<div class="outline-text-3" id="text-org24325c9">
+<div id="outline-container-orgf7d46db" class="outline-3">
+<h3 id="orgf7d46db">function list-foreign-keys (table-name)</h3>
+<div class="outline-text-3" id="text-orgf7d46db">
 <p>
 → list
 </p>
@@ -1719,9 +1729,9 @@ Returns a list of sublists of foreign key info in the form of
 </div>
 </div>
 
-<div id="outline-container-orgdcea10c" class="outline-3">
-<h3 id="orgdcea10c">function list-unique-or-primary-constraints (table-name)</h3>
-<div class="outline-text-3" id="text-orgdcea10c">
+<div id="outline-container-org9ef0101" class="outline-3">
+<h3 id="org9ef0101">function list-unique-or-primary-constraints (table-name)</h3>
+<div class="outline-text-3" id="text-org9ef0101">
 <p>
 → list
 </p>
@@ -1732,9 +1742,9 @@ List constraints on a table.
 </div>
 </div>
 
-<div id="outline-container-org61cc6ea" class="outline-3">
-<h3 id="org61cc6ea">function list-all-constraints (table-name)</h3>
-<div class="outline-text-3" id="text-org61cc6ea">
+<div id="outline-container-org23734e2" class="outline-3">
+<h3 id="org23734e2">function list-all-constraints (table-name)</h3>
+<div class="outline-text-3" id="text-org23734e2">
 <p>
 → list
 </p>
@@ -1746,9 +1756,9 @@ can be either a string or quoted.
 </div>
 </div>
 
-<div id="outline-container-org19eb477" class="outline-3">
-<h3 id="org19eb477">function describe-constraint (table-name constraint-name)</h3>
-<div class="outline-text-3" id="text-org19eb477">
+<div id="outline-container-orgb59a7a9" class="outline-3">
+<h3 id="orgb59a7a9">function describe-constraint (table-name constraint-name)</h3>
+<div class="outline-text-3" id="text-orgb59a7a9">
 <p>
 → list
 </p>
@@ -1760,9 +1770,9 @@ the table-name and the constraint name using the information_schema table.
 </div>
 </div>
 
-<div id="outline-container-org7e2c10b" class="outline-3">
-<h3 id="org7e2c10b">function describe-foreign-key-constraints ()</h3>
-<div class="outline-text-3" id="text-org7e2c10b">
+<div id="outline-container-org5f2f52b" class="outline-3">
+<h3 id="org5f2f52b">function describe-foreign-key-constraints ()</h3>
+<div class="outline-text-3" id="text-org5f2f52b">
 <p>
 → list
 </p>
@@ -1773,9 +1783,9 @@ Generates a list of lists of information on the foreign key constraints
 </div>
 </div>
 
-<div id="outline-container-org8d54386" class="outline-3">
-<h3 id="org8d54386">function list-triggers (&amp;optional table-name)</h3>
-<div class="outline-text-3" id="text-org8d54386">
+<div id="outline-container-org2442647" class="outline-3">
+<h3 id="org2442647">function list-triggers (&amp;optional table-name)</h3>
+<div class="outline-text-3" id="text-org2442647">
 <p>
 → list
 </p>
@@ -1787,9 +1797,9 @@ can be either quoted or string.
 </div>
 </div>
 
-<div id="outline-container-org67eac16" class="outline-3">
-<h3 id="org67eac16">function list-detailed-triggers ()</h3>
-<div class="outline-text-3" id="text-org67eac16">
+<div id="outline-container-orgd915c81" class="outline-3">
+<h3 id="orgd915c81">function list-detailed-triggers ()</h3>
+<div class="outline-text-3" id="text-orgd915c81">
 <p>
 → list
 </p>
@@ -1800,9 +1810,9 @@ List detailed information on the triggers from the information_schema table.
 </div>
 </div>
 
-<div id="outline-container-org0168937" class="outline-3">
-<h3 id="org0168937">function list-database-users ()</h3>
-<div class="outline-text-3" id="text-org0168937">
+<div id="outline-container-orgdb505fa" class="outline-3">
+<h3 id="orgdb505fa">function list-database-users ()</h3>
+<div class="outline-text-3" id="text-orgdb505fa">
 <p>
 → list
 </p>
@@ -1812,9 +1822,9 @@ List database users.
 </p>
 </div>
 </div>
-<div id="outline-container-org0f8fdad" class="outline-3">
-<h3 id="org0f8fdad">function list-available-extensions ()</h3>
-<div class="outline-text-3" id="text-org0f8fdad">
+<div id="outline-container-orgbde46da" class="outline-3">
+<h3 id="orgbde46da">function list-available-extensions ()</h3>
+<div class="outline-text-3" id="text-orgbde46da">
 <p>
 → list
 </p>
@@ -1825,9 +1835,9 @@ currently connected database. The extensions may or may not be installed.
 </p>
 </div>
 </div>
-<div id="outline-container-org61a1133" class="outline-3">
-<h3 id="org61a1133">function list-installed-extensions ()</h3>
-<div class="outline-text-3" id="text-org61a1133">
+<div id="outline-container-orgd75fa2f" class="outline-3">
+<h3 id="orgd75fa2f">function list-installed-extensions ()</h3>
+<div class="outline-text-3" id="text-orgd75fa2f">
 <p>
 → list
 </p>
@@ -1838,9 +1848,9 @@ connected database.
 </p>
 </div>
 </div>
-<div id="outline-container-orgccaa0d4" class="outline-3">
-<h3 id="orgccaa0d4">function change-toplevel-database (new-database user password host)</h3>
-<div class="outline-text-3" id="text-orgccaa0d4">
+<div id="outline-container-orgb849d68" class="outline-3">
+<h3 id="orgb849d68">function change-toplevel-database (new-database user password host)</h3>
+<div class="outline-text-3" id="text-orgb849d68">
 <p>
 → string
 </p>
@@ -1855,9 +1865,9 @@ connected database as a string.
 </div>
 
 
-<div id="outline-container-orgd97efd3" class="outline-2">
-<h2 id="orgd97efd3">Database access objects</h2>
-<div class="outline-text-2" id="text-orgd97efd3">
+<div id="outline-container-orgc6b3918" class="outline-2">
+<h2 id="orgc6b3918">Database access objects</h2>
+<div class="outline-text-2" id="text-orgc6b3918">
 <p>
 Postmodern contains a simple system for defining CLOS classes that
 represent rows in the database. This is not intended as a full-fledged
@@ -1867,9 +1877,9 @@ a humble SQL library like this.
 </p>
 </div>
 
-<div id="outline-container-org3e7d292" class="outline-3">
-<h3 id="org3e7d292">metaclass dao-class</h3>
-<div class="outline-text-3" id="text-org3e7d292">
+<div id="outline-container-org007b559" class="outline-3">
+<h3 id="org007b559">metaclass dao-class</h3>
+<div class="outline-text-3" id="text-org007b559">
 <p>
 At the heart of Postmodern's DAO system is the dao-class metaclass. It
 allows you to define classes for your database-access objects as regular
@@ -1946,9 +1956,9 @@ and specify a slot like this:
 </div>
 </div>
 
-<div id="outline-container-orgc7123a9" class="outline-3">
-<h3 id="orgc7123a9">method dao-keys (class)</h3>
-<div class="outline-text-3" id="text-orgc7123a9">
+<div id="outline-container-org78031d7" class="outline-3">
+<h3 id="org78031d7">method dao-keys (class)</h3>
+<div class="outline-text-3" id="text-org78031d7">
 <p>
 → list
 </p>
@@ -1970,9 +1980,9 @@ find-primary-key-info function.
 </div>
 </div>
 
-<div id="outline-container-org3c6db0c" class="outline-3">
-<h3 id="org3c6db0c">method dao-keys (dao)</h3>
-<div class="outline-text-3" id="text-org3c6db0c">
+<div id="outline-container-orgb288fc7" class="outline-3">
+<h3 id="orgb288fc7">method dao-keys (dao)</h3>
+<div class="outline-text-3" id="text-orgb288fc7">
 <p>
 → list
 </p>
@@ -1983,9 +1993,9 @@ Returns list of values that are the primary key of dao.
 </div>
 </div>
 
-<div id="outline-container-org27e1e0f" class="outline-3">
-<h3 id="org27e1e0f">method dao-exists-p (dao)</h3>
-<div class="outline-text-3" id="text-org27e1e0f">
+<div id="outline-container-org24eaf6f" class="outline-3">
+<h3 id="org24eaf6f">method dao-exists-p (dao)</h3>
+<div class="outline-text-3" id="text-org24eaf6f">
 <p>
 → boolean
 </p>
@@ -1998,9 +2008,9 @@ unbound.
 </div>
 </div>
 
-<div id="outline-container-orga61b131" class="outline-3">
-<h3 id="orga61b131">method make-dao (type &amp;rest args &amp;key &amp;allow-other-keys)</h3>
-<div class="outline-text-3" id="text-orga61b131">
+<div id="outline-container-orga47a748" class="outline-3">
+<h3 id="orga47a748">method make-dao (type &amp;rest args &amp;key &amp;allow-other-keys)</h3>
+<div class="outline-text-3" id="text-orga47a748">
 <p>
 → dao
 </p>
@@ -2011,9 +2021,9 @@ Combines make-instance with insert-dao. Return the created dao.
 </div>
 </div>
 
-<div id="outline-container-orgb3ef560" class="outline-3">
-<h3 id="orgb3ef560">macro define-dao-finalization (((dao-name class) &amp;rest keyword-args) &amp;body body)</h3>
-<div class="outline-text-3" id="text-orgb3ef560">
+<div id="outline-container-orge2d47f3" class="outline-3">
+<h3 id="orge2d47f3">macro define-dao-finalization (((dao-name class) &amp;rest keyword-args) &amp;body body)</h3>
+<div class="outline-text-3" id="text-orge2d47f3">
 <p>
 Create an :around-method for make-dao. The body is executed in a lexical
 environment where dao-name is bound to a freshly created and inserted DAO.
@@ -2024,9 +2034,9 @@ slots with the type serial, which are unknown before insert-dao.
 </div>
 </div>
 
-<div id="outline-container-orgce7d413" class="outline-3">
-<h3 id="orgce7d413">method get-dao (type &amp;rest keys)</h3>
-<div class="outline-text-3" id="text-orgce7d413">
+<div id="outline-container-orgbf81cbc" class="outline-3">
+<h3 id="orgbf81cbc">method get-dao (type &amp;rest keys)</h3>
+<div class="outline-text-3" id="text-orgbf81cbc">
 <p>
 → dao
 </p>
@@ -2041,9 +2051,9 @@ The same goes for select-dao and query-dao.
 </div>
 </div>
 
-<div id="outline-container-org5acd26e" class="outline-3">
-<h3 id="org5acd26e">macro select-dao (type &amp;optional (test t) &amp;rest sort)</h3>
-<div class="outline-text-3" id="text-org5acd26e">
+<div id="outline-container-org1e525fb" class="outline-3">
+<h3 id="org1e525fb">macro select-dao (type &amp;optional (test t) &amp;rest sort)</h3>
+<div class="outline-text-3" id="text-org1e525fb">
 <p>
 → list
 </p>
@@ -2065,9 +2075,9 @@ the result.
 </div>
 </div>
 
-<div id="outline-container-orgae8d7f2" class="outline-3">
-<h3 id="orgae8d7f2">macro do-select-dao (((type type-var) &amp;optional (test t) &amp;rest sort) &amp;body body)</h3>
-<div class="outline-text-3" id="text-orgae8d7f2">
+<div id="outline-container-orgd79fb79" class="outline-3">
+<h3 id="orgd79fb79">macro do-select-dao (((type type-var) &amp;optional (test t) &amp;rest sort) &amp;body body)</h3>
+<div class="outline-text-3" id="text-orgd79fb79">
 <p>
 Like select-dao, but iterates over the results rather than returning them.
 For each matching DAO, body is evaluated with type-var bound to the DAO
@@ -2081,9 +2091,9 @@ instance.
 </div>
 </div>
 
-<div id="outline-container-org057bc79" class="outline-3">
-<h3 id="org057bc79">macro query-dao (type query &amp;rest args)</h3>
-<div class="outline-text-3" id="text-org057bc79">
+<div id="outline-container-orga85e21c" class="outline-3">
+<h3 id="orga85e21c">macro query-dao (type query &amp;rest args)</h3>
+<div class="outline-text-3" id="text-orga85e21c">
 <p>
 → list
 </p>
@@ -2098,9 +2108,9 @@ the DAO class, or be bound through with-column-writers.
 </div>
 </div>
 
-<div id="outline-container-orgb46a620" class="outline-3">
-<h3 id="orgb46a620">function do-query-dao (((type type-var) query &amp;rest args) &amp;body body)</h3>
-<div class="outline-text-3" id="text-orgb46a620">
+<div id="outline-container-org67037b3" class="outline-3">
+<h3 id="org67037b3">function do-query-dao (((type type-var) query &amp;rest args) &amp;body body)</h3>
+<div class="outline-text-3" id="text-org67037b3">
 <p>
 → list
 </p>
@@ -2117,9 +2127,9 @@ For each matching DAO, body is evaluated with type-var bound to the instance.
 </div>
 </div>
 
-<div id="outline-container-orgc548f24" class="outline-3">
-<h3 id="orgc548f24">variable <b>ignore-unknown-columns</b></h3>
-<div class="outline-text-3" id="text-orgc548f24">
+<div id="outline-container-orgc43848b" class="outline-3">
+<h3 id="orgc43848b">variable <b>ignore-unknown-columns</b></h3>
+<div class="outline-text-3" id="text-orgc43848b">
 <p>
 Normally, when get-dao, select-dao, or query-dao finds a column in the database
 that's not in the DAO class, it will raise an error. Setting this variable to
@@ -2128,9 +2138,9 @@ a non-NIL will cause it to simply ignore the unknown column.
 </div>
 </div>
 
-<div id="outline-container-orgd50b062" class="outline-3">
-<h3 id="orgd50b062">method insert-dao (dao)</h3>
-<div class="outline-text-3" id="text-orgd50b062">
+<div id="outline-container-org3a80ac0" class="outline-3">
+<h3 id="org3a80ac0">method insert-dao (dao)</h3>
+<div class="outline-text-3" id="text-org3a80ac0">
 <p>
 → dao
 </p>
@@ -2144,9 +2154,9 @@ be failed. (This feature only works on PostgreSQL 8.2 and up.)
 </div>
 </div>
 
-<div id="outline-container-org12447ba" class="outline-3">
-<h3 id="org12447ba">method update-dao (dao)</h3>
-<div class="outline-text-3" id="text-org12447ba">
+<div id="outline-container-org43e391f" class="outline-3">
+<h3 id="org43e391f">method update-dao (dao)</h3>
+<div class="outline-text-3" id="text-org43e391f">
 <p>
 → dao
 </p>
@@ -2159,9 +2169,9 @@ non-primary-key columns. Raises an error when no row matching the dao exists.
 </div>
 </div>
 
-<div id="outline-container-org7e41df1" class="outline-3">
-<h3 id="org7e41df1">function save-dao (dao)</h3>
-<div class="outline-text-3" id="text-org7e41df1">
+<div id="outline-container-orgd0e20ec" class="outline-3">
+<h3 id="orgd0e20ec">function save-dao (dao)</h3>
+<div class="outline-text-3" id="text-orgd0e20ec">
 <p>
 → boolean
 </p>
@@ -2186,9 +2196,9 @@ See also: upsert-dao.
 </div>
 </div>
 
-<div id="outline-container-org87f82a4" class="outline-3">
-<h3 id="org87f82a4">function save-dao/transaction (dao)</h3>
-<div class="outline-text-3" id="text-org87f82a4">
+<div id="outline-container-orge0c4e1f" class="outline-3">
+<h3 id="orge0c4e1f">function save-dao/transaction (dao)</h3>
+<div class="outline-text-3" id="text-orge0c4e1f">
 <p>
 → boolean
 </p>
@@ -2204,9 +2214,9 @@ See also: upsert-dao.
 </div>
 </div>
 
-<div id="outline-container-org1c078c7" class="outline-3">
-<h3 id="org1c078c7">method upsert-dao (dao)</h3>
-<div class="outline-text-3" id="text-org1c078c7">
+<div id="outline-container-org8f0c6f8" class="outline-3">
+<h3 id="org8f0c6f8">method upsert-dao (dao)</h3>
+<div class="outline-text-3" id="text-org8f0c6f8">
 <p>
 → dao
 </p>
@@ -2253,18 +2263,18 @@ was inserted, NIL if it was updated).
 </div>
 </div>
 
-<div id="outline-container-orgec5b546" class="outline-3">
-<h3 id="orgec5b546">method delete-dao (dao)</h3>
-<div class="outline-text-3" id="text-orgec5b546">
+<div id="outline-container-org67bf700" class="outline-3">
+<h3 id="org67bf700">method delete-dao (dao)</h3>
+<div class="outline-text-3" id="text-org67bf700">
 <p>
 Delete the given dao from the database.
 </p>
 </div>
 </div>
 
-<div id="outline-container-orge1dec5a" class="outline-3">
-<h3 id="orge1dec5a">function dao-table-name (class)</h3>
-<div class="outline-text-3" id="text-orge1dec5a">
+<div id="outline-container-orge7b7c0b" class="outline-3">
+<h3 id="orge7b7c0b">function dao-table-name (class)</h3>
+<div class="outline-text-3" id="text-orge7b7c0b">
 <p>
 → string
 </p>
@@ -2276,9 +2286,9 @@ symbol naming such a class).
 </div>
 </div>
 
-<div id="outline-container-orgb0a7d53" class="outline-3">
-<h3 id="orgb0a7d53">function dao-table-definition (class)</h3>
-<div class="outline-text-3" id="text-orgb0a7d53">
+<div id="outline-container-orgf48f6ce" class="outline-3">
+<h3 id="orgf48f6ce">function dao-table-definition (class)</h3>
+<div class="outline-text-3" id="text-orgf48f6ce">
 <p>
 → string
 </p>
@@ -2292,9 +2302,9 @@ own queries to add them, in which case look to s-sql's create-table function.
 </div>
 </div>
 
-<div id="outline-container-org0a62e5e" class="outline-3">
-<h3 id="org0a62e5e">macro with-column-writers ((&amp;rest writers) &amp;body body)</h3>
-<div class="outline-text-3" id="text-org0a62e5e">
+<div id="outline-container-org59172d0" class="outline-3">
+<h3 id="org59172d0">macro with-column-writers ((&amp;rest writers) &amp;body body)</h3>
+<div class="outline-text-3" id="text-org59172d0">
 <p>
 Provides control over the way get-dao, select-dao, and query-dao read values
 from the database. This is not commonly needed, but can be used to reduce the
@@ -2317,9 +2327,9 @@ about the objects, and immediately store it in the new instances.
 </div>
 </div>
 
-<div id="outline-container-orgeed3abc" class="outline-2">
-<h2 id="orgeed3abc">Table definition and creation</h2>
-<div class="outline-text-2" id="text-orgeed3abc">
+<div id="outline-container-orgeed8250" class="outline-2">
+<h2 id="orgeed8250">Table definition and creation</h2>
+<div class="outline-text-2" id="text-orgeed8250">
 <p>
 It can be useful to have the SQL statements needed to build an application's
 tables available from the source code, to do things like automatically
@@ -2329,9 +2339,9 @@ in table definitions.
 </p>
 </div>
 
-<div id="outline-container-orgbda5696" class="outline-3">
-<h3 id="orgbda5696">macro deftable (name &amp;body definition)</h3>
-<div class="outline-text-3" id="text-orgbda5696">
+<div id="outline-container-org6855342" class="outline-3">
+<h3 id="org6855342">macro deftable (name &amp;body definition)</h3>
+<div class="outline-text-3" id="text-org6855342">
 <p>
 Define a table. name can be either a symbol or a (symbol string) list.
 In the first case, the table name is derived from the symbol's name by
@@ -2345,9 +2355,9 @@ and then define indices on it.
 </div>
 </div>
 
-<div id="outline-container-orge7e4389" class="outline-3">
-<h3 id="orge7e4389">function !dao-def ()</h3>
-<div class="outline-text-3" id="text-orge7e4389">
+<div id="outline-container-orgf0d4464" class="outline-3">
+<h3 id="orgf0d4464">function !dao-def ()</h3>
+<div class="outline-text-3" id="text-orgf0d4464">
 <p>
 Should only be used inside deftable's body. Adds the result of calling
 dao-table-definition on <b>table-symbol</b> to the definition.
@@ -2355,9 +2365,9 @@ dao-table-definition on <b>table-symbol</b> to the definition.
 </div>
 </div>
 
-<div id="outline-container-orga2c4bf6" class="outline-3">
-<h3 id="orga2c4bf6">function !index (&amp;rest columns), !unique-index (&amp;rest columns)</h3>
-<div class="outline-text-3" id="text-orga2c4bf6">
+<div id="outline-container-org08a3c23" class="outline-3">
+<h3 id="org08a3c23">function !index (&amp;rest columns), !unique-index (&amp;rest columns)</h3>
+<div class="outline-text-3" id="text-org08a3c23">
 <p>
 Define an index on the table being defined. The columns can be given as
 symbols or strings.
@@ -2365,9 +2375,9 @@ symbols or strings.
 </div>
 </div>
 
-<div id="outline-container-org6097983" class="outline-3">
-<h3 id="org6097983">function !foreign (target-table columns &amp;optional target-columns &amp;key on-delete on-update deferrable initially-deferred)</h3>
-<div class="outline-text-3" id="text-org6097983">
+<div id="outline-container-org043be46" class="outline-3">
+<h3 id="org043be46">function !foreign (target-table columns &amp;optional target-columns &amp;key on-delete on-update deferrable initially-deferred)</h3>
+<div class="outline-text-3" id="text-org043be46">
 <p>
 Add a foreign key to the table being defined. target-table is the referenced
 table. columns is a list of column names or single name in this table, and,
@@ -2389,9 +2399,9 @@ so that they can be specified even when target-columns is not given.
 </div>
 </div>
 
-<div id="outline-container-org62be441" class="outline-3">
-<h3 id="org62be441">function !unique (target-fields &amp;key deferrable initially-deferred)</h3>
-<div class="outline-text-3" id="text-org62be441">
+<div id="outline-container-org8c5c6b9" class="outline-3">
+<h3 id="org8c5c6b9">function !unique (target-fields &amp;key deferrable initially-deferred)</h3>
+<div class="outline-text-3" id="text-org8c5c6b9">
 <p>
 Constrains one or more columns to only contain unique (combinations of) values,
 with deferrable and initially-deferred defined as in !foreign
@@ -2399,36 +2409,36 @@ with deferrable and initially-deferred defined as in !foreign
 </div>
 </div>
 
-<div id="outline-container-orga931660" class="outline-3">
-<h3 id="orga931660">function create-table (symbol)</h3>
-<div class="outline-text-3" id="text-orga931660">
+<div id="outline-container-orge4b097b" class="outline-3">
+<h3 id="orge4b097b">function create-table (symbol)</h3>
+<div class="outline-text-3" id="text-orge4b097b">
 <p>
 Creates the table identified by symbol by executing all forms in its definition.
 </p>
 </div>
 </div>
 
-<div id="outline-container-orge480d8a" class="outline-3">
-<h3 id="orge480d8a">function create-all-tables ()</h3>
-<div class="outline-text-3" id="text-orge480d8a">
+<div id="outline-container-org2ca2b8d" class="outline-3">
+<h3 id="org2ca2b8d">function create-all-tables ()</h3>
+<div class="outline-text-3" id="text-org2ca2b8d">
 <p>
 Creates all defined tables.
 </p>
 </div>
 </div>
 
-<div id="outline-container-orgdd79715" class="outline-3">
-<h3 id="orgdd79715">function create-package-tables (package)</h3>
-<div class="outline-text-3" id="text-orgdd79715">
+<div id="outline-container-org93120ba" class="outline-3">
+<h3 id="org93120ba">function create-package-tables (package)</h3>
+<div class="outline-text-3" id="text-org93120ba">
 <p>
 Creates all tables identified by symbols interned in the given package.
 </p>
 </div>
 </div>
 
-<div id="outline-container-orgfd826c0" class="outline-3">
-<h3 id="orgfd826c0">variables <b>table-name</b>, <b>table-symbol</b></h3>
-<div class="outline-text-3" id="text-orgfd826c0">
+<div id="outline-container-org5b3e257" class="outline-3">
+<h3 id="org5b3e257">variables <b>table-name</b>, <b>table-symbol</b></h3>
+<div class="outline-text-3" id="text-org5b3e257">
 <p>
 These variables are bound to the relevant name and symbol while the forms of a
 table definition are evaluated. Can be used to define shorthands like the ones
@@ -2438,9 +2448,9 @@ below.
 </div>
 </div>
 
-<div id="outline-container-org26dbf4a" class="outline-2">
-<h2 id="org26dbf4a">Schemata</h2>
-<div class="outline-text-2" id="text-org26dbf4a">
+<div id="outline-container-org94988a4" class="outline-2">
+<h2 id="org94988a4">Schemata</h2>
+<div class="outline-text-2" id="text-org94988a4">
 <p>
 Schema allow you to separate tables into differnet name spaces. In different
 schemata two tables with the same name are allowed to exists. The tables can
@@ -2451,44 +2461,44 @@ functions allow you to create, drop schemata and to set the search path.
 </p>
 </div>
 
-<div id="outline-container-org90fd2a6" class="outline-3">
-<h3 id="org90fd2a6">function create-schema (schema)</h3>
-<div class="outline-text-3" id="text-org90fd2a6">
+<div id="outline-container-orgfb8a41d" class="outline-3">
+<h3 id="orgfb8a41d">function create-schema (schema)</h3>
+<div class="outline-text-3" id="text-orgfb8a41d">
 <p>
 Creates a new schema. Raises an error if the schema is already exists.
 </p>
 </div>
 </div>
 
-<div id="outline-container-orgf2a0940" class="outline-3">
-<h3 id="orgf2a0940">function drop-schema (schema)</h3>
-<div class="outline-text-3" id="text-orgf2a0940">
+<div id="outline-container-orga69ac80" class="outline-3">
+<h3 id="orga69ac80">function drop-schema (schema)</h3>
+<div class="outline-text-3" id="text-orga69ac80">
 <p>
 Removes a schema. Raises an error if the schema is not empty.
 </p>
 </div>
 </div>
 
-<div id="outline-container-org8bc0bc9" class="outline-3">
-<h3 id="org8bc0bc9">function get-search-path ()</h3>
-<div class="outline-text-3" id="text-org8bc0bc9">
+<div id="outline-container-org2dbd10b" class="outline-3">
+<h3 id="org2dbd10b">function get-search-path ()</h3>
+<div class="outline-text-3" id="text-org2dbd10b">
 <p>
 Retrieve the current search path.
 </p>
 </div>
 </div>
 
-<div id="outline-container-org515af3e" class="outline-3">
-<h3 id="org515af3e">function set-search-path (path)</h3>
-<div class="outline-text-3" id="text-org515af3e">
+<div id="outline-container-org917c9f7" class="outline-3">
+<h3 id="org917c9f7">function set-search-path (path)</h3>
+<div class="outline-text-3" id="text-org917c9f7">
 <p>
 Sets the search path to the path. This function is used by with-schema.
 </p>
 </div>
 </div>
-<div id="outline-container-org42dfec3" class="outline-3">
-<h3 id="org42dfec3">function split-fully-qualified-table-name (name)</h3>
-<div class="outline-text-3" id="text-org42dfec3">
+<div id="outline-container-orgb8e5556" class="outline-3">
+<h3 id="orgb8e5556">function split-fully-qualified-table-name (name)</h3>
+<div class="outline-text-3" id="text-orgb8e5556">
 <p>
 → list
 Takes a name of the form database.schema.table or schema.table or just table
@@ -2499,7 +2509,7 @@ and returns a list in the form '(table schema database)
 </div>
 </div>
 <div id="postamble" class="status">
-<p class="date">Created: 2018-12-02 Sun 21:42</p>
+<p class="date">Created: 2018-12-06 Thu 22:10</p>
 <p class="validation"><a href="http://validator.w3.org/check?uri=referer">Validate</a></p>
 </div>
 </body>

--- a/doc/postmodern.org
+++ b/doc/postmodern.org
@@ -148,11 +148,12 @@ whose cdr contains the arguments. For example:
 ** macro prepare (query &optional (format :rows))
 → function
 
-Creates a function that can be used as the interface to a prepared statement.
-The given query (either a string or an S-SQL form) may contain placeholders,
-which look like $1, $2, etc. The resulting function takes one argument for
-every placeholder in the query, executes the prepared query, and returns the
-result in the format specified. (Allowed formats are the same as for query.)
+Wraps a query into a function that can be used as the interface to a prepared
+statement. The given query (either a string or an S-SQL form) may contain
+placeholders, which look like $1, $2, etc. The resulting function takes one
+argument for every placeholder in the query, executes the prepared query,
+and returns the result in the format specified. (Allowed formats are the
+same as for query.)
 
 For queries that have to be run very often, especially when they are complex,
 it may help performance since the server only has to plan them once. See
@@ -162,6 +163,12 @@ In some cases, the server will complain about not being able to deduce the
 type of the arguments in a statement. In that case you should add type
 declarations (either with the PostgreSQL's CAST SQL-conforming syntax or
 historical :: syntax, or with S-SQL's :type construct) to help it out.
+
+Note that it will attempt to automatically reconnect if
+database-connection-error, or admin-shutdown. It will reset prepared
+statements triggering an invalid-sql-statement-name error. It will
+overwrite old prepared statements triggering a duplicate-prepared-statement
+error.
 
 ** macro defprepared (name query &optional (format :rows))
 → function
@@ -351,11 +358,12 @@ when given only one argument, for transforming :nulls to NIL.
 This returns t if the prepared statement exists in the current
 postgresql session, otherwise nil.
 
-** function list-prepared-statements()
+** function list-prepared-statements(&optional (names-only nil))
 → list
 
 This is syntactic sugar. It runs a query that lists the prepared statements in
-the session in which the function is run.
+the session in which the function is run. If the names-only parameter is set
+to t, it will only return a list of the names of the prepared statements.
 
 ** function drop-prepared-statement (statement-name &key (location :both) (database *database*))
 

--- a/doc/postmodern.org
+++ b/doc/postmodern.org
@@ -16,7 +16,6 @@ that break the connection (socket errors, database shutdowns) will be
 raised as subtypes of database-connection-error, providing a :reconnect
 restart to re-try the operation that encountered to the error.
 
-
 * Connecting
 ** class database-connection
 
@@ -165,9 +164,11 @@ declarations (either with the PostgreSQL's CAST SQL-conforming syntax or
 historical :: syntax, or with S-SQL's :type construct) to help it out.
 
 ** macro defprepared (name query &optional (format :rows))
+→ function
 
-This is the macro-style variant of prepare. It will define a top-level
-function for the prepared statement.
+This is the macro-style variant of prepare. It is like prepare, but gives
+the function a name which now becomes a top-level function for the
+prepared statement. The name should not be quoted or a string.
 
 ** macro defprepared-with-names (name (&rest args) (query &rest query-args) &optional (format :rows))
 
@@ -341,6 +342,93 @@ according to S-SQL rules.
 Returns the first non-NIL, non-NULL (as in :null) argument, or NIL if none are
 present. Useful for providing a fall-back value for the result of a query, or,
 when given only one argument, for transforming :nulls to NIL.
+
+
+* Helper functions for Prepared Statements
+
+** function prepared-statement-exists-p (name)
+→ boolean
+This returns t if the prepared statement exists in the current
+postgresql session, otherwise nil.
+
+** function list-prepared-statements()
+→ list
+
+This is syntactic sugar. It runs a query that lists the prepared statements in
+the session in which the function is run.
+
+** function drop-prepared-statement (statement-name &key (location :both) (database *database*))
+
+Prepared statements are stored both in the meta slot in the postmodern
+connection and in postgresql session information. If you know the prepared
+statement name, you can delete the prepared statement from both locations (the
+default behavior), just from postmodern (passing :postmodern to the location
+key parameter) or just from postgresql (passing :postgresql to the location
+key parameter). If you pass the name 'All' as the statement name, it will
+delete all prepared statements.
+
+** function list-postmodern-prepared-statements (&optional (names-only nil))
+→ list
+
+List the prepared statements that postmodern has put in the meta slot in
+the connection. It will return a list of alists of form:
+  ((:NAME . \"SNY24\")
+  (:STATEMENT . \"(SELECT name, salary FROM employee WHERE (city = $1))\")
+  (:PREPARE-TIME . #<TIMESTAMP 25-11-2018T15:36:43,385>)
+  (:PARAMETER-TYPES . \"{text}\") (:FROM-SQL)
+
+If the names-only parameter is set to t, it will only return a list of
+the names of the prepared statements.
+
+** function find-postgresql-prepared-statement (name)
+→ string
+
+Returns the specified named prepared statement (if any) that postgresql has for this
+session.
+
+** function find-postmodern-prepared-statement (name)
+→ string
+
+Returns the specified named prepared statement (if any) that postmodern has
+put in the meta slot in the connection. Note that this is the statement itself,
+not the name.
+
+** function reset-prepared-statement (condition)
+→ restart
+
+If you have received an invalid-prepared-statement error but the prepared
+statement is still in the meta slot in the postmodern connection, this will
+try to regenerate the prepared statement at the database connection level
+and restart the connection.
+
+** function overwrite-prepared-statement (condition)
+→ restart
+
+If you have received an invalid-prepared-statement error but the prepared
+statement is still in the meta slot in the postmodern connection,
+this will try to regenerate the prepared statement at the database
+connection level and restart the connection.
+
+** function get-pid ()
+→ integer
+
+Get the process id used by postgresql for this connection.
+
+** function get-pid-from-postmodern ()
+→ integer
+
+Get the process id used by postgresql for this connection,
+but get it from the postmodern connection parameters.
+
+** function cancel-backend (pid)
+
+Polite way of terminating a query at the database (as opposed to calling close-database).
+Slower than (terminate-backend pid) and does not always work.
+
+** function terminate-backend (pid)
+
+Less polite way of terminating at the database (as opposed to calling close-database).
+Faster than (cancel-backend pid) and more reliable.
 
 * Inspecting the database
 ** function list-tables (&optional strings-p)

--- a/doc/postmodern.org
+++ b/doc/postmodern.org
@@ -166,7 +166,7 @@ historical :: syntax, or with S-SQL's :type construct) to help it out.
 
 ** macro defprepared (name query &optional (format :rows))
 
-This is the defun-style variant of prepare. It will define a top-level
+This is the macro-style variant of prepare. It will define a top-level
 function for the prepared statement.
 
 ** macro defprepared-with-names (name (&rest args) (query &rest query-args) &optional (format :rows))

--- a/postmodern/package.lisp
+++ b/postmodern/package.lisp
@@ -63,7 +63,7 @@
    #:find-postgresql-prepared-statement
    #:reset-prepared-statement
    #:overwrite-prepared-statement
-   #:get-pid #:cancel-backend #:terminate-backed
+   #:get-pid #:cancel-backend #:terminate-backend
    #:get-pid-from-postmodern
 
    ;; Reduced S-SQL interface

--- a/postmodern/package.lisp
+++ b/postmodern/package.lisp
@@ -56,6 +56,16 @@
    #:list-tables-in-schema
    #:split-fully-qualified-tablename
 
+   ;; Prepared Statement Functions
+   #:prepared-statement-exists-p #:list-prepared-statements
+   #:drop-prepared-statement #:list-postmodern-prepared-statements
+   #:find-postmodern-prepared-statement
+   #:find-postgresql-prepared-statement
+   #:reset-prepared-statement
+   #:overwrite-prepared-statement
+   #:get-pid #:cancel-backend #:terminate-backed
+   #:get-pid-from-postmodern
+
    ;; Reduced S-SQL interface
    #:sql #:sql-compile
    #:smallint #:bigint #:numeric #:real #:double-precision
@@ -66,6 +76,8 @@
    ;; Condition type from cl-postgres
    #:database-error #:database-error-message #:database-error-code
    #:database-error-detail #:database-error-query #:database-error-cause
-   #:database-connection-error #:database-error-constraint-name))
+   #:database-connection-error #:database-error-constraint-name
+   #:database-error-invalid-sql-statement-name
+   #:database-error-syntax-error-or-access-violation))
 
 (in-package :postmodern)

--- a/postmodern/package.lisp
+++ b/postmodern/package.lisp
@@ -77,7 +77,6 @@
    #:database-error #:database-error-message #:database-error-code
    #:database-error-detail #:database-error-query #:database-error-cause
    #:database-connection-error #:database-error-constraint-name
-   #:database-error-invalid-sql-statement-name
-   #:database-error-syntax-error-or-access-violation))
+   #:database-error-extract-name))
 
 (in-package :postmodern)

--- a/postmodern/prepare.lisp
+++ b/postmodern/prepare.lisp
@@ -1,9 +1,12 @@
 (in-package :postmodern)
 
 (defun ensure-prepared (connection id query)
-  "Make sure a statement has been prepared for this connection."
+  "Make sure a statement has been prepared for this connection.
+If there is a query by the same name in the connection meta slot
+and that query is different than the query parameter, the query
+in the connection meta slot will be replaced by the new query."
   (let ((meta (connection-meta connection)))
-    (unless (gethash id meta)
+    (unless (and (gethash id meta) (equal (gethash id meta) query))
       (setf (gethash id meta) query)
       (prepare-query connection id query))))
 
@@ -20,9 +23,29 @@
       `(let ((statement-id ,(string name))
              (query ,(real-query query)))
          (,@function-form (&rest params)
+            (handler-bind ((cl-postgres-error:admin-shutdown
+                            (lambda (msg)
+                              (declare (ignore msg))
+                  (invoke-restart :reconnect))))
+               (cl-postgres::with-reconnect-restart *database*
+                  (handler-bind
+                      ((cl-postgres-error:invalid-sql-statement-name #'pomo:reset-prepared-statement))
+                    (cl-postgres::with-reconnect-restart *database*
+                  (handler-bind
+                     ((cl-postgres-error:duplicate-prepared-statement #'pomo:overwrite-prepared-statement))
+                     (ensure-prepared *database* statement-id query)
+                     (,result-form ,base)))))))))))
+#|
+(defun generate-prepared (function-form name query format)
+  "Helper function for the following two macros."
+  (destructuring-bind (reader result-form) (reader-for-format format)
+    (let ((base `(exec-prepared *database* statement-id params ,reader)))
+      `(let ((statement-id ,(string name))
+             (query ,(real-query query)))
+         (,@function-form (&rest params)
                           (ensure-prepared *database* statement-id query)
                           (,result-form ,base))))))
-
+|#
 (defmacro prepare (query &optional (format :rows))
   "Wraps a query into a function that will prepare it once for a
 connection, and then execute it with the given parameters. The query
@@ -35,48 +58,132 @@ it. The name should not be quoted or a string."
   (generate-prepared `(defun ,name) name query format))
 
 (defun prepared-statement-exists-p (statement-name)
-  "Returns t if the prepared statement exists in the current postgresql session."
-  (query (:select 'name
-                  :from 'pg-prepared-statements
-                  :where (:= 'name (string-upcase statement-name)))))
+  "Returns t if the prepared statement exists in the current postgresql
+session, otherwise nil."
+  (if (query (:select 'name
+                   :from 'pg-prepared-statements
+                   :where (:= 'name (string-upcase statement-name)))
+             :single)
+      t
+      nil))
 
 (defun list-prepared-statements ()
   "Syntactic sugar. A query that lists the prepared statements
 in the session in which the function is run."
-  (query (:select '* :from 'pg-prepared-statements) :alists))
+  (query "select * from pg_prepared_statements" :alists))
 
-(defun drop-prepared-statement (statement-name &optional (database *database*))
-  "If you know the prepared statement name, this will call
-postgresql to deallocate the prepared statement"
+(defun drop-prepared-statement (statement-name &key (location :both) (database *database*))
+  "Prepared statements are stored both in the meta slot in the postmodern
+connection and in postgresql session information. If you know the prepared
+statement name, you can delete the prepared statement from both locations (the
+default behavior), just from postmodern (passing :postmodern to the location
+key parameter) or just from postgresql (passing :postgresql to the location
+key parameter). If you pass the name 'All' as the statement name, it will
+delete all prepared statements."
   (check-type statement-name string)
-  (when (gethash (string-upcase statement-name) (connection-meta database))
-    (remhash (string-upcase statement-name) (connection-meta database))
-    (query (format nil "deallocate \"~a\"" (string-upcase statement-name)))))
+  (check-type location keyword)
+  (setf statement-name (string-upcase statement-name))
+  (cond ((eq location :both)
+         (when (or (equal statement-name "ALL")
+                   (prepared-statement-exists-p statement-name))
+           (if (equal statement-name "ALL")
+               (progn
+                 (clrhash (connection-meta database))
+                 (query "deallocate ALL"))
+               (progn
+                 (remhash statement-name (connection-meta database))
+                 (query (format nil "deallocate ~:@(~S~)" statement-name))))))
+        ((eq location :postmodern)
+         (if (equal statement-name "ALL")
+             (clrhash (connection-meta database))
+             (remhash (string-upcase statement-name) (connection-meta database))))
+        ((eq location :postgresql)
+         (cond ((equal statement-name "ALL")
+                (query "deallocate ALL"))
+               ((prepared-statement-exists-p statement-name)
+                (query (format nil "deallocate ~:@(~S~)" statement-name)))
+               (t nil)))))
 
-(defun list-postmodern-prepared-statements ()
+(defun list-postmodern-prepared-statements (&optional (names-only nil))
   "List the prepared statements that postmodern has put in the meta slot in
 the connection. It will return a list of alists of form:
   ((:NAME . \"SNY24\")
   (:STATEMENT . \"(SELECT name, salary FROM employee WHERE (city = $1))\")
   (:PREPARE-TIME . #<TIMESTAMP 25-11-2018T15:36:43,385>)
-  (:PARAMETER-TYPES . \"{text}\") (:FROM-SQL)"
-  (alexandria:hash-table-alist (postmodern::connection-meta *database*)))
+  (:PARAMETER-TYPES . \"{text}\") (:FROM-SQL).
+
+If the names-only parameter is set to t, it will only return a list of
+the names of the prepared statements."
+  (if names-only
+      (alexandria:hash-table-keys (postmodern::connection-meta *database*))
+      (alexandria:hash-table-alist (postmodern::connection-meta *database*))))
+
+(defun find-postgresql-prepared-statement (name)
+  "Returns the specified named prepared statement (if any) that postgresql
+has for this session."
+  (query (:select 'statement
+                  :from 'pg-prepared-statements
+                  :where (:= 'name (string-upcase name)))
+         :single))
 
 (defun find-postmodern-prepared-statement (name)
-  "Returns the named prepared statement (if any) that postmodern has put in
+  "Returns the specified named prepared statement (if any) that postmodern has put in
 the meta slot in the connection."
-  (gethash name (postmodern::connection-meta *database*)))
+  (gethash (string-upcase name) (postmodern::connection-meta *database*)))
+
+(defun reset-prepared-statement (condition)
+  "If you have received an invalid-prepared-statement error but the prepared
+statement is still in the meta slot in the postmodern connection,
+try to regenerate the prepared statement at the database connection level
+and restart the connection."
+  (let* ((name (cl-postgres::database-error-invalid-sql-statement-name condition))
+         (statement (find-postmodern-prepared-statement name))
+         (pid (write-to-string (first (cl-postgres::connection-pid *database*)))))
+    (setf (cl-postgres::connection-available *database*) t)
+    (cl-postgres::with-reconnect-restart *database*
+      (terminate-backend pid))
+    (cl-postgres:prepare-query *database* name statement)
+    (invoke-restart 'reset-prepared-statement)))
+
+(defun overwrite-prepared-statement (condition)
+  "If you have received an invalid-prepared-statement error but the prepared
+statement is still in the meta slot in the postmodern connection,
+try to regenerate the prepared statement at the database connection level
+and restart the connection."
+  (let* ((name (cl-postgres::database-error-syntax-error-or-access-violation condition))
+         (statement (find-postmodern-prepared-statement name))
+         (pid (write-to-string (first (cl-postgres::connection-pid *database*)))))
+    (setf (cl-postgres::connection-available *database*) t)
+    (cl-postgres::with-reconnect-restart *database*
+      (terminate-backend pid))
+    (cl-postgres:prepare-query *database* name statement)
+    (invoke-restart 'overwrite-prepared-statement)))
 
 (defun get-pid ()
-  "Get the process id used by postgresql for this connection"
+  "Get the process id used by postgresql for this connection."
   (query "select pg_backend_pid()" :single))
 
-(defun cancel-backend (pid)
-  "Polite way of terminating a query at the database (as opposed to calling close-database).
-Slower than (terminate-backend pid)"
-  (query "select pg_cancel_backend($1);" pid))
+(defun get-pid-from-postmodern ()
+  "Get the process id used by postgresql for this connection,
+but get it from the postmodern connection parameters."
+  (gethash "pid" (pomo::connection-parameters *database*)))
 
-(defun terminate-backend (pid)
+(defun cancel-backend (pid &optional (database *database*))
+  "Polite way of terminating a query at the database (as opposed to calling close-database).
+Slower than (terminate-backend pid) and does not always work."
+    (let ((database-name (cl-postgres::connection-db database))
+        (user (cl-postgres::connection-user database))
+        (password (cl-postgres::connection-password database))
+        (host (cl-postgres::connection-host database)))
+    (with-connection `(,database-name ,user ,password ,host)
+      (query "select pg_cancel_backend($1);" pid))))
+
+(defun terminate-backend (pid &optional (database *database*))
   "Less polite way of terminating at the database (as opposed to calling close-database).
-Faster than (cancel-backend pid)"
-  (query "select pg_terminate_backend($1);" pid))
+Faster than (cancel-backend pid) and more reliable."
+  (let ((database-name (cl-postgres::connection-db database))
+        (user (cl-postgres::connection-user database))
+        (password (cl-postgres::connection-password database))
+        (host (cl-postgres::connection-host database)))
+    (with-connection `(,database-name ,user ,password ,host)
+      (query "select pg_terminate_backend($1);" pid))))

--- a/postmodern/prepare.lisp
+++ b/postmodern/prepare.lisp
@@ -136,7 +136,7 @@ the meta slot in the connection."
 statement is still in the meta slot in the postmodern connection,
 try to regenerate the prepared statement at the database connection level
 and restart the connection."
-  (let* ((name (cl-postgres::database-error-invalid-sql-statement-name condition))
+  (let* ((name (pomo:database-error-extract-name condition))
          (statement (find-postmodern-prepared-statement name))
          (pid (write-to-string (first (cl-postgres::connection-pid *database*)))))
     (setf (cl-postgres::connection-available *database*) t)
@@ -150,7 +150,7 @@ and restart the connection."
 statement is still in the meta slot in the postmodern connection,
 try to regenerate the prepared statement at the database connection level
 and restart the connection."
-  (let* ((name (cl-postgres::database-error-syntax-error-or-access-violation condition))
+  (let* ((name (pomo:database-error-extract-name condition))
          (statement (find-postmodern-prepared-statement name))
          (pid (write-to-string (first (cl-postgres::connection-pid *database*)))))
     (setf (cl-postgres::connection-available *database*) t)

--- a/postmodern/prepare.lisp
+++ b/postmodern/prepare.lisp
@@ -11,35 +11,72 @@
   (defun next-statement-id ()
     "Provide unique statement names."
     (incf next-id)
-    (with-standard-io-syntax (format nil "STATEMENT-~A" next-id))))
+    (with-standard-io-syntax (format nil "STATEMENT_~A" next-id))))
 
-(defun generate-prepared (function-form query format)
-  "Helper macro for the following two functions."
+(defun generate-prepared (function-form name query format)
+  "Helper function for the following two macros."
   (destructuring-bind (reader result-form) (reader-for-format format)
     (let ((base `(exec-prepared *database* statement-id params ,reader)))
-      `(let ((statement-id (next-statement-id))
+      `(let ((statement-id ,(string name))
              (query ,(real-query query)))
-        (,@function-form (&rest params)
-          (ensure-prepared *database* statement-id query)
-         (,result-form ,base))))))
+         (,@function-form (&rest params)
+                          (ensure-prepared *database* statement-id query)
+                          (,result-form ,base))))))
 
 (defmacro prepare (query &optional (format :rows))
   "Wraps a query into a function that will prepare it once for a
 connection, and then execute it with the given parameters. The query
 should contain a placeholder \($1, $2, etc) for every parameter."
-  (generate-prepared '(lambda) query format))
+  (generate-prepared '(lambda) (next-statement-id) query format))
 
 (defmacro defprepared (name query &optional (format :rows))
-  "Like perpare, but gives the function a name instead of returning
-it."
-  (generate-prepared `(defun ,name) query format))
+  "Like prepare, but gives the function a name instead of returning
+it. The name should not be quoted or a string."
+  (generate-prepared `(defun ,name) name query format))
 
-(defmacro defprepared-with-names (name (&rest args)
-				  (query &rest query-args)
-				  &optional (format :rows))
-  "Like defprepared, but with lambda list for statement arguments."
-  (let ((prepared-name (gensym "PREPARED")))
-    `(let ((,prepared-name (prepare ,query ,format)))
-       (declare (type function ,prepared-name))
-       (defun ,name ,args
-	       (funcall ,prepared-name ,@query-args)))))
+(defun prepared-statement-exists-p (statement-name)
+  "Returns t if the prepared statement exists in the current postgresql session."
+  (query (:select 'name
+                  :from 'pg-prepared-statements
+                  :where (:= 'name (string-upcase statement-name)))))
+
+(defun list-prepared-statements ()
+  "Syntactic sugar. A query that lists the prepared statements
+in the session in which the function is run."
+  (query (:select '* :from 'pg-prepared-statements) :alists))
+
+(defun drop-prepared-statement (statement-name &optional (database *database*))
+  "If you know the prepared statement name, this will call
+postgresql to deallocate the prepared statement"
+  (check-type statement-name string)
+  (when (gethash (string-upcase statement-name) (connection-meta database))
+    (remhash (string-upcase statement-name) (connection-meta database))
+    (query (format nil "deallocate \"~a\"" (string-upcase statement-name)))))
+
+(defun list-postmodern-prepared-statements ()
+  "List the prepared statements that postmodern has put in the meta slot in
+the connection. It will return a list of alists of form:
+  ((:NAME . \"SNY24\")
+  (:STATEMENT . \"(SELECT name, salary FROM employee WHERE (city = $1))\")
+  (:PREPARE-TIME . #<TIMESTAMP 25-11-2018T15:36:43,385>)
+  (:PARAMETER-TYPES . \"{text}\") (:FROM-SQL)"
+  (alexandria:hash-table-alist (postmodern::connection-meta *database*)))
+
+(defun find-postmodern-prepared-statement (name)
+  "Returns the named prepared statement (if any) that postmodern has put in
+the meta slot in the connection."
+  (gethash name (postmodern::connection-meta *database*)))
+
+(defun get-pid ()
+  "Get the process id used by postgresql for this connection"
+  (query "select pg_backend_pid()" :single))
+
+(defun cancel-backend (pid)
+  "Polite way of terminating a query at the database (as opposed to calling close-database).
+Slower than (terminate-backend pid)"
+  (query "select pg_cancel_backend($1);" pid))
+
+(defun terminate-backend (pid)
+  "Less polite way of terminating at the database (as opposed to calling close-database).
+Faster than (cancel-backend pid)"
+  (query "select pg_terminate_backend($1);" pid))

--- a/postmodern/table.lisp
+++ b/postmodern/table.lisp
@@ -7,6 +7,14 @@
    (column-map :reader dao-column-map))
   (:documentation "Metaclass for database-access-object classes."))
 
+(defgeneric dao-keys (class)
+  (:documentation "Returns list of slot names that are the primary key of DAO
+class. This is likely interesting if you have primary keys which are composed
+of more than one slot. Pay careful attention to situations where the primary
+key not only has more than one column, but they are actually in a different
+order than they are in the database table itself. You can check this with the
+find-primary-key-info function."))
+
 (defmethod dao-keys :before ((class dao-class))
   (unless (class-finalized-p class)
                #+postmodern-thread-safe

--- a/postmodern/tests/tests.lisp
+++ b/postmodern/tests/tests.lisp
@@ -111,39 +111,61 @@
     (execute (:insert-into 'test-data :set 'a 2 'b 88 'c :null))
     (let ((select-int (prepare (:select (:type '$1 integer)) :single))
           (byte-arr (make-array 10 :element-type '(unsigned-byte 8) :initial-element 10))
-          (select-bytes (prepare (:select (:type '$1 bytea)) :single)))
+          (select-bytes (prepare (:select (:type '$1 bytea)) :single))
+          (select-int-internal-name nil))
       (defprepared select1 "select a from test_data where c = $1" :single)
-      (is (not (list-prepared-statements)))
+      ;; Defprepared does not change the prepared statements logged in the postmodern connection or
+      ;; in the postgresql connection. That will happen when the prepared statement is funcalled.
+      (is (equal 0 (length (list-postmodern-prepared-statements t))))
+      (is (equal 0 (length (list-prepared-statements t))))
       (is (= (funcall select-int 10) 10))
       (is (= (funcall select-int -40) -40))
       (is (eq (funcall select-int :null) :null))
+      (setf select-int-internal-name (car (list-prepared-statements t)))
+      ;; the funcall creates the prepared statements logged in the postmodern connection
+      ;; and the postgresql connection
+      (is (equal 1 (length (list-postmodern-prepared-statements t))))
+      (is (equal 1 (length (list-prepared-statements t))))
       (is (equalp (funcall select-bytes byte-arr) byte-arr))
-      (is (equal 2 (length (list-prepared-statements))))
+      (is (equal 2 (length (list-prepared-statements t))))
       (is (not (prepared-statement-exists-p "select1")))
       (is (equal 1 (funcall 'select1 "foobar")))
       (is (prepared-statement-exists-p "select1"))
-      (is (equal 3 (length (list-prepared-statements))))
+      (is (equal 3 (length (list-postmodern-prepared-statements t))))
+      (is (equal 3 (length (list-prepared-statements t))))
+      ;; drop the defprepared statement from postgresql, but not from postmodern`
       (drop-prepared-statement "select1" :location :postgresql)
+      (is (equal 3 (length (list-postmodern-prepared-statements t))))
+      (is (equal 2 (length (list-prepared-statements t))))
+      ;; drop one of the prepared statements from both postgresql and postmodern
+      (drop-prepared-statement select-int-internal-name)
       (is (not (prepared-statement-exists-p "select1")))
-      (is (equal 2 (length (list-prepared-statements))))
-      (is (equal 3 (length (list-postmodern-prepared-statements))))
+      (is (equal 1 (length (list-prepared-statements t))))
+      (is (equal 2 (length (list-postmodern-prepared-statements t))))
+      ;; recreate the defprepared statement into postgresql
       (is (equal 1 (funcall 'select1 "foobar")))
-      (is (equal 3 (length (list-prepared-statements))))
+      (is (equal 2 (length (list-prepared-statements t))))
+      ;; recreate the first prepared statement back into both postgresql and postmodern
+      (is (= (funcall select-int 10) 10))
+      (is (equal 3 (length (list-postmodern-prepared-statements t))))
+      (is (equal 3 (length (list-prepared-statements t))))
       (is (member '("SELECT1" . "select a from test_data where c = $1")
                   (list-postmodern-prepared-statements) :test 'equal))
       (is (member "SELECT1" (list-postmodern-prepared-statements t) :test 'equal))
       (is (equal "select a from test_data where c = $1" (find-postmodern-prepared-statement "select1")))
+      ;; Now change the defprepared statement
       (defprepared select1 "select c from test_data where a = $1" :single)
       ;; Defprepared does not change the prepared statements logged in the postmodern connection or
       ;; in the postgresql connection. That will happen when the prepared statement is funcalled.
       (is (equal "select a from test_data where c = $1" (find-postmodern-prepared-statement "select1")))
       (funcall 'select1 2)
+      ;; Now the defprepared statement is actually changed in both postmodern and postgresql
       (is (equal "select c from test_data where a = $1" (find-postmodern-prepared-statement "select1")))
       (is (equal "select c from test_data where a = $1" (find-postgresql-prepared-statement "select1")))
       (is (eq :null (funcall 'select1 2)))
       (drop-prepared-statement "all")
-      (is (equal 0 (length (list-prepared-statements))))
-      (is (equal 0 (length (list-postmodern-prepared-statements)))))
+      (is (equal 0 (length (list-prepared-statements t))))
+      (is (equal 0 (length (list-postmodern-prepared-statements t)))))
     (execute (:drop-table 'test-data))))
 
 (test prepare-pooled
@@ -157,40 +179,155 @@
     (execute (:insert-into 'test-data :set 'a 2 'b 88 'c :null))
     (let ((select-int (prepare (:select (:type '$1 integer)) :single))
           (byte-arr (make-array 10 :element-type '(unsigned-byte 8) :initial-element 10))
-          (select-bytes (prepare (:select (:type '$1 bytea)) :single)))
+          (select-bytes (prepare (:select (:type '$1 bytea)) :single))
+          (select-int-internal-name nil))
       (defprepared select1 "select a from test_data where c = $1" :single)
-      (is (not (list-prepared-statements)))
+      ;; Defprepared does not change the prepared statements logged in the postmodern connection or
+      ;; in the postgresql connection. That will happen when the prepared statement is funcalled.
+      (is (equal 0 (length (list-postmodern-prepared-statements t))))
+      (is (equal 0 (length (list-prepared-statements t))))
       (is (= (funcall select-int 10) 10))
       (is (= (funcall select-int -40) -40))
       (is (eq (funcall select-int :null) :null))
+      (setf select-int-internal-name (car (list-prepared-statements t)))
+      ;; the funcall creates the prepared statements logged in the postmodern connection
+      ;; and the postgresql connection
+      (is (equal 1 (length (list-postmodern-prepared-statements t))))
+      (is (equal 1 (length (list-prepared-statements t))))
       (is (equalp (funcall select-bytes byte-arr) byte-arr))
-      (is (equal 2 (length (list-prepared-statements))))
+      (is (equal 2 (length (list-prepared-statements t))))
       (is (not (prepared-statement-exists-p "select1")))
       (is (equal 1 (funcall 'select1 "foobar")))
       (is (prepared-statement-exists-p "select1"))
-      (is (equal 3 (length (list-prepared-statements))))
+      (is (equal 3 (length (list-postmodern-prepared-statements t))))
+      (is (equal 3 (length (list-prepared-statements t))))
+      ;; drop the defprepared statement from postgresql, but not from postmodern`
       (drop-prepared-statement "select1" :location :postgresql)
+      (is (equal 3 (length (list-postmodern-prepared-statements t))))
+      (is (equal 2 (length (list-prepared-statements t))))
+      ;; drop one of the prepared statements from both postgresql and postmodern
+      (drop-prepared-statement select-int-internal-name)
       (is (not (prepared-statement-exists-p "select1")))
-      (is (equal 2 (length (list-prepared-statements))))
-      (is (equal 3 (length (list-postmodern-prepared-statements))))
+      (is (equal 1 (length (list-prepared-statements t))))
+      (is (equal 2 (length (list-postmodern-prepared-statements t))))
+      ;; recreate the defprepared statement into postgresql
       (is (equal 1 (funcall 'select1 "foobar")))
-      (is (equal 3 (length (list-prepared-statements))))
+      (is (equal 2 (length (list-prepared-statements t))))
+      ;; recreate the first prepared statement back into both postgresql and postmodern
+      (is (= (funcall select-int 10) 10))
+      (is (equal 3 (length (list-postmodern-prepared-statements t))))
+      (is (equal 3 (length (list-prepared-statements t))))
       (is (member '("SELECT1" . "select a from test_data where c = $1")
                   (list-postmodern-prepared-statements) :test 'equal))
       (is (member "SELECT1" (list-postmodern-prepared-statements t) :test 'equal))
       (is (equal "select a from test_data where c = $1" (find-postmodern-prepared-statement "select1")))
+      ;; Now change the defprepared statement
       (defprepared select1 "select c from test_data where a = $1" :single)
       ;; Defprepared does not change the prepared statements logged in the postmodern connection or
       ;; in the postgresql connection. That will happen when the prepared statement is funcalled.
       (is (equal "select a from test_data where c = $1" (find-postmodern-prepared-statement "select1")))
       (funcall 'select1 2)
+      ;; Now the defprepared statement is actually changed in both postmodern and postgresql
       (is (equal "select c from test_data where a = $1" (find-postmodern-prepared-statement "select1")))
       (is (equal "select c from test_data where a = $1" (find-postgresql-prepared-statement "select1")))
       (is (eq :null (funcall 'select1 2)))
       (drop-prepared-statement "all")
-      (is (equal 0 (length (list-prepared-statements))))
-      (is (equal 0 (length (list-postmodern-prepared-statements)))))
+      (is (equal 0 (length (list-prepared-statements t))))
+      (is (equal 0 (length (list-postmodern-prepared-statements t)))))
     (execute (:drop-table 'test-data))))
+
+(test prepared-statement-over-reconnect
+  (let ((terminate-backend
+          (prepare
+              "SELECT pg_terminate_backend($1) WHERE pg_backend_pid() = $1"
+              :rows))
+         (getpid (prepare "SELECT pg_backend_pid()" :single)))
+    (with-test-connection
+      (is (equal (query "select pg_backend_pid()" :single)
+                 (funcall getpid)))
+      (is (equal (funcall getpid) (pomo:get-pid-from-postmodern)))
+      (let ((pid (pomo:get-pid)))
+        (pomo:terminate-backend pid)
+        (signals database-connection-error
+          (query "select pg_backend_pid()" :single)))
+      (is (integerp (funcall getpid))))
+
+    ;; Demonstrate that a prepared statement will reconnect
+    ;; even if it is a termination
+    (with-test-connection
+      (is (equal (query "select pg_backend_pid()" :single)
+                 (funcall getpid)))
+      (is (equal (funcall getpid) (pomo:get-pid-from-postmodern)))
+        (funcall getpid)
+        (is-true (query "select pg_backend_pid()" :single)))
+
+    (with-pooled-test-connection
+      (is (equal (query "select pg_backend_pid()" :single)
+                 (funcall getpid)))
+      (is (equal (funcall getpid) (pomo:get-pid-from-postmodern)))
+      (let ((pid (pomo:get-pid)))
+        (pomo:terminate-backend pid)
+        (signals database-connection-error
+          (query "select pg_backend_pid()" :single))))
+
+    ;; Demonstrate that a prepared statement will reconnect
+    ;; even if it is a termination
+    (with-pooled-test-connection
+      (is (equal (query "select pg_backend_pid()" :single)
+                 (funcall getpid)))
+      (is (equal (funcall getpid) (pomo:get-pid-from-postmodern)))
+        (funcall getpid)
+        (is-true (query "select pg_backend_pid()" :single)))
+
+    ;; A regular query does not have the built-in exception handling
+    ;; available to prepared statements, so this will trigger the
+    ;; exception handling below, setting reconnected to true.
+    (with-test-connection
+      (let ((original-pid (funcall getpid))
+            (reconnectedp nil))
+        (block done
+          (handler-bind
+              ((database-connection-error
+                 (lambda (condition)
+                   (let ((restart (find-restart :reconnect condition)))
+                     (is (not (null restart)))
+                     (setq reconnectedp t)
+                     (invoke-restart restart)))))
+            (pomo:terminate-backend original-pid)
+            (is-true (query "select pg_backend_pid()" :single))
+            (is-true reconnectedp)
+            (is (/= original-pid (funcall getpid)))))
+
+        ;; Re-using the prepared statement on the new connection.
+        (multiple-value-bind (rows count)
+            (funcall terminate-backend 0)
+          (is (null rows))
+          (is (zerop count)))))
+
+    ;; A funcall to a prepared statement reconnects on its own
+    ;; without acdessing the database-connection-error handler
+    ;; above, so reconnectedp will still be nil
+    (with-test-connection
+      (let ((original-pid (funcall getpid))
+            (reconnectedp nil))
+        (block done
+          (handler-bind
+              ((database-connection-error
+                 (lambda (condition)
+                   (let ((restart (find-restart :reconnect condition)))
+                     (is (not (null restart)))
+                     (setq reconnectedp t)
+                     (invoke-restart restart)))))
+            (pomo:terminate-backend original-pid)
+            (is-true (funcall getpid))
+            (is-false reconnectedp)
+            (is (/= original-pid (funcall getpid)))))
+
+        ;; Re-using the prepared statement on the new connection.
+        (multiple-value-bind (rows count)
+            (funcall terminate-backend 0)
+          (is (null rows))
+          (is (zerop count)))))))
 
 (test doquery
   (with-test-connection
@@ -431,99 +568,6 @@
       (execute (:insert-into 'test-data :set 'a #()))
       (execute (:drop-table 'test-data)))
     (is (not (table-exists-p 'test-data)))))
-
-(test prepared-statement-over-reconnect
-  (let ((terminate-backend
-          (prepare
-              "SELECT pg_terminate_backend($1) WHERE pg_backend_pid() = $1"
-              :rows))
-         (getpid (prepare "SELECT pg_backend_pid()" :single)))
-    (with-test-connection
-      (is (equal (query "select pg_backend_pid()" :single)
-                 (funcall getpid)))
-      (is (equal (funcall getpid) (pomo:get-pid-from-postmodern)))
-      (let ((pid (pomo:get-pid)))
-        (pomo:terminate-backend pid)
-        (signals database-connection-error
-          (query "select pg_backend_pid()" :single)))
-      (signals database-connection-error (funcall getpid)))
-
-    ;; Demonstrate that a prepared statement will reconnect
-    ;; even if it is a termination
-    (with-test-connection
-      (is (equal (query "select pg_backend_pid()" :single)
-                 (funcall getpid)))
-      (is (equal (funcall getpid) (pomo:get-pid-from-postmodern)))
-        (funcall getpid)
-        (is-true (query "select pg_backend_pid()" :single)))
-
-    (with-pooled-test-connection
-      (is (equal (query "select pg_backend_pid()" :single)
-                 (funcall getpid)))
-      (is (equal (funcall getpid) (pomo:get-pid-from-postmodern)))
-      (let ((pid (pomo:get-pid)))
-        (pomo:terminate-backend pid)
-        (signals database-connection-error
-          (query "select pg_backend_pid()" :single))))
-
-    ;; Demonstrate that a prepared statement will reconnect
-    ;; even if it is a termination
-    (with-pooled-test-connection
-      (is (equal (query "select pg_backend_pid()" :single)
-                 (funcall getpid)))
-      (is (equal (funcall getpid) (pomo:get-pid-from-postmodern)))
-        (funcall getpid)
-        (is-true (query "select pg_backend_pid()" :single)))
-
-    ;; A regular query does not have the built-in exception handling
-    ;; available to prepared statements, so this will trigger the
-    ;; exception handling below, setting reconnected to true.
-    (with-test-connection
-      (let ((original-pid (funcall getpid))
-            (reconnectedp nil))
-        (block done
-          (handler-bind
-              ((database-connection-error
-                 (lambda (condition)
-                   (let ((restart (find-restart :reconnect condition)))
-                     (is (not (null restart)))
-                     (setq reconnectedp t)
-                     (invoke-restart restart)))))
-            (pomo:terminate-backend original-pid)
-            (is-true (query "select pg_backend_pid()" :single))
-            (is-true reconnectedp)
-            (is (/= original-pid (funcall getpid)))))
-
-        ;; Re-using the prepared statement on the new connection.
-        (multiple-value-bind (rows count)
-            (funcall terminate-backend 0)
-          (is (null rows))
-          (is (zerop count)))))
-
-    ;; A funcall to a prepared statement reconnects on its own
-    ;; without acdessing the database-connection-error handler
-    ;; above, so reconnectedp will still be nil
-    (with-test-connection
-      (let ((original-pid (funcall getpid))
-            (reconnectedp nil))
-        (block done
-          (handler-bind
-              ((database-connection-error
-                 (lambda (condition)
-                   (let ((restart (find-restart :reconnect condition)))
-                     (is (not (null restart)))
-                     (setq reconnectedp t)
-                     (invoke-restart restart)))))
-            (pomo:terminate-backend original-pid)
-            (is-true (funcall getpid))
-            (is-false reconnectedp)
-            (is (/= original-pid (funcall getpid)))))
-
-        ;; Re-using the prepared statement on the new connection.
-        (multiple-value-bind (rows count)
-            (funcall terminate-backend 0)
-          (is (null rows))
-          (is (zerop count)))))))
 
 (test find-primary-key-info
   "Testing find-primary-key-info function. Given a table name, it returns


### PR DESCRIPTION
Bug fixes for issues 178, 179 on prepared statements

Upon connecting to a postgresql database, postmodern puts various parameters
into a hash table in the parameters slot in a database-connection class
instance. With this commit, postmodern also collects the postgresql pid for
a session connection and places that in the in the parameters slot hashtable
as well. It is accessible either using postmodern:get-pid or via
cl-postgres:connection-pid which will return a list of the pid and the session
"secret-key". The secret-key is potentially useful for cancelling queries, but
that functionality is not yet included in postmodern.

It has been pointed out that from time to time over
a network connection, a prepared statement may be created and stored in the
postmodern database-connection class instance, but due to network failure,
timeout, etc has not been provided to postgresql, generating an
invalid-sql-statement-name error when an application tries to use a prepared
statement. Attempts to cancel the prepared statement query while maintaining the
original connection are often rejected claiming that the system is still
processing another query.

With this commit, a funcall to a prepared statement will handle the following
situations differently:

1. If there is an invalid-sql-statement-name error, postmodern will re-prepare
the statement in postgresql. If necessary, it will open another session,
terminate the current session and reconnect.

2. If there is a duplicate-prepared-statement error, postmodern will re-prepare
a new statement in postgresql, overwriting the old prepared statement. If
necessary, it will open another session, terminate the current session and
reconnect if that is necessary.

3. If there is an admin-shutdown error, the funcall to a prepared statement
will attempt to reconnect, and, if necessary, re-prepare the statement at the
postgresql level.

4. If there is a database-connection error, the funcall to a prepared statement
will attempt to reconnect.

Issue 179: This commit also adds the ability to specify prepared statement names
that will be used by postgresql using the defprepared macro. This can help in
reading postgresql log files. Prepared statements generated by the prepare macro
will still use the automatically generated statements.

With this commit, as noted above, any generation of a prepared statement with
the same name as an existing prepared statement will overwrite the existing
statement, effectively allowing you to edit existing statements. Feedback is
requested whether this should be optional. Please note that since prepared
statements using the prepare macro have automatically generated names, this
only impacts prepared statements using the defprepared macro.

Postmodern has added conditions for:
- database-error-invalid-sql-statement-name
- database-error-syntax-error-or-access-violation

There is substantial additional functionality regarding listing and dropping
prepared statements. 

The following new functions are exported:

- (prepared-statement-exists-p (name))
This returns t if the prepared statement exists in the current
postgresql session, otherwise nil.

- (list-prepared-statements (&optional (names-only nil)))
This is syntactic sugar. It runs a query that lists the prepared statements in
the postgresql session in which the function is run. If the optional parameter
names-only is set to t, it will return a list of the names of the prepared
statements. The default behavior is to return a list of alists of the prepared
statements as understood by postgresql for this session in the form of:

(((:NAME . "SELECT3")
  (:STATEMENT . "(SELECT name FROM employee WHERE (city = $1))")
  (:PREPARE-TIME . 3753222874) (:PARAMETER-TYPES . "{text}") (:FROM-SQL))
 ((:NAME . "SELECT2") (:STATEMENT . "(SELECT name FROM employee)")
  (:PREPARE-TIME . 3753222686) (:PARAMETER-TYPES . "{}") (:FROM-SQL)))


- (drop-prepared-statement (statement-name &key (location :both) (database *database*))
Prepared statements are stored both in the meta slot in the postmodern
connection and in postgresql session information. If you know the prepared
statement name, you can delete the prepared statement from both locations (the
default behavior), just from postmodern (passing :postmodern to the location
key parameter) or just from postgresql (passing :postgresql to the location
key parameter). If you pass the name 'All' as the statement name, it will
delete all prepared statements.

- (list-postmodern-prepared-statements (&optional (names-only nil))
List the prepared statements that postmodern has put in the meta slot in
the connection. It will return a list of alists of form:
  ((:NAME . \"SNY24\")
  (:STATEMENT . \"(SELECT name, salary FROM employee WHERE (city = $1))\")
  (:PREPARE-TIME . #<TIMESTAMP 25-11-2018T15:36:43,385>)
  (:PARAMETER-TYPES . \"{text}\") (:FROM-SQL)

If the names-only parameter is set to t, it will only return a list of
the names of the prepared statements.

- (find-postgresql-prepared-statement (name))
Returns the specified named prepared statement (if any) that postgresql has for this
session.

- (find-postmodern-prepared-statement (name))

Returns the specified named prepared statement (if any) that postmodern has
put in the meta slot in the connection. Note that this is the statement itself,
not the name.

- (reset-prepared-statement) (condition)
  If you have received an invalid-prepared-statement error but the prepared
statement is still in the meta slot in the postmodern connection,
try to regenerate the prepared statement at the database connection level.

- (overwrite-prepared-statement) (condition)
  If you have received an invalid-prepared-statement error but the prepared
statement is still in the meta slot in the postmodern connection,
try to regenerate the prepared statement at the database connection level.

- (get-pid)
Get the process id used by postgresql for this connection.

- (get-pid-from-postmodern)
Get the process id used by postgresql for this connection,
but get it from the postmodern connection parameters.

There are also two additional functions to cancel or terminate a postgresql session

- (cancel-backend)
Polite way of terminating a query at the database (as opposed to calling close-database).
Slower than (terminate-backend pid) and does not always work.

- (terminate-backend)
Less polite way of terminating at the database (as opposed to calling close-database).
Faster than (cancel-backend pid) and more reliable.