### PR TITLE
Allow some auto overwriting of prepared statements

### DIFF
--- a/doc/postmodern.html
+++ b/doc/postmodern.html
@@ -1090,7 +1090,7 @@ statement name, you can delete the prepared statement from both locations (the
 default behavior), just from postmodern (passing :postmodern to the location
 key parameter) or just from postgresql (passing :postgresql to the location
 key parameter). If you pass the name 'All' as the statement name, it will
-delete all prepared statements.
+delete all prepared statements. The statement name can be a string or quoted symbol.
 </p>
 </div>
 </div>

--- a/doc/postmodern.html
+++ b/doc/postmodern.html
@@ -279,7 +279,8 @@ for the JavaScript code in this tag.
 </ul>
 </li>
 <li><a href="#org2580dda">Helper functions for Prepared Statements</a>
-<ul>
+  <ul>
+<li><a href="#org730cd12a4">parameter *allow-overwriting-prepared-statements*</a></li>
 <li><a href="#org730cd12">function prepared-statement-exists-p (name)</a></li>
 <li><a href="#org7df9842">function list-prepared-statements(&amp;optional (names-only nil))</a></li>
 <li><a href="#orgfbdd58c">function drop-prepared-statement (statement-name &amp;key (location :both) (database <b>database</b>))</a></li>
@@ -1054,6 +1055,20 @@ when given only one argument, for transforming :nulls to NIL.
 <h2 id="org2580dda">Helper functions for Prepared Statements</h2>
 <div class="outline-text-2" id="text-org2580dda">
 </div>
+
+<div id="outline-container-org730cd12a4" class="outline-3">
+<h3 id="org730cd12a4">parameter *allow-overwriting-prepared-statements*</h3>
+<div class="outline-text-3" id="text-org730cd12a4">
+<p>
+→ parameter
+
+When set to t, ensured-prepared will overwrite prepared statements having
+the same name if the query statement itself in the postmodern meta connection
+is different than the query statement provided to ensure-prepared.
+</p>
+</div>
+</div>
+
 <div id="outline-container-org730cd12" class="outline-3">
 <h3 id="org730cd12">function prepared-statement-exists-p (name)</h3>
 <div class="outline-text-3" id="text-org730cd12">

--- a/doc/postmodern.org
+++ b/doc/postmodern.org
@@ -374,7 +374,7 @@ statement name, you can delete the prepared statement from both locations (the
 default behavior), just from postmodern (passing :postmodern to the location
 key parameter) or just from postgresql (passing :postgresql to the location
 key parameter). If you pass the name 'All' as the statement name, it will
-delete all prepared statements.
+delete all prepared statements. The statement name can be a string or quoted symbol.
 
 ** function list-postmodern-prepared-statements (&optional (names-only nil))
 → list

--- a/doc/postmodern.org
+++ b/doc/postmodern.org
@@ -354,6 +354,12 @@ when given only one argument, for transforming :nulls to NIL.
 
 * Helper functions for Prepared Statements
 
+** defparameter *allow-overwriting-prepared-statements*
+
+When set to t, ensured-prepared will overwrite prepared statements having
+the same name if the query statement itself in the postmodern meta connection
+is different than the query statement provided to ensure-prepared.
+
 ** function prepared-statement-exists-p (name)
 → boolean
 This returns t if the prepared statement exists in the current

--- a/postmodern/package.lisp
+++ b/postmodern/package.lisp
@@ -57,6 +57,7 @@
    #:split-fully-qualified-tablename
 
    ;; Prepared Statement Functions
+   #:*allow-overwriting-prepared-statements*
    #:prepared-statement-exists-p #:list-prepared-statements
    #:drop-prepared-statement #:list-postmodern-prepared-statements
    #:find-postmodern-prepared-statement

--- a/postmodern/prepare.lisp
+++ b/postmodern/prepare.lisp
@@ -89,6 +89,7 @@ default behavior), just from postmodern (passing :postmodern to the location
 key parameter) or just from postgresql (passing :postgresql to the location
 key parameter). If you pass the name 'All' as the statement name, it will
 delete all prepared statements."
+  (when (symbolp statement-name) (setf statement-name (string statement-name)))
   (check-type statement-name string)
   (check-type location keyword)
   (setf statement-name (string-upcase statement-name))

--- a/postmodern/prepare.lisp
+++ b/postmodern/prepare.lisp
@@ -1,9 +1,17 @@
 (in-package :postmodern)
 
+(defparameter *allow-overwriting-prepared-statements* t
+  "When set to t, ensured-prepared will overwrite prepared statements having
+the same name if the query statement itself in the postmodern meta connection
+is different than the query statement provided to ensure-prepared.")
+
 (defun ensure-prepared (connection id query)
   "Make sure a statement has been prepared for this connection."
   (let ((meta (connection-meta connection)))
-    (unless (and (gethash id meta) (equal (gethash id meta) query))
+    (unless (and (gethash id meta)
+                 (if *allow-overwriting-prepared-statements*
+                     (equal (gethash id meta) query)
+                     t))
       (setf (gethash id meta) query)
       (prepare-query connection id query))))
 


### PR DESCRIPTION
Allow some auto overwriting of prepared statements

When the exported postmodern parameter *allow-overwriting-prepared-statements*
is set to t (the default), prepared statements created with defprepared
will overwrite existing prepared statements of the same name
if the query statement provided to defprepared is different than the query
statement which exists in the postmodern meta connection hashtable. Remember
the prepared statements are stored separately for each postgresql
session. When set to nil, existing prepared statements with the
same name will not be overwritten regardless of whether the statements
are the same.

Making the check only at the postmodern meta connection
level avoids hitting the database again, but there is always
a possibility that postmodern and postgresql can get out of sync
if someone uses multiple threads but a single connection. Do not
do that.

Add a check to reset-prepared-statement to ensure you
actually have a prepared statement to use

Slight simplification of the condition handler in generate-prepared

Drop-prepared-statement can take a quoted symbol

Drop-prepared-statement can now accept the statement
name as either a string or a quoted symbol.

More tests on prepared statements.