### PR TITLE
Add full verification option to use-ssl

### DIFF
--- a/cl-postgres/public.lisp
+++ b/cl-postgres/public.lisp
@@ -39,13 +39,15 @@ currently connected."
        (open-stream-p (connection-socket connection))))
 
 (defun open-database (database user password host &optional (port 5432) (use-ssl :no) (service "postgres"))
-  "Create and connect a database object. use-ssl may be :no, :yes, or :try."
+  "Create and connect a database object. use-ssl may be :no, :try, :yes, or
+:full (NOTE: :yes only verifies that the server cert is issued by a trusted CA,
+but does not verify the server hostname; use :full to also verify the hostname)."
   (check-type database string)
   (check-type user string)
   (check-type password (or null string))
   (check-type host (or string (eql :unix)) "a string or :unix")
   (check-type port (integer 1 65535) "an integer from 1 to 65535")
-  (check-type use-ssl (member :no :yes :try) ":no, :yes, or :try")
+  (check-type use-ssl (member :no :try :yes :full) ":no, :try, :yes or :full")
   (let ((conn (make-instance 'database-connection :host host :port port :user user
                              :password password :socket nil :db database :ssl use-ssl
                              :service service)))

--- a/doc/cl-postgres.html
+++ b/doc/cl-postgres.html
@@ -3,7 +3,7 @@
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 <head>
-<!-- 2018-09-02 Sun 07:42 -->
+<!-- 2019-01-17 Thu 13:21 -->
 <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Cl-Postgres Reference Manual</title>
@@ -334,9 +334,11 @@ Objects of this type represent database connections.
 
 <p>
 Create and open a connection for the specified server, database, and user.
-use-ssl may be :no, :yes, or :try, where :try means 'if the server supports
-it'. When it is anything but :no, you must have the CL+SSL package loaded to
-initiate the connection.
+use-ssl may be :no, :try, :yes, or :full; where :try means 'if the server
+supports it', :yes means 'expect a CA-signed cert from the server, for any host
+name', and :full 'means expect a CA-signed cert for the supplied host name'.
+When it is anything but :no, you must have the CL+SSL package loaded to initiate
+the connection.
 </p>
 
 <p>

--- a/doc/cl-postgres.org
+++ b/doc/cl-postgres.org
@@ -17,9 +17,11 @@ Objects of this type represent database connections.
 → database-connection
 
 Create and open a connection for the specified server, database, and user.
-use-ssl may be :no, :yes, or :try, where :try means 'if the server supports
-it'. When it is anything but :no, you must have the CL+SSL package loaded to
-initiate the connection.
+use-ssl may be :no, :try, :yes, or :full; where :try means 'if the server
+supports it', :yes means 'expect a CA-signed cert from the server, for any host
+name', and :full 'means expect a CA-signed cert for the supplied host name'.
+When it is anything but :no, you must have the CL+SSL package loaded to initiate
+the connection.
 
 On SBCL and Clozure CL, the value :unix may be passed for host, in order to
 connect using a Unix domain socket instead of a TCP socket.


### PR DESCRIPTION
The current-strictest option, :yes, does not verify the server host name. This
adds a stricter option, :full, that does that too.

Fixes #187