### PR TITLE
Fix INSERT-DAO for slots with a different column name

### DIFF
--- a/postmodern/table.lisp
+++ b/postmodern/table.lisp
@@ -267,7 +267,8 @@ or accessor or reader.)"
                                     (remove-if (lambda (x) (member x ghost-fields)) bound) ))
                     (returned (query (sql-compile `(:insert-into ,table-name
                                                                  :set ,@values
-                                                                 ,@(when unbound (cons :returning unbound))))
+                                                                 ,@(when unbound (cons :returning (mapcar #'field-sql-name
+                                                                                                          unbound)))))
                                      :row)))
                (when unbound
                  (loop :for value :in returned

--- a/postmodern/tests/test-dao.lisp
+++ b/postmodern/tests/test-dao.lisp
@@ -193,7 +193,13 @@
     (is (string= "1" (test-a (get-dao 'test-col-name "1"))))
     (is (string= "b" (test-b (get-dao 'test-col-name "1"))))
     (is (string= "3" (test-c (get-dao 'test-col-name "1"))))
-    (is (string= "Vestmannaeyjar" (test-d (get-dao 'test-col-name "1"))))))
+    (is (string= "Vestmannaeyjar" (test-d (get-dao 'test-col-name "1")))))
+  (with-test-connection
+    (execute "CREATE TEMPORARY TABLE test_col_name (aa text primary key default md5(random()::text), bb text not null, c text not null,
+              \"from\" text not null, \"to\" text not null)")
+    (let ((o (make-instance 'test-col-name :b "2" :c "3" :d "Reykjavík" :e "Garðabær")))
+      (fiveam:finishes
+        (insert-dao o)))))
 
 ;;; For threading tests
 (defvar *dao-update-lock* (bt:make-lock))


### PR DESCRIPTION
Without this fix, `INSERT-DAO` would signals an error since the SQL INSERT statement tries to return a column that does not exist.