### PR TITLE
Fixed warnings in non-Latin1 encodings

### DIFF
--- a/cl-postgres/protocol.lisp
+++ b/cl-postgres/protocol.lisp
@@ -91,7 +91,7 @@ a query.")
 and put them in an alist."
   (loop :for type = (read-uint1 socket)
         :until (zerop type)
-        :collect (cons (code-char type) (read-simple-str socket))))
+        :collect (cons (code-char type) (read-str socket))))
 
 (define-condition postgresql-notification (simple-warning)
   ((pid :initarg :pid :accessor postgresql-notification-pid)


### PR DESCRIPTION
cl-postgres function read-byte-delimited was calling
(read-simple-str socket) instead of (read-str socket). This
drops characters when the socket is actually providing utf8
characters in non-Latin1 encodings.

Changed to (read-str socket).