### PR TITLE
Update execute-file.lisp

### DIFF
--- a/postmodern/execute-file.lisp
+++ b/postmodern/execute-file.lisp
@@ -211,13 +211,17 @@ Another test case for the classic quotes:
 	      (format q "~a~%" line))
        finally (return q))))
 
-(defun read-queries (filename)
-  "read SQL queries in given file and split them, returns a list"
-  (let ((file-content (get-output-stream-string (read-lines filename))))
+(defun parse-queries (file-content)
+  "read SQL queries in given string and split them, returns a list"
     (with-input-from-string (s file-content)
       (loop :for query := (parse-query s)
          :while query
-         :collect query))))
+         :collect query)))
+
+(defun read-queries (filename)
+  "read SQL queries in given file and split them, returns a list"
+  (let ((file-content (get-output-stream-string (read-lines filename))))
+    (parse-queries (file-content))))
 
 (defun execute-file (pathname &optional (print nil))
   "Executes all queries in the provided SQL file. If print is set to t,

--- a/postmodern/package.lisp
+++ b/postmodern/package.lisp
@@ -20,7 +20,8 @@
    #:connect-toplevel #:disconnect-toplevel
    #:clear-connection-pool #:*max-pool-size* #:*default-use-ssl*
    #:list-connections
-   #:query #:execute #:doquery #:execute-file
+   #:query #:execute #:doquery 
+   #:parse-queries #:read-queries #:execute-file
    #:prepare #:defprepared #:defprepared-with-names
    #:sequence-next #:list-sequences #:sequence-exists-p
    #:create-sequence #:drop-sequence


### PR DESCRIPTION
Split read-queries into two functions to allow parsing strings instead of only files.