### PR TITLE
fix compiling errors created by September 14 commit

### DIFF
--- a/cl-postgres.asd
+++ b/cl-postgres.asd
@@ -22,15 +22,15 @@
   :components
   ((:module "cl-postgres"
             :components ((:file "package")
-			 (:file "features")
+                         (:file "features")
                          (:file "errors" :depends-on ("package"))
                          (:file "sql-string" :depends-on ("package"))
-			 (:file "trivial-utf-8" :depends-on ("package"))
+                         (:file "trivial-utf-8" :depends-on ("package"))
                          (:file #.*string-file* :depends-on ("package" "trivial-utf-8"))
                          (:file "communicate" :depends-on (#.*string-file* "sql-string"))
                          (:file "messages" :depends-on ("communicate"))
                          (:file "oid" :depends-on ("package"))
-			 (:file "ieee-floats")
+                         (:file "ieee-floats")
                          (:file "interpret" :depends-on ("oid" "communicate" "ieee-floats"))
                          (:file "protocol" :depends-on ("interpret" "messages" "errors"))
                          (:file "public" :depends-on ("protocol" "features"))
@@ -50,11 +50,11 @@
 
 
 (defsystem "cl-postgres/simple-date-tests"
-  :depends-on ("cl-postgres" "cl-postgres/tests" "fiveam" "simple-date/postgres-glue")
+  :depends-on ("cl-postgres" "cl-postgres/tests" "fiveam" "simple-date" "simple-date/postgres-glue")
   :components
   ((:module "cl-postgres/tests"
             :components ((:file "test-package")
-			 (:file "simple-date-tests"))))
+                         (:file "simple-date-tests"))))
   :perform (test-op (o c)
              (uiop:symbol-call :cl-postgres-simple-date-tests '#:prompt-connection)
              (uiop:symbol-call :fiveam '#:run! :cl-postgres-simple-date)))

--- a/cl-postgres/tests/simple-date-tests.lisp
+++ b/cl-postgres/tests/simple-date-tests.lisp
@@ -1,4 +1,9 @@
 ;;;; -*- Mode: LISP; Syntax: Ansi-Common-Lisp; Base: 10; Package: CL-POSTGRES-SIMPLE-DATE-TESTS; -*-
+(defpackage :cl-postgres-simple-date-tests
+  (:use :common-lisp :fiveam :cl-postgres :cl-postgres-error :simple-date)
+  (:import-from #:cl-postgres-tests
+                #:prompt-connection))
+
 (in-package :cl-postgres-simple-date-tests)
 
 (defmacro with-simple-date-readtable (&body body)
@@ -56,4 +61,3 @@
       (is (time= (caaar (exec-query connection "select row('2010-04-05 14:42:21.500'::timestamp)"
                                     'list-row-reader))
                  (encode-timestamp 2010 4 5 14 42 21 500))))))
-

--- a/cl-postgres/tests/test-package.lisp
+++ b/cl-postgres/tests/test-package.lisp
@@ -3,10 +3,3 @@
 (defpackage :cl-postgres-tests
   (:use :common-lisp :fiveam :cl-postgres :cl-postgres-error)
   (:export #:prompt-connection #:with-test-connection #:*test-connection*))
-
-(defpackage :cl-postgres-simple-date-tests
-  (:use :common-lisp :fiveam :cl-postgres :cl-postgres-error :simple-date)
-  (:import-from #:cl-postgres-tests
-                #:prompt-connection))
-
-

--- a/s-sql.asd
+++ b/s-sql.asd
@@ -18,7 +18,7 @@
   :in-order-to ((test-op (test-op "s-sql/tests"))))
 
 (defsystem "s-sql/tests"
-  :depends-on ("postmodern" "s-sql" "cl-postgres/tests" "fiveam" )
+  :depends-on ("postmodern" "s-sql" "cl-postgres/tests" "fiveam")
   :components
   ((:module "s-sql/tests"
             :components ((:file "test-package")


### PR DESCRIPTION
package cl-postgres-simple-date-tests needs to kept separate. Some people use simple-date, some people use local-time. the Sept 14 commit to solve Genera compilation issues pulled cl-postgres-simple-date-tests into the main tests, triggering package-does-not-exist errors. This should resolve that problem. 

Symbolics - you will need to validate that this does not create any new Genera problems.