### PR TITLE
Trigger clear error instead of infinite loop 

### DIFF
--- a/postmodern/table.lisp
+++ b/postmodern/table.lisp
@@ -35,7 +35,7 @@ find-primary-key-info function."))
 (defmethod dao-keys (dao)
   (mapcar #'(lambda (slot)
               (slot-value dao slot))
-          (dao-keys (class-of dao))))
+          (dao-keys (the dao-class (class-of dao)))))
 
 (defun dao-column-slots (class)
   "Enumerate the slots in a class that refer to table rows."


### PR DESCRIPTION
It's easy to cause infinite loop by passing non-dao object to #'dao-keys