### PR TITLE
Adds get-postgresql-version to cl-postgres

### DIFF
--- a/cl-postgres.asd
+++ b/cl-postgres.asd
@@ -16,7 +16,7 @@
   :author "Marijn Haverbeke <marijnh@gmail.com>"
   :maintainer "Sabra Crolleton <sabra.crolleton@gmail.com>"
   :license "zlib"
-  :depends-on ("md5"
+  :depends-on ("md5" "split-sequence"
                (:feature (:or :sbcl :allegro :ccl :clisp :genera :armedbear :cmucl) "usocket")
                (:feature :sbcl (:require :sb-bsd-sockets)))
   :components

--- a/cl-postgres/package.lisp
+++ b/cl-postgres/package.lisp
@@ -16,6 +16,7 @@
            #:database-socket-error
            #:connection-meta
            #:connection-parameters
+           #:get-postgresql-version
            #:open-database
            #:reopen-database
            #:database-open-p

--- a/cl-postgres/public.lisp
+++ b/cl-postgres/public.lisp
@@ -33,6 +33,16 @@ These are needed for cancelling connections and error processing with respect to
   (list (gethash "pid" (slot-value connection 'parameters))
         (gethash "secret-key" (slot-value connection 'parameters))))
 
+(defun get-postgresql-version (connection)
+  "Returns the version of the connected postgresql instance."
+  (let* ((version-str (gethash "server_version" (connection-parameters connection)))
+         (split-version (split-sequence:split-sequence #\. version-str))
+         (major-version (parse-integer (first split-version)))
+         (minor-version (if (> (length split-version) 1)
+                            (/ (parse-integer (second split-version)) (expt 10 (length (second split-version))))
+                            0)))
+    (+ major-version minor-version)))
+
 (defun database-open-p (connection)
   "Returns a boolean indicating whether the given connection is
 currently connected."

--- a/doc/cl-postgres.org
+++ b/doc/cl-postgres.org
@@ -74,6 +74,8 @@ This function blocks until a notification is received on the connection.
 The PostgreSQL LISTEN command must be used to enable listening for
 notifications.
 
+** function get-postgresql-version (database-connection)
+This function returns the version of the connected postgresql instance as a number (generally a float assuming a major-version.minor-version).
 * Querying
 ** function exec-query (database-connection query &optional (row-reader 'ignore-row-reader))
 → result


### PR DESCRIPTION
Adds get-postgresql-version to cl-postgres

An exported function providing syntactic sugar to easily get the version of the connected postgresql
instance as a float.

For the curious, other postgresql data is available from the database
connection in a hashtable accessible with the accessor
connection-parameters. As of version 12 the following parameters were
provided:

"secret_key"
"pid"
"TimeZone"
"standard_conforming_strings"
"session_authorization"
"server_version"
"server_encoding"
"is_superuser"
"IntervalStyle"
"integer_datetimes"
"DateStyel"
"client-encoding"
"application_name"