### PR TITLE
Resolve issue 186. Reconnect to saved schema path

### DIFF
--- a/postmodern/connect.lisp
+++ b/postmodern/connect.lisp
@@ -15,6 +15,9 @@ on a database assume this contains a connected database.")
 This starts at :no. If you set it to anything else, be sure to also load the
 CL+SSL library.")
 
+(defparameter *schema-path* nil "If the default path is reset, it will also reset
+this parameter which will get read by reconnect.")
+
 (defun connect (database-name user-name password host &key (port 5432) pooled-p
                                                         (use-ssl *default-use-ssl*)
                                                         (service "postgres"))
@@ -65,7 +68,10 @@ connection into the pool."))
 
 (defgeneric reconnect (database)
   (:method ((database database-connection))
-    (reopen-database database))
+    (reopen-database database)
+    (when *schema-path*
+      (let ((path *schema-path*))
+        (set-search-path path))))
   (:method ((connection pooled-database-connection))
     (error "Can not reconnect a pooled database."))
   (:documentation "Reconnect a disconnected database connection. This is not

--- a/postmodern/namespace.lisp
+++ b/postmodern/namespace.lisp
@@ -48,8 +48,10 @@ namespace is just first schema on the search path upon the the body execution.
                                 (concatenate 'string (to-sql-name schema t)
                                              ","
                                              old-search-path)))
+           (setf *schema-path* (get-search-path))
            (funcall thunk))
       (set-search-path old-search-path)
+      (setf *schema-path* old-search-path)
       (when drop-after (drop-schema schema :cascade 't)))))
 
 (defun get-search-path ()

--- a/postmodern/tests/tests.lisp
+++ b/postmodern/tests/tests.lisp
@@ -55,7 +55,17 @@
     (disconnect *database*)
     (is (not (connected-p *database*)))
     (reconnect *database*)
-    (is (connected-p *database*))))
+    (is (connected-p *database*))
+    (is (equal (get-search-path)
+               "\"$user\", public"))
+    (is (equal
+         (with-schema ("a")
+           (disconnect *database*)
+           (reconnect *database*)
+           (get-search-path))
+         "a"))
+    (is (equal (get-search-path)
+               "\"$user\", public"))))
 
 (test simple-query
   (with-test-connection


### PR DESCRIPTION
If reconnect happens inside (with-schema...) postmodern will reconnect
with the schema set inside the with-schema scope.