### PR TITLE
fix deftype real breakage

### DIFF
--- a/s-sql/s-sql.lisp
+++ b/s-sql/s-sql.lisp
@@ -217,8 +217,6 @@ hyphens."
   'number)
 (deftype double-precision ()
   'double-float)
-(deftype real ()
-  'float)
 (deftype bytea ()
   '(array (unsigned-byte 8)))
 (deftype text ()


### PR DESCRIPTION
Lock on package COMMON-LISP violated when defining REAL as a type specifier while in package S-SQL

Revert change that created the issue. Will look at phoe's suggestion as soon as possible.