### PR TITLE
Fix get-notification format-control string

### DIFF
--- a/cl-postgres/protocol.lisp
+++ b/cl-postgres/protocol.lisp
@@ -118,8 +118,8 @@ signal a condition for it."
           :pid pid
           :channel channel
           :payload payload
-          :format-control "Asynchronous notification ~S~@[ (payload: ~S)~]
-                           received from ~ server process with PID ~D."
+          :format-control "Asynchronous notification ~S~@[ (payload: ~S)~] ~
+                           received from server process with PID ~D."
           :format-arguments (list channel payload pid))))
 
 (defun get-error (socket)


### PR DESCRIPTION
Affected by this while experimenting with notify/listen.

Currently, `get-notification` always fails with

```
error in FORMAT: Unknown directive (character: Space)
```

Used to be trailing tilde, which is valid, before
9662cb493b7a4bef43dc0663d452811d303514c4; reverting back to that.