### PR TITLE
Correct typo in docs using generated-as-identity

### DIFF
--- a/doc/create-tables.html
+++ b/doc/create-tables.html
@@ -533,19 +533,27 @@ Note: The data type used for identity columns must be one of smallint, int or bi
 
 <div class="org-src-container">
 <pre class="src src-lisp">(query (<span style="color: #98fb98; font-weight: bold;">:create-table</span> 'color
-         ((color-id <span style="color: #98fb98; font-weight: bold;">:type</span> int <span style="color: #98fb98; font-weight: bold;">:generated-as-identity-always</span>)
+         ((color-id <span style="color: #98fb98; font-weight:
+         bold;">:type</span> int <span style="color: #98fb98;
+         font-weight: bold;">:generated-as-identity-always t</span>)
           (color-name <span style="color: #98fb98; font-weight: bold;">:type</span> varchar))))
 
 (query (<span style="color: #98fb98; font-weight: bold;">:create-table</span> 'color
-         ((color-id <span style="color: #98fb98; font-weight: bold;">:type</span> int <span style="color: #98fb98; font-weight: bold;">:generated-as-identity-by-default</span>)
+         ((color-id <span style="color: #98fb98; font-weight:
+         bold;">:type</span> int <span style="color: #98fb98;
+         font-weight: bold;">:generated-as-identity-by-default t</span>)
           (color-name <span style="color: #98fb98; font-weight: bold;">:type</span> varchar))))
 
 (query (<span style="color: #98fb98; font-weight: bold;">:create-table</span> 'color
-         ((color-id <span style="color: #98fb98; font-weight: bold;">:type</span> int <span style="color: #98fb98; font-weight: bold;">:identity-always</span>)
+         ((color-id <span style="color: #98fb98; font-weight:
+         bold;">:type</span> int <span style="color: #98fb98;
+         font-weight: bold;">:identity-always t</span>)
           (color-name <span style="color: #98fb98; font-weight: bold;">:type</span> varchar))))
 
 (query (<span style="color: #98fb98; font-weight: bold;">:create-table</span> 'color
-         ((color-id <span style="color: #98fb98; font-weight: bold;">:type</span> int <span style="color: #98fb98; font-weight: bold;">:identity-by-default</span>)
+         ((color-id <span style="color: #98fb98; font-weight:
+         bold;">:type</span> int <span style="color: #98fb98;
+         font-weight: bold;">:identity-by-default t</span>)
           (color-name <span style="color: #98fb98; font-weight: bold;">:type</span> varchar))))
 </pre>
 </div>

--- a/doc/create-tables.org
+++ b/doc/create-tables.org
@@ -213,19 +213,19 @@ Note: The data type used for identity columns must be one of smallint, int or bi
 
 #+BEGIN_SRC lisp
 (query (:create-table 'color
-         ((color-id :type int :generated-as-identity-always)
+         ((color-id :type int :generated-as-identity-always t)
           (color-name :type varchar))))
 
 (query (:create-table 'color
-         ((color-id :type int :generated-as-identity-by-default)
+         ((color-id :type int :generated-as-identity-by-default t)
           (color-name :type varchar))))
 
 (query (:create-table 'color
-         ((color-id :type int :identity-always)
+         ((color-id :type int :identity-always t)
           (color-name :type varchar))))
 
 (query (:create-table 'color
-         ((color-id :type int :identity-by-default)
+         ((color-id :type int :identity-by-default t)
           (color-name :type varchar))))
 #+END_SRC
 


### PR DESCRIPTION
The doc examples were missing the critical t value parameter