### PR TITLE
Bugfix on ssl :try and new utility functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+# Changelog v. 1.32.9
+Adds new utility functions
+
+- table-description-menu which allows you to pick and choose
+what table characteristics you want returned. See giant docstring for details.
+
+- get-schema-comment which takes a schema name and returns the schema comment
+as a string
+
+- list-check-constraints which takes a fully qualified table name and returns
+a list of lists of check constraints where each sublist has the form
+of (check-constraint-name check).
+
+Example: (list-check-constraints "s2.employees")
+(("employees_birth_date_check" "CHECK (birth_date > '1900-01-01'::date)")
+ ("employees_check" "CHECK (start_date > birth_date)")
+ ("employees_salary_check" "CHECK (salary > 0::numeric)"))
+
+Now exports
+get-column-comments (the parameter string has changed if you were using the internal version)
+get-all-table-comments
+
+Bug Fixes:
+
+Fixes a bug when trying to connect to a database using ssl. If the keyword :try was used,
+the connection would not fall back to non-ssl connections.
+
 # Changelog v. 1.32.8
 S-SQL Enhancements
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,10 +49,6 @@ No guarantee is given with respect to resolution or timing on any item.
 - [ ]   Named Prepared Statement explicit arglist
 - [ ]   SQL Read Table Review (comments requested on any work that should be done here)
 - [ ]   Row Reader Review (comments requested on any work that should be done here)
-- [ ]   Prepared Query Review (comments requested on any work that should be done here)
-- [ ]   Reading large bytea column over ssl connection errors have been reported. Postgresql does not
-        have a chunk API so the network is handling the content as a whole.
-- [ ]   Alter system (postgresql 9.4)
 - [ ]   Allow parameters to be passed as binary to postgresql
 
 ## Connections/Reconnections and Transactions

--- a/doc/postmodern.html
+++ b/doc/postmodern.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- 2020-11-03 Tue 07:30 -->
+<!-- 2021-03-16 Tue 21:33 -->
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Postmodern Reference Manual</title>
@@ -285,7 +285,7 @@ for the JavaScript code in this tag.
 <li><a href="#453612e6-2835-41b2-8305-01b6b5473138">macro with-transaction ((&amp;optional name isolation-level) &amp;body body)</a></li>
 <li><a href="#10b5d3e9-b174-4f02-8c47-6eb3430e60fe">function commit-transaction (transaction)</a></li>
 <li><a href="#58a7459f-a1f4-4797-83b5-8b5257ca2cf7">function abort-transaction (transaction)</a></li>
-<li><a href="#org1f0878d">function rollback-transaction (transaction)</a></li>
+<li><a href="#org16d195f">function rollback-transaction (transaction)</a></li>
 <li><a href="#5899097b-a5fb-4b7a-961b-3c65a95f81d4">macro with-savepoint (name &amp;body body)</a></li>
 <li><a href="#a6d99838-ed98-4839-ac13-c03ecbfd6f96">function release-savepoint (savepoint)</a></li>
 <li><a href="#1f84633f-e567-42c6-bcfc-2167dad89165">function rollback-savepoint (savepoint)</a></li>
@@ -328,11 +328,11 @@ for the JavaScript code in this tag.
 <li><a href="#9027b960-0a1a-4b64-a621-d1d4ab2906f0">Out of Sync Dao Objects</a></li>
 <li><a href="#b12ed2b8-fc3f-4d3a-ba2a-3c9484d770dc">method dao-keys (class)</a></li>
 <li><a href="#34196ad8-c657-4fd0-a475-e2f0b81ff86c">method dao-keys (dao)</a></li>
-<li><a href="#org055dcc7">method find-primary-key-column</a></li>
+<li><a href="#org36b2d69">method find-primary-key-column</a></li>
 <li><a href="#d5835157-a4ba-4bf0-abbd-214b5a90bc80">method dao-exists-p (dao)</a></li>
 <li><a href="#24bce212-b7c3-4526-a869-92c0218f187d">method make-dao (type &amp;rest args &amp;key &amp;allow-other-keys)</a></li>
-<li><a href="#org5d65e55">method fetch-defaults (dao)</a></li>
-<li><a href="#orgc0460c2">method find-primary-key-column (class)</a></li>
+<li><a href="#orgfd8e143">method fetch-defaults (dao)</a></li>
+<li><a href="#org0347175">method find-primary-key-column (class)</a></li>
 <li><a href="#f7351c36-cb79-43a2-8a5b-5f8aac8ea2d9">macro define-dao-finalization (((dao-name class) &amp;rest keyword-args) &amp;body body)</a></li>
 <li><a href="#73e62fab-5bfa-4986-b8c4-992e4d0a134b">method get-dao (type &amp;rest keys)</a></li>
 <li><a href="#cd11fa85-5019-4b94-a24c-d0857d633bd2">macro select-dao (type &amp;optional (test t) &amp;rest sort)</a></li>
@@ -388,6 +388,7 @@ for the JavaScript code in this tag.
 <li><a href="#database-information">Database Information</a>
 <ul>
 <li><a href="#22c6eb1c-c0ca-44fc-a8f1-590fda047866">function add-comment (type name comment &amp;optional (second-name ""))</a></li>
+<li><a href="#org5fdd515">find-comments (type identifier)</a></li>
 <li><a href="#d993f27b-95d6-4a5b-bdf3-3e06beed0213">function get-database-comment (database-name)</a></li>
 <li><a href="#29d56bfd-15a0-40bb-b7f1-a1683b392695">function postgresql-version ()</a></li>
 <li><a href="#29d56bfd-15a0-40bb-b7f1-a1683b392695">function database-version ()</a></li>
@@ -447,6 +448,7 @@ for the JavaScript code in this tag.
 <li><a href="#b8999d95-0ef5-492e-af5b-cfbdc91278e6">function get-search-path ()</a></li>
 <li><a href="#125a3594-080f-40eb-997d-d7ef927420e6">function set-search-path (path)</a></li>
 <li><a href="#cfacd9fe-b640-4aee-985b-149f4b9ce930">function split-fully-qualified-tablename (name)</a></li>
+<li><a href="#org3b9444c">function get-schema-comment (schema-name)</a></li>
 </ul>
 </li>
 <li><a href="#sequences">Sequences</a>
@@ -468,13 +470,16 @@ for the JavaScript code in this tag.
 <li><a href="#bb623170-32c2-43b4-807d-66c34efe9c40">function table-size (table-name)</a></li>
 <li><a href="#ee444ea2-f49f-41c9-905c-177d89770254">function table-description (name &amp;optional schema-name)</a></li>
 <li><a href="#795b7f54-85ee-4c77-b962-9176f93ad7ac">function table-description-plus (table-name)</a></li>
+<li><a href="#orgc0b234d">function table-description-menu (table-name &amp;key char-max-length data-type-length</a></li>
+<li><a href="#orgc3abe89">function list-check-constraints (table-name)</a></li>
 <li><a href="#74baf413-72fb-4f17-abb0-1e7535af33ab">function list-columns (table-name)</a></li>
 <li><a href="#9ada61bd-a670-49f3-8c04-cf025cde431f">function list-columns-with-types (table-name)</a></li>
 <li><a href="#11e937a0-91f6-4475-b393-8f4f2e5d9659">function column-exists-p (table-name column-name &amp;optional schema-name)</a></li>
 <li><a href="#8ab55683-e44b-44df-bb11-67909d402383">function get-table-oid (table-name &amp;optional schema-name)</a></li>
 <li><a href="#e8d6e402-5c76-4533-9b5c-a823b9582c26">function get-table-comment (table-name &amp;optional schema-name)</a></li>
-<li><a href="#org8f67d37">function rename-table (old-name new-name)</a></li>
-<li><a href="#org0ca0bf5">function rename-column (table-name old-name new-name)</a></li>
+<li><a href="#e8d6e402-5c76-4533-9b5c-a823b9582c26">function get-column-comments (database schema table)</a></li>
+<li><a href="#orgede774c">function rename-table (old-name new-name)</a></li>
+<li><a href="#orgb61ef23">function rename-column (table-name old-name new-name)</a></li>
 </ul>
 </li>
 <li><a href="#tablespaces">Tablespaces</a>
@@ -560,12 +565,12 @@ database-connection-error, providing a :reconnect restart to re-try the
 operation that encountered to the error.
 </p>
 
-<div id="outline-container-org92e12b9" class="outline-2">
-<h2 id="connecting"><a id="org92e12b9"></a><a id="ID-75c23b08-3840-4d28-8ced-978d10a629d5"></a>Connecting</h2>
+<div id="outline-container-orgcf779a6" class="outline-2">
+<h2 id="connecting"><a id="orgcf779a6"></a><a id="ID-75c23b08-3840-4d28-8ced-978d10a629d5"></a>Connecting</h2>
 <div class="outline-text-2" id="text-connecting">
 </div>
-<div id="outline-container-orgfe75b57" class="outline-3">
-<h3 id="dfc95b36-94d7-42ab-827b-8622f593e7f6"><a id="orgfe75b57"></a><a id="ID-821e500c-5206-4f8b-a505-266d18faf8cb"></a>class database-connection</h3>
+<div id="outline-container-org5454a48" class="outline-3">
+<h3 id="dfc95b36-94d7-42ab-827b-8622f593e7f6"><a id="org5454a48"></a><a id="ID-821e500c-5206-4f8b-a505-266d18faf8cb"></a>class database-connection</h3>
 <div class="outline-text-3" id="text-dfc95b36-94d7-42ab-827b-8622f593e7f6">
 <p>
 Representation of a database connection. Contains login information in order to
@@ -574,8 +579,8 @@ be able to automatically re-establish a connection when it is somehow closed.
 </div>
 </div>
 
-<div id="outline-container-orga0a9f08" class="outline-3">
-<h3 id="d4aa3e04-ab90-4271-b3e7-60a48e4f2e49"><a id="orga0a9f08"></a><a id="ID-66e24327-bae9-4378-987c-ccdacc312ddf"></a>function connect (database user-name password host &amp;key (port 5432) pooled-p use-ssl)</h3>
+<div id="outline-container-org6f0a6ed" class="outline-3">
+<h3 id="d4aa3e04-ab90-4271-b3e7-60a48e4f2e49"><a id="org6f0a6ed"></a><a id="ID-66e24327-bae9-4378-987c-ccdacc312ddf"></a>function connect (database user-name password host &amp;key (port 5432) pooled-p use-ssl)</h3>
 <div class="outline-text-3" id="text-d4aa3e04-ab90-4271-b3e7-60a48e4f2e49">
 <p>
 → database-connection
@@ -602,8 +607,8 @@ If you set it to anything other than :no be sure to also load the CL+SSL library
 </div>
 </div>
 
-<div id="outline-container-org824aea3" class="outline-3">
-<h3 id="e140fab3-b6fe-4e88-b9ca-241bbb64fce4"><a id="org824aea3"></a><a id="ID-106f14f7-270e-4e27-a238-34c50b14e44b"></a>variable <b>default-use-ssl</b></h3>
+<div id="outline-container-org9e35090" class="outline-3">
+<h3 id="e140fab3-b6fe-4e88-b9ca-241bbb64fce4"><a id="org9e35090"></a><a id="ID-106f14f7-270e-4e27-a238-34c50b14e44b"></a>variable <b>default-use-ssl</b></h3>
 <div class="outline-text-3" id="text-e140fab3-b6fe-4e88-b9ca-241bbb64fce4">
 <p>
 The default for connect's use-ssl argument.
@@ -617,8 +622,8 @@ If you set it to anything other than :no be sure to also load the CL+SSL library
 </div>
 </div>
 
-<div id="outline-container-org5c0c04e" class="outline-3">
-<h3 id="9a1a03af-a67e-4419-9066-d79a81885f81"><a id="org5c0c04e"></a><a id="ID-4c9746be-27ce-485c-b35e-d739e7def9c4"></a>method disconnect (database-connection)</h3>
+<div id="outline-container-orgeaf3c91" class="outline-3">
+<h3 id="9a1a03af-a67e-4419-9066-d79a81885f81"><a id="orgeaf3c91"></a><a id="ID-4c9746be-27ce-485c-b35e-d739e7def9c4"></a>method disconnect (database-connection)</h3>
 <div class="outline-text-3" id="text-9a1a03af-a67e-4419-9066-d79a81885f81">
 <p>
 Disconnects a normal database connection, or moves a pooled connection into the
@@ -627,8 +632,8 @@ pool.
 </div>
 </div>
 
-<div id="outline-container-orgaa1cef7" class="outline-3">
-<h3 id="a660d0cc-4795-41df-b183-0ea31f6b6584"><a id="orgaa1cef7"></a><a id="ID-d9f11a8d-3676-42e9-aee9-a544ef67df28"></a>function connected-p (database-connection)</h3>
+<div id="outline-container-org28e2a93" class="outline-3">
+<h3 id="a660d0cc-4795-41df-b183-0ea31f6b6584"><a id="org28e2a93"></a><a id="ID-d9f11a8d-3676-42e9-aee9-a544ef67df28"></a>function connected-p (database-connection)</h3>
 <div class="outline-text-3" id="text-a660d0cc-4795-41df-b183-0ea31f6b6584">
 <p>
 → boolean
@@ -641,8 +646,8 @@ the server.
 </div>
 </div>
 
-<div id="outline-container-org5f984c6" class="outline-3">
-<h3 id="426a8f5d-5dc7-4973-a1fc-11b488afcd82"><a id="org5f984c6"></a><a id="ID-6e117ba4-b3f7-48f3-9616-67e3c3e2b7e4"></a>method reconnect (database-connection)</h3>
+<div id="outline-container-orge2e3298" class="outline-3">
+<h3 id="426a8f5d-5dc7-4973-a1fc-11b488afcd82"><a id="orge2e3298"></a><a id="ID-6e117ba4-b3f7-48f3-9616-67e3c3e2b7e4"></a>method reconnect (database-connection)</h3>
 <div class="outline-text-3" id="text-426a8f5d-5dc7-4973-a1fc-11b488afcd82">
 <p>
 Reconnect a disconnected database connection. This is not allowed for pooled
@@ -652,8 +657,8 @@ process, and should no longer be used.
 </div>
 </div>
 
-<div id="outline-container-orgc55d932" class="outline-3">
-<h3 id="9b9cf868-214b-4026-8f80-25b23f445c91"><a id="orgc55d932"></a><a id="ID-73c9e729-4db7-4ef3-a095-7b91a9db6238"></a>variable <b>database</b></h3>
+<div id="outline-container-org316d521" class="outline-3">
+<h3 id="9b9cf868-214b-4026-8f80-25b23f445c91"><a id="org316d521"></a><a id="ID-73c9e729-4db7-4ef3-a095-7b91a9db6238"></a>variable <b>database</b></h3>
 <div class="outline-text-3" id="text-9b9cf868-214b-4026-8f80-25b23f445c91">
 <p>
 Special variable holding the current database connection information. Most
@@ -663,8 +668,8 @@ database.
 </div>
 </div>
 
-<div id="outline-container-org61a94ec" class="outline-3">
-<h3 id="056d4921-c834-4655-a487-83314f22da42"><a id="org61a94ec"></a><a id="ID-c5d5b7f9-9555-4a0e-b691-1b10742e482d"></a>macro with-connection (spec &amp;body body)</h3>
+<div id="outline-container-org7426c81" class="outline-3">
+<h3 id="056d4921-c834-4655-a487-83314f22da42"><a id="org7426c81"></a><a id="ID-c5d5b7f9-9555-4a0e-b691-1b10742e482d"></a>macro with-connection (spec &amp;body body)</h3>
 <div class="outline-text-3" id="text-056d4921-c834-4655-a487-83314f22da42">
 <p>
 Evaluates the body with <b>database</b> bound to a connection as specified by spec,
@@ -673,8 +678,8 @@ which should be list that connect can be applied to.
 </div>
 </div>
 
-<div id="outline-container-orgcb0671c" class="outline-3">
-<h3 id="0e0c03e9-7681-433f-ae75-8f06c9685221"><a id="orgcb0671c"></a><a id="ID-476f90d8-15ac-49fb-ac19-1dc3dfdfcef7"></a>macro call-with-connection (spec thunk)</h3>
+<div id="outline-container-orgef9ecd6" class="outline-3">
+<h3 id="0e0c03e9-7681-433f-ae75-8f06c9685221"><a id="orgef9ecd6"></a><a id="ID-476f90d8-15ac-49fb-ac19-1dc3dfdfcef7"></a>macro call-with-connection (spec thunk)</h3>
 <div class="outline-text-3" id="text-0e0c03e9-7681-433f-ae75-8f06c9685221">
 <p>
 The functional backend to with-connection. Binds <b>database</b> to a new connection
@@ -685,8 +690,8 @@ When the function returns or throws, the new connection is disconnected.
 </div>
 </div>
 
-<div id="outline-container-org804f6f4" class="outline-3">
-<h3 id="a74be5d0-9b86-4c15-b738-76cd92908d25"><a id="org804f6f4"></a><a id="ID-ffab8aae-0ed7-4466-a68d-fc90d2e36dbe"></a>function connect-toplevel (database user-name password host &amp;key (port 5432))</h3>
+<div id="outline-container-org3076159" class="outline-3">
+<h3 id="a74be5d0-9b86-4c15-b738-76cd92908d25"><a id="org3076159"></a><a id="ID-ffab8aae-0ed7-4466-a68d-fc90d2e36dbe"></a>function connect-toplevel (database user-name password host &amp;key (port 5432))</h3>
 <div class="outline-text-3" id="text-a74be5d0-9b86-4c15-b738-76cd92908d25">
 <p>
 Bind the <b>database</b> to a new connection. Use this if you only need one
@@ -695,8 +700,8 @@ connection, or if you want a connection for debugging from the REPL.
 </div>
 </div>
 
-<div id="outline-container-orgdd2374e" class="outline-3">
-<h3 id="a63f929c-805d-42d5-8fbe-f1c01e62b50a"><a id="orgdd2374e"></a><a id="ID-f5819286-2754-468d-bfdd-e4ee06b877e3"></a>function disconnect-toplevel ()</h3>
+<div id="outline-container-org41babaf" class="outline-3">
+<h3 id="a63f929c-805d-42d5-8fbe-f1c01e62b50a"><a id="org41babaf"></a><a id="ID-f5819286-2754-468d-bfdd-e4ee06b877e3"></a>function disconnect-toplevel ()</h3>
 <div class="outline-text-3" id="text-a63f929c-805d-42d5-8fbe-f1c01e62b50a">
 <p>
 Disconnect the <b>database</b>.
@@ -704,8 +709,8 @@ Disconnect the <b>database</b>.
 </div>
 </div>
 
-<div id="outline-container-org00ce7b6" class="outline-3">
-<h3 id="56c370e4-8f4e-414a-82b6-ae4408fc0b61"><a id="org00ce7b6"></a><a id="ID-04d09496-6a7b-4794-a204-8667f3b69011"></a>function clear-connection-pool ()</h3>
+<div id="outline-container-orgb4bcbab" class="outline-3">
+<h3 id="56c370e4-8f4e-414a-82b6-ae4408fc0b61"><a id="orgb4bcbab"></a><a id="ID-04d09496-6a7b-4794-a204-8667f3b69011"></a>function clear-connection-pool ()</h3>
 <div class="outline-text-3" id="text-56c370e4-8f4e-414a-82b6-ae4408fc0b61">
 <p>
 Disconnect and remove all connections from the connection pools.
@@ -713,8 +718,8 @@ Disconnect and remove all connections from the connection pools.
 </div>
 </div>
 
-<div id="outline-container-org9705b9f" class="outline-3">
-<h3 id="97aa1ebb-ef91-4254-a6b7-bfcd8128ad96"><a id="org9705b9f"></a><a id="ID-92ab48e3-bf8f-4327-8d9c-69b6c168f94e"></a>variable <b>max-pool-size</b></h3>
+<div id="outline-container-orgc5d8806" class="outline-3">
+<h3 id="97aa1ebb-ef91-4254-a6b7-bfcd8128ad96"><a id="orgc5d8806"></a><a id="ID-92ab48e3-bf8f-4327-8d9c-69b6c168f94e"></a>variable <b>max-pool-size</b></h3>
 <div class="outline-text-3" id="text-97aa1ebb-ef91-4254-a6b7-bfcd8128ad96">
 <p>
 Set the maximum amount of connections kept in a single connection pool, where a
@@ -724,8 +729,8 @@ arguments. Defaults to NIL, which means there is no maximum.
 </div>
 </div>
 
-<div id="outline-container-org00f993e" class="outline-3">
-<h3 id="09583f9a-388a-400a-bb3c-d118242508c8"><a id="org00f993e"></a><a id="ID-1410d2f2-3f68-4e3d-947b-46167ecf1d37"></a>function list-connections ()</h3>
+<div id="outline-container-orgc38e3ef" class="outline-3">
+<h3 id="09583f9a-388a-400a-bb3c-d118242508c8"><a id="orgc38e3ef"></a><a id="ID-1410d2f2-3f68-4e3d-947b-46167ecf1d37"></a>function list-connections ()</h3>
 <div class="outline-text-3" id="text-09583f9a-388a-400a-bb3c-d118242508c8">
 <p>
 → list
@@ -738,12 +743,12 @@ does this by returningo info from pg_stat_activity on open connections.
 </div>
 </div>
 </div>
-<div id="outline-container-org85a874f" class="outline-2">
-<h2 id="querying"><a id="org85a874f"></a><a id="ID-e5e99216-0a15-4de8-b1d9-21bdcdf378fa"></a>Querying</h2>
+<div id="outline-container-org702aa85" class="outline-2">
+<h2 id="querying"><a id="org702aa85"></a><a id="ID-e5e99216-0a15-4de8-b1d9-21bdcdf378fa"></a>Querying</h2>
 <div class="outline-text-2" id="text-querying">
 </div>
-<div id="outline-container-org033bc31" class="outline-3">
-<h3 id="5a8c24fb-6d7b-4952-8520-b5e8ea98dd77"><a id="org033bc31"></a><a id="ID-0f8ab85f-b592-4648-8936-d16abce50faa"></a>macro query (query &amp;rest args/format)</h3>
+<div id="outline-container-orge440391" class="outline-3">
+<h3 id="5a8c24fb-6d7b-4952-8520-b5e8ea98dd77"><a id="orge440391"></a><a id="ID-0f8ab85f-b592-4648-8936-d16abce50faa"></a>macro query (query &amp;rest args/format)</h3>
 <div class="outline-text-3" id="text-5a8c24fb-6d7b-4952-8520-b5e8ea98dd77">
 <p>
 → result
@@ -863,9 +868,9 @@ instead. Any of the following formats can be used, with the default being :rows:
 Some Examples:
 </p>
 </div>
-<div id="outline-container-org86de3e8" class="outline-4">
-<h4 id="org86de3e8">Default</h4>
-<div class="outline-text-4" id="text-org86de3e8">
+<div id="outline-container-orgccb925a" class="outline-4">
+<h4 id="orgccb925a">Default</h4>
+<div class="outline-text-4" id="text-orgccb925a">
 <p>
 The default is :lists
 </p>
@@ -876,9 +881,9 @@ The default is :lists
 </div>
 </div>
 </div>
-<div id="outline-container-org02e62bf" class="outline-4">
-<h4 id="org02e62bf">Single</h4>
-<div class="outline-text-4" id="text-org02e62bf">
+<div id="outline-container-org6555544" class="outline-4">
+<h4 id="org6555544">Single</h4>
+<div class="outline-text-4" id="text-org6555544">
 <p>
 Returns a single field. Will throw an error if the queries returns more than one field or more than one row
 </p>
@@ -889,9 +894,9 @@ Returns a single field. Will throw an error if the queries returns more than one
 </div>
 </div>
 </div>
-<div id="outline-container-orge5bc7cf" class="outline-4">
-<h4 id="orge5bc7cf">List</h4>
-<div class="outline-text-4" id="text-orge5bc7cf">
+<div id="outline-container-org5f7c632" class="outline-4">
+<h4 id="org5f7c632">List</h4>
+<div class="outline-text-4" id="text-org5f7c632">
 <p>
 Returns a list containing the selected fields. Will throw an error if the query returns more than one row
 </p>
@@ -902,9 +907,9 @@ Returns a list containing the selected fields. Will throw an error if the query 
 </div>
 </div>
 </div>
-<div id="outline-container-orge16f6fb" class="outline-4">
-<h4 id="orge16f6fb">Lists</h4>
-<div class="outline-text-4" id="text-orge16f6fb">
+<div id="outline-container-org81ac3a0" class="outline-4">
+<h4 id="org81ac3a0">Lists</h4>
+<div class="outline-text-4" id="text-org81ac3a0">
 <p>
 This is the default
 </p>
@@ -915,9 +920,9 @@ This is the default
 </div>
 </div>
 </div>
-<div id="outline-container-orge169878" class="outline-4">
-<h4 id="orge169878">Alist</h4>
-<div class="outline-text-4" id="text-orge169878">
+<div id="outline-container-org0cf656f" class="outline-4">
+<h4 id="org0cf656f">Alist</h4>
+<div class="outline-text-4" id="text-org0cf656f">
 <p>
 Returns an alist containing the field name as a keyword and the selected fields. Will throw an error if the query returns more than one row.
 </p>
@@ -928,9 +933,9 @@ Returns an alist containing the field name as a keyword and the selected fields.
 </div>
 </div>
 </div>
-<div id="outline-container-org9083d55" class="outline-4">
-<h4 id="org9083d55">Str-alist</h4>
-<div class="outline-text-4" id="text-org9083d55">
+<div id="outline-container-org34726ab" class="outline-4">
+<h4 id="org34726ab">Str-alist</h4>
+<div class="outline-text-4" id="text-org34726ab">
 <p>
 Returns an alist containing the field name as a lower case string and the selected fields. Will throw an error if the query returns more than one row.
 </p>
@@ -942,9 +947,9 @@ Returns an alist containing the field name as a lower case string and the select
 </div>
 </div>
 
-<div id="outline-container-orgbc25e47" class="outline-4">
-<h4 id="orgbc25e47">Alists</h4>
-<div class="outline-text-4" id="text-orgbc25e47">
+<div id="outline-container-org5558d6d" class="outline-4">
+<h4 id="org5558d6d">Alists</h4>
+<div class="outline-text-4" id="text-org5558d6d">
 <p>
 Returns a list of alists containing the field name as a keyword and the selected fields.
 </p>
@@ -956,9 +961,9 @@ Returns a list of alists containing the field name as a keyword and the selected
 </div>
 </div>
 </div>
-<div id="outline-container-orga3b29a8" class="outline-4">
-<h4 id="orga3b29a8">Str-alists</h4>
-<div class="outline-text-4" id="text-orga3b29a8">
+<div id="outline-container-orgec42c9c" class="outline-4">
+<h4 id="orgec42c9c">Str-alists</h4>
+<div class="outline-text-4" id="text-orgec42c9c">
 <p>
 Returns a list of alists containing the field name as a lower case string and the selected fields.
 </p>
@@ -970,9 +975,9 @@ Returns a list of alists containing the field name as a lower case string and th
 </div>
 </div>
 </div>
-<div id="outline-container-org1fe962c" class="outline-4">
-<h4 id="org1fe962c">Plist</h4>
-<div class="outline-text-4" id="text-org1fe962c">
+<div id="outline-container-org489ec20" class="outline-4">
+<h4 id="org489ec20">Plist</h4>
+<div class="outline-text-4" id="text-org489ec20">
 <p>
 Returns a plist containing the field name as a keyword and the selected fields. Will throw an error if the query returns more than one row.
 </p>
@@ -983,9 +988,9 @@ Returns a plist containing the field name as a keyword and the selected fields. 
 </div>
 </div>
 </div>
-<div id="outline-container-org7c6706d" class="outline-4">
-<h4 id="org7c6706d">Plists</h4>
-<div class="outline-text-4" id="text-org7c6706d">
+<div id="outline-container-orgf34b655" class="outline-4">
+<h4 id="orgf34b655">Plists</h4>
+<div class="outline-text-4" id="text-orgf34b655">
 <p>
 Returns a list of plists containing the field name as a keyword and the selected fields.
 </p>
@@ -996,9 +1001,9 @@ Returns a list of plists containing the field name as a keyword and the selected
 </div>
 </div>
 </div>
-<div id="outline-container-org77e2bf4" class="outline-4">
-<h4 id="org77e2bf4">Array-hash</h4>
-<div class="outline-text-4" id="text-org77e2bf4">
+<div id="outline-container-orge7084ce" class="outline-4">
+<h4 id="orge7084ce">Array-hash</h4>
+<div class="outline-text-4" id="text-orge7084ce">
 <p>
 Returns a vector of hashtables where each hash table is a returned row from the query with field name as the key expressed as a lower case string.
 </p>
@@ -1016,9 +1021,9 @@ Returns a vector of hashtables where each hash table is a returned row from the 
 </div>
 </div>
 </div>
-<div id="outline-container-orgbb6e89d" class="outline-4">
-<h4 id="orgbb6e89d">Dao</h4>
-<div class="outline-text-4" id="text-orgbb6e89d">
+<div id="outline-container-orgf566f1b" class="outline-4">
+<h4 id="orgf566f1b">Dao</h4>
+<div class="outline-text-4" id="text-orgf566f1b">
 <p>
 Returns a list of daos of the type specified
 </p>
@@ -1032,9 +1037,9 @@ Returns a list of daos of the type specified
 </div>
 </div>
 </div>
-<div id="outline-container-orgddfdade" class="outline-4">
-<h4 id="orgddfdade">Column</h4>
-<div class="outline-text-4" id="text-orgddfdade">
+<div id="outline-container-org804e967" class="outline-4">
+<h4 id="org804e967">Column</h4>
+<div class="outline-text-4" id="text-org804e967">
 <p>
 Returns a list of field values of a single field. Will throw an error if more than one field is selected
 </p>
@@ -1048,9 +1053,9 @@ Returns a list of field values of a single field. Will throw an error if more th
 </div>
 </div>
 </div>
-<div id="outline-container-orgec8cd7c" class="outline-4">
-<h4 id="orgec8cd7c">Json-strs</h4>
-<div class="outline-text-4" id="text-orgec8cd7c">
+<div id="outline-container-orgb26ec31" class="outline-4">
+<h4 id="orgb26ec31">Json-strs</h4>
+<div class="outline-text-4" id="text-orgb26ec31">
 <p>
 Return a list of strings where the row returned is a json object expressed as a string
 </p>
@@ -1088,9 +1093,9 @@ The following is an example with a simple-date timestamp.
 </div>
 </div>
 </div>
-<div id="outline-container-org6bada5b" class="outline-4">
-<h4 id="org6bada5b">Json-str</h4>
-<div class="outline-text-4" id="text-org6bada5b">
+<div id="outline-container-org122c2ab" class="outline-4">
+<h4 id="org122c2ab">Json-str</h4>
+<div class="outline-text-4" id="text-org122c2ab">
 <p>
 Return a single string where the row returned is a json object expressed as a string
 </p>
@@ -1105,9 +1110,9 @@ As with :json-strs, this will also work for either simple-date or local-time tim
 </div>
 </div>
 
-<div id="outline-container-org0cdd964" class="outline-4">
-<h4 id="org0cdd964">Json-array-str</h4>
-<div class="outline-text-4" id="text-org0cdd964">
+<div id="outline-container-org4438e53" class="outline-4">
+<h4 id="org4438e53">Json-array-str</h4>
+<div class="outline-text-4" id="text-org4438e53">
 <p>
 Return a string containing a json array, each element in the array is a selected row expressed as a json object
 </p>
@@ -1121,9 +1126,9 @@ As with :json-strs, this will also work for either simple-date or local-time tim
 </p>
 </div>
 </div>
-<div id="outline-container-orgd9f67ae" class="outline-4">
-<h4 id="orgd9f67ae">Second value returned</h4>
-<div class="outline-text-4" id="text-orgd9f67ae">
+<div id="outline-container-org79b7bce" class="outline-4">
+<h4 id="org79b7bce">Second value returned</h4>
+<div class="outline-text-4" id="text-org79b7bce">
 <p>
 If the database returns information about the amount rows that were affected,
 such as with updating or deleting queries, this is returned as a second value.
@@ -1132,8 +1137,8 @@ such as with updating or deleting queries, this is returned as a second value.
 </div>
 </div>
 
-<div id="outline-container-org9b58e56" class="outline-3">
-<h3 id="71106869-4169-49c8-ba7d-ce6b9fc7d780"><a id="org9b58e56"></a><a id="ID-b494a547-353c-4de4-8071-e8703a62b919"></a>macro execute (query &amp;rest args)</h3>
+<div id="outline-container-org2cc482f" class="outline-3">
+<h3 id="71106869-4169-49c8-ba7d-ce6b9fc7d780"><a id="org2cc482f"></a><a id="ID-b494a547-353c-4de4-8071-e8703a62b919"></a>macro execute (query &amp;rest args)</h3>
 <div class="outline-text-3" id="text-71106869-4169-49c8-ba7d-ce6b9fc7d780">
 <p>
 Execute a query, ignore the results. So, in effect, Like a query called with
@@ -1144,8 +1149,8 @@ deprecated.)
 </div>
 </div>
 
-<div id="outline-container-orgab9dd3e" class="outline-3">
-<h3 id="66aa9f57-ac8a-4457-9891-3453682518e0"><a id="orgab9dd3e"></a><a id="ID-db023195-6f0f-446d-9188-0886d895202b"></a>macro doquery (query (&amp;rest names) &amp;body body)</h3>
+<div id="outline-container-orgd7c7871" class="outline-3">
+<h3 id="66aa9f57-ac8a-4457-9891-3453682518e0"><a id="orgd7c7871"></a><a id="ID-db023195-6f0f-446d-9188-0886d895202b"></a>macro doquery (query (&amp;rest names) &amp;body body)</h3>
 <div class="outline-text-3" id="text-66aa9f57-ac8a-4457-9891-3453682518e0">
 <p>
 Execute the given query (a string or a list starting with a keyword), iterating
@@ -1165,8 +1170,8 @@ arguments. For example:
 </div>
 </div>
 
-<div id="outline-container-org5a42434" class="outline-3">
-<h3 id="625b6ade-7b09-49dc-b288-78c550b25d83"><a id="org5a42434"></a><a id="ID-0daaa786-45e9-4853-934c-e1499b4c87f0"></a>macro prepare (query &amp;optional (format :rows))</h3>
+<div id="outline-container-orgd2aada1" class="outline-3">
+<h3 id="625b6ade-7b09-49dc-b288-78c550b25d83"><a id="orgd2aada1"></a><a id="ID-0daaa786-45e9-4853-934c-e1499b4c87f0"></a>macro prepare (query &amp;optional (format :rows))</h3>
 <div class="outline-text-3" id="text-625b6ade-7b09-49dc-b288-78c550b25d83">
 <p>
 → function
@@ -1203,8 +1208,8 @@ statements triggering a duplicate-prepared-statement error.
 </div>
 </div>
 
-<div id="outline-container-org8912dbc" class="outline-3">
-<h3 id="b2ed5fb5-d5f5-4425-b30e-5c40a2997eee"><a id="org8912dbc"></a><a id="ID-d95a6214-b951-4fcd-96ab-a0c40d62ee2b"></a>macro defprepared (name query &amp;optional (format :rows))</h3>
+<div id="outline-container-orgff3104e" class="outline-3">
+<h3 id="b2ed5fb5-d5f5-4425-b30e-5c40a2997eee"><a id="orgff3104e"></a><a id="ID-d95a6214-b951-4fcd-96ab-a0c40d62ee2b"></a>macro defprepared (name query &amp;optional (format :rows))</h3>
 <div class="outline-text-3" id="text-b2ed5fb5-d5f5-4425-b30e-5c40a2997eee">
 <p>
 → function
@@ -1218,8 +1223,8 @@ statement. The name should not a string but may be quoted.
 </div>
 </div>
 
-<div id="outline-container-orgc54ae51" class="outline-3">
-<h3 id="73823e7b-1fc5-40b2-908f-cec99ac1bc9e"><a id="orgc54ae51"></a><a id="ID-b29f3cc1-4af4-4619-9817-ecbc06d98d51"></a>macro defprepared-with-names (name (&amp;rest args) (query &amp;rest query-args) &amp;optional (format :rows))</h3>
+<div id="outline-container-org0b4cff9" class="outline-3">
+<h3 id="73823e7b-1fc5-40b2-908f-cec99ac1bc9e"><a id="org0b4cff9"></a><a id="ID-b29f3cc1-4af4-4619-9817-ecbc06d98d51"></a>macro defprepared-with-names (name (&amp;rest args) (query &amp;rest query-args) &amp;optional (format :rows))</h3>
 <div class="outline-text-3" id="text-73823e7b-1fc5-40b2-908f-cec99ac1bc9e">
 <p>
 Like defprepared, but allows to specify names of the function arguments in a
@@ -1237,8 +1242,8 @@ lambda list as well as arguments supplied to the query.
 </div>
 </div>
 
-<div id="outline-container-org8560c04" class="outline-3">
-<h3 id="453612e6-2835-41b2-8305-01b6b5473138"><a id="org8560c04"></a><a id="ID-29d50700-9459-4e40-baaa-efafc7fbe0cf"></a>macro with-transaction ((&amp;optional name isolation-level) &amp;body body)</h3>
+<div id="outline-container-orgac5b23a" class="outline-3">
+<h3 id="453612e6-2835-41b2-8305-01b6b5473138"><a id="orgac5b23a"></a><a id="ID-29d50700-9459-4e40-baaa-efafc7fbe0cf"></a>macro with-transaction ((&amp;optional name isolation-level) &amp;body body)</h3>
 <div class="outline-text-3" id="text-453612e6-2835-41b2-8305-01b6b5473138">
 <p>
 Execute the given body within a database transaction, committing it when the
@@ -1292,8 +1297,8 @@ Further discussion of transactions and isolation levels can found at
 </div>
 </div>
 
-<div id="outline-container-org03bce89" class="outline-3">
-<h3 id="10b5d3e9-b174-4f02-8c47-6eb3430e60fe"><a id="org03bce89"></a><a id="ID-c5f3a2df-ebef-4180-af02-f54921552736"></a>function commit-transaction (transaction)</h3>
+<div id="outline-container-orgeb1fff7" class="outline-3">
+<h3 id="10b5d3e9-b174-4f02-8c47-6eb3430e60fe"><a id="orgeb1fff7"></a><a id="ID-c5f3a2df-ebef-4180-af02-f54921552736"></a>function commit-transaction (transaction)</h3>
 <div class="outline-text-3" id="text-10b5d3e9-b174-4f02-8c47-6eb3430e60fe">
 <p>
 Immediately commit an open transaction.
@@ -1301,8 +1306,8 @@ Immediately commit an open transaction.
 </div>
 </div>
 
-<div id="outline-container-orgafc64fd" class="outline-3">
-<h3 id="58a7459f-a1f4-4797-83b5-8b5257ca2cf7"><a id="orgafc64fd"></a><a id="ID-6c705c87-8bd9-41cd-b63a-7ef67d5691f6"></a>function abort-transaction (transaction)</h3>
+<div id="outline-container-org9875250" class="outline-3">
+<h3 id="58a7459f-a1f4-4797-83b5-8b5257ca2cf7"><a id="org9875250"></a><a id="ID-6c705c87-8bd9-41cd-b63a-7ef67d5691f6"></a>function abort-transaction (transaction)</h3>
 <div class="outline-text-3" id="text-58a7459f-a1f4-4797-83b5-8b5257ca2cf7">
 <p>
 Roll back the given transaction, but the transaction
@@ -1316,9 +1321,9 @@ is present only for historical reasons..
 </div>
 </div>
 
-<div id="outline-container-org1f0878d" class="outline-3">
-<h3 id="org1f0878d">function rollback-transaction (transaction)</h3>
-<div class="outline-text-3" id="text-org1f0878d">
+<div id="outline-container-org16d195f" class="outline-3">
+<h3 id="org16d195f">function rollback-transaction (transaction)</h3>
+<div class="outline-text-3" id="text-org16d195f">
 <p>
 Roll back the given transaction, but the transaction
 block is still active. Thus calling abort-transaction in the middle of a
@@ -1329,8 +1334,8 @@ transaction and causes all the updates made by the transaction to be discarded.
 </div>
 </div>
 
-<div id="outline-container-orgecb5cff" class="outline-3">
-<h3 id="5899097b-a5fb-4b7a-961b-3c65a95f81d4"><a id="orgecb5cff"></a><a id="ID-2b3980a2-969c-4376-92aa-ce9ee5867b6c"></a>macro with-savepoint (name &amp;body body)</h3>
+<div id="outline-container-org91b9401" class="outline-3">
+<h3 id="5899097b-a5fb-4b7a-961b-3c65a95f81d4"><a id="org91b9401"></a><a id="ID-2b3980a2-969c-4376-92aa-ce9ee5867b6c"></a>macro with-savepoint (name &amp;body body)</h3>
 <div class="outline-text-3" id="text-5899097b-a5fb-4b7a-961b-3c65a95f81d4">
 <p>
 Can only be used within a transaction. Establishes a savepoint with the given
@@ -1389,8 +1394,8 @@ release-savepoint.
 </div>
 </div>
 
-<div id="outline-container-org0c9c71a" class="outline-3">
-<h3 id="a6d99838-ed98-4839-ac13-c03ecbfd6f96"><a id="org0c9c71a"></a><a id="ID-1d876de8-f717-4a15-a222-18aa4c344583"></a>function release-savepoint (savepoint)</h3>
+<div id="outline-container-org176a802" class="outline-3">
+<h3 id="a6d99838-ed98-4839-ac13-c03ecbfd6f96"><a id="org176a802"></a><a id="ID-1d876de8-f717-4a15-a222-18aa4c344583"></a>function release-savepoint (savepoint)</h3>
 <div class="outline-text-3" id="text-a6d99838-ed98-4839-ac13-c03ecbfd6f96">
 <p>
 Immediately release a savepoint, commiting its results.
@@ -1398,8 +1403,8 @@ Immediately release a savepoint, commiting its results.
 </div>
 </div>
 
-<div id="outline-container-orgee0fb2c" class="outline-3">
-<h3 id="1f84633f-e567-42c6-bcfc-2167dad89165"><a id="orgee0fb2c"></a><a id="ID-a19e709e-b574-4494-bb79-aa788fcc0200"></a>function rollback-savepoint (savepoint)</h3>
+<div id="outline-container-orgfe7a9dd" class="outline-3">
+<h3 id="1f84633f-e567-42c6-bcfc-2167dad89165"><a id="orgfe7a9dd"></a><a id="ID-a19e709e-b574-4494-bb79-aa788fcc0200"></a>function rollback-savepoint (savepoint)</h3>
 <div class="outline-text-3" id="text-1f84633f-e567-42c6-bcfc-2167dad89165">
 <p>
 Immediately roll back a savepoint, aborting the results.
@@ -1407,8 +1412,8 @@ Immediately roll back a savepoint, aborting the results.
 </div>
 </div>
 
-<div id="outline-container-orge5b593d" class="outline-3">
-<h3 id="919494ae-625f-4f63-b271-6cc5d0b16549"><a id="orge5b593d"></a><a id="ID-c297fecf-bcb8-451c-bd91-22892d04c96d"></a>method commit-hooks (transaction-or-savepoint), setf (commit-hooks transaction-or-savepoint)</h3>
+<div id="outline-container-org8447c5c" class="outline-3">
+<h3 id="919494ae-625f-4f63-b271-6cc5d0b16549"><a id="org8447c5c"></a><a id="ID-c297fecf-bcb8-451c-bd91-22892d04c96d"></a>method commit-hooks (transaction-or-savepoint), setf (commit-hooks transaction-or-savepoint)</h3>
 <div class="outline-text-3" id="text-919494ae-625f-4f63-b271-6cc5d0b16549">
 <p>
 An accessor for the transaction or savepoint's list of commit hooks, each of
@@ -1418,8 +1423,8 @@ executed when a transaction is committed or a savepoint released.
 </div>
 </div>
 
-<div id="outline-container-org5e25024" class="outline-3">
-<h3 id="94700fa6-1f29-4c0f-86ad-487e640933b9"><a id="org5e25024"></a><a id="ID-7dd2980a-9f3d-4bff-a1f5-0745adecba24"></a>function abort-hooks (transaction-or-savepoint), setf (abort-hooks transaction-or-savepoint)</h3>
+<div id="outline-container-orgf939f09" class="outline-3">
+<h3 id="94700fa6-1f29-4c0f-86ad-487e640933b9"><a id="orgf939f09"></a><a id="ID-7dd2980a-9f3d-4bff-a1f5-0745adecba24"></a>function abort-hooks (transaction-or-savepoint), setf (abort-hooks transaction-or-savepoint)</h3>
 <div class="outline-text-3" id="text-94700fa6-1f29-4c0f-86ad-487e640933b9">
 <p>
 An accessor for the transaction or savepoint's list of abort hooks, each of
@@ -1431,8 +1436,8 @@ rollback-savepoint).
 </div>
 </div>
 
-<div id="outline-container-orga8c65e8" class="outline-3">
-<h3 id="44dac415-f1b2-4f01-bb05-a31c6c977b4c"><a id="orga8c65e8"></a><a id="ID-01275b50-0fa5-4b2f-968f-c360bc3efde0"></a>variable <b>isolation-level</b></h3>
+<div id="outline-container-org2f5e7ef" class="outline-3">
+<h3 id="44dac415-f1b2-4f01-bb05-a31c6c977b4c"><a id="org2f5e7ef"></a><a id="ID-01275b50-0fa5-4b2f-968f-c360bc3efde0"></a>variable <b>isolation-level</b></h3>
 <div class="outline-text-3" id="text-44dac415-f1b2-4f01-bb05-a31c6c977b4c">
 <p>
 The transaction isolation level currently in use. Defaults to :read-committed-rw
@@ -1453,8 +1458,8 @@ You can specify the following isolation levels in postmodern transactions:
 </div>
 
 
-<div id="outline-container-orgb3dc191" class="outline-3">
-<h3 id="5fdcafe3-5da4-48ee-8bb0-8567c7e00837"><a id="orgb3dc191"></a><a id="ID-355157ce-0f0c-4f9a-9be0-cfd12fd7bea0"></a>macro with-logical-transaction ((&amp;optional name isolation-level) &amp;body body)</h3>
+<div id="outline-container-org7f753b9" class="outline-3">
+<h3 id="5fdcafe3-5da4-48ee-8bb0-8567c7e00837"><a id="org7f753b9"></a><a id="ID-355157ce-0f0c-4f9a-9be0-cfd12fd7bea0"></a>macro with-logical-transaction ((&amp;optional name isolation-level) &amp;body body)</h3>
 <div class="outline-text-3" id="text-5fdcafe3-5da4-48ee-8bb0-8567c7e00837">
 <p>
 Executes body within a with-transaction form if no transaction is currently
@@ -1507,8 +1512,8 @@ expected here:
 </div>
 </div>
 
-<div id="outline-container-org60bd325" class="outline-3">
-<h3 id="7d237c64-5c3e-44a6-8b7c-6eecc4379b71"><a id="org60bd325"></a><a id="ID-196ef5b0-9c58-4f28-9766-e37334448d3c"></a>function abort-logical-transaction (transaction-or-savepoint)</h3>
+<div id="outline-container-org703dbdb" class="outline-3">
+<h3 id="7d237c64-5c3e-44a6-8b7c-6eecc4379b71"><a id="org703dbdb"></a><a id="ID-196ef5b0-9c58-4f28-9766-e37334448d3c"></a>function abort-logical-transaction (transaction-or-savepoint)</h3>
 <div class="outline-text-3" id="text-7d237c64-5c3e-44a6-8b7c-6eecc4379b71">
 <p>
 Roll back the given logical transaction, regardless of whether it is an actual
@@ -1517,8 +1522,8 @@ transaction or a savepoint.
 </div>
 </div>
 
-<div id="outline-container-orge6418e4" class="outline-3">
-<h3 id="ae0f0c99-0bda-491e-99a5-3a61e0a86166"><a id="orge6418e4"></a><a id="ID-33fd01cd-603f-48e0-a2d9-1433d9b7f4db"></a>function commit-logical-transaction (transaction-or-savepoint)</h3>
+<div id="outline-container-org222721e" class="outline-3">
+<h3 id="ae0f0c99-0bda-491e-99a5-3a61e0a86166"><a id="org222721e"></a><a id="ID-33fd01cd-603f-48e0-a2d9-1433d9b7f4db"></a>function commit-logical-transaction (transaction-or-savepoint)</h3>
 <div class="outline-text-3" id="text-ae0f0c99-0bda-491e-99a5-3a61e0a86166">
 <p>
 Commit the given logical transaction, regardless of whether it is an actual
@@ -1527,8 +1532,8 @@ transaction or a savepoint.
 </div>
 </div>
 
-<div id="outline-container-org0f54d96" class="outline-3">
-<h3 id="bf78478f-92a2-4162-963d-b4e101b23154"><a id="org0f54d96"></a><a id="ID-2a5d91c2-f990-4a3c-a775-5e1fd539fee8"></a>variable <b>current-logical-transaction</b></h3>
+<div id="outline-container-org9a5a3f4" class="outline-3">
+<h3 id="bf78478f-92a2-4162-963d-b4e101b23154"><a id="org9a5a3f4"></a><a id="ID-2a5d91c2-f990-4a3c-a775-5e1fd539fee8"></a>variable <b>current-logical-transaction</b></h3>
 <div class="outline-text-3" id="text-bf78478f-92a2-4162-963d-b4e101b23154">
 <p>
 This is bound to the current transaction-handle or savepoint-handle instance
@@ -1537,8 +1542,8 @@ representing the innermost open logical transaction.
 </div>
 </div>
 
-<div id="outline-container-orgd3fe9c8" class="outline-3">
-<h3 id="6ad767b2-75b7-48ee-a260-6caece5bad62"><a id="orgd3fe9c8"></a><a id="ID-34881db5-1c47-444e-bb55-bb6249d4764c"></a>macro ensure-transaction (&amp;body body)</h3>
+<div id="outline-container-org2ab0da2" class="outline-3">
+<h3 id="6ad767b2-75b7-48ee-a260-6caece5bad62"><a id="org2ab0da2"></a><a id="ID-34881db5-1c47-444e-bb55-bb6249d4764c"></a>macro ensure-transaction (&amp;body body)</h3>
 <div class="outline-text-3" id="text-6ad767b2-75b7-48ee-a260-6caece5bad62">
 <p>
 Ensures that body is executed within a transaction, but does not begin a new
@@ -1547,8 +1552,8 @@ transaction if one is already in progress.
 </div>
 </div>
 
-<div id="outline-container-org3b70f36" class="outline-3">
-<h3 id="9ca2ed2b-60ea-4e34-b370-a4f54c1f1dcd"><a id="org3b70f36"></a><a id="ID-dba390df-3c75-4d4c-b8c9-79af3f763914"></a>macro ensure-transaction-with-isolation-level (isolation-level &amp;body body)</h3>
+<div id="outline-container-org344b1e0" class="outline-3">
+<h3 id="9ca2ed2b-60ea-4e34-b370-a4f54c1f1dcd"><a id="org344b1e0"></a><a id="ID-dba390df-3c75-4d4c-b8c9-79af3f763914"></a>macro ensure-transaction-with-isolation-level (isolation-level &amp;body body)</h3>
 <div class="outline-text-3" id="text-9ca2ed2b-60ea-4e34-b370-a4f54c1f1dcd">
 <p>
 Executes body within a with-transaction form if and only if no transaction is
@@ -1559,13 +1564,13 @@ than the current default
 </div>
 </div>
 
-<div id="outline-container-orgc863969" class="outline-2">
-<h2 id="prepared-statement-helper-functions"><a id="orgc863969"></a><a id="ID-d4846b02-aa2f-4e44-9294-7e5811e61e6c"></a>Helper functions for Prepared Statements</h2>
+<div id="outline-container-orgb26bb36" class="outline-2">
+<h2 id="prepared-statement-helper-functions"><a id="orgb26bb36"></a><a id="ID-d4846b02-aa2f-4e44-9294-7e5811e61e6c"></a>Helper functions for Prepared Statements</h2>
 <div class="outline-text-2" id="text-prepared-statement-helper-functions">
 </div>
 
-<div id="outline-container-org5c290ad" class="outline-3">
-<h3 id="533331a5-6780-41bd-9ae8-2efac3a3c2c2"><a id="org5c290ad"></a><a id="ID-ca5ba066-3d35-4bb1-97b1-c22436c1bc6d"></a>defparameter <b>allow-overwriting-prepared-statements</b></h3>
+<div id="outline-container-org312d943" class="outline-3">
+<h3 id="533331a5-6780-41bd-9ae8-2efac3a3c2c2"><a id="org312d943"></a><a id="ID-ca5ba066-3d35-4bb1-97b1-c22436c1bc6d"></a>defparameter <b>allow-overwriting-prepared-statements</b></h3>
 <div class="outline-text-3" id="text-533331a5-6780-41bd-9ae8-2efac3a3c2c2">
 <p>
 When set to t, ensured-prepared will overwrite prepared statements having the
@@ -1575,8 +1580,8 @@ different than the query statement provided to ensure-prepared.
 </div>
 </div>
 
-<div id="outline-container-org332a1a4" class="outline-3">
-<h3 id="7ca58f04-2ad5-4896-b8c2-b13b276b4f5b"><a id="org332a1a4"></a><a id="ID-a9d22ab2-b849-475c-b325-a91638aed7a0"></a>function prepared-statement-exists-p (name)</h3>
+<div id="outline-container-org5ba54ff" class="outline-3">
+<h3 id="7ca58f04-2ad5-4896-b8c2-b13b276b4f5b"><a id="org5ba54ff"></a><a id="ID-a9d22ab2-b849-475c-b325-a91638aed7a0"></a>function prepared-statement-exists-p (name)</h3>
 <div class="outline-text-3" id="text-7ca58f04-2ad5-4896-b8c2-b13b276b4f5b">
 <p>
 → boolean
@@ -1586,8 +1591,8 @@ session, otherwise nil.
 </div>
 </div>
 
-<div id="outline-container-org5dae613" class="outline-3">
-<h3 id="3788ef72-d6a7-4e3b-acad-3f2608914dfb"><a id="org5dae613"></a><a id="ID-0028b494-ebd0-40ca-ac31-a4ae7b598609"></a>function list-prepared-statements (&amp;optional (names-only nil))</h3>
+<div id="outline-container-org3f26d4a" class="outline-3">
+<h3 id="3788ef72-d6a7-4e3b-acad-3f2608914dfb"><a id="org3f26d4a"></a><a id="ID-0028b494-ebd0-40ca-ac31-a4ae7b598609"></a>function list-prepared-statements (&amp;optional (names-only nil))</h3>
 <div class="outline-text-3" id="text-3788ef72-d6a7-4e3b-acad-3f2608914dfb">
 <p>
 → list
@@ -1601,8 +1606,8 @@ to t, it will only return a list of the names of the prepared statements.
 </div>
 </div>
 
-<div id="outline-container-org3bb2fe2" class="outline-3">
-<h3 id="7ec6297f-85a7-419e-a9d4-8f6e2ceb9559"><a id="org3bb2fe2"></a><a id="ID-7ce9f5ff-3750-4359-9850-e9a23b0a279a"></a>function drop-prepared-statement (statement-name &amp;key (location :both) (database <b>database</b>))</h3>
+<div id="outline-container-org965c28d" class="outline-3">
+<h3 id="7ec6297f-85a7-419e-a9d4-8f6e2ceb9559"><a id="org965c28d"></a><a id="ID-7ce9f5ff-3750-4359-9850-e9a23b0a279a"></a>function drop-prepared-statement (statement-name &amp;key (location :both) (database <b>database</b>))</h3>
 <div class="outline-text-3" id="text-7ec6297f-85a7-419e-a9d4-8f6e2ceb9559">
 <p>
 The statement name can be a string or quoted symbol.
@@ -1634,8 +1639,8 @@ This behavior is controlled by the remove-function key parameter.
 </div>
 </div>
 
-<div id="outline-container-org2f882b8" class="outline-3">
-<h3 id="b6049a3a-55a2-44be-9dc0-1af2849e2128"><a id="org2f882b8"></a><a id="ID-3350ba3c-2389-44d7-af61-a7b2193794f4"></a>function list-postmodern-prepared-statements (&amp;optional (names-only nil))</h3>
+<div id="outline-container-org4d37802" class="outline-3">
+<h3 id="b6049a3a-55a2-44be-9dc0-1af2849e2128"><a id="org4d37802"></a><a id="ID-3350ba3c-2389-44d7-af61-a7b2193794f4"></a>function list-postmodern-prepared-statements (&amp;optional (names-only nil))</h3>
 <div class="outline-text-3" id="text-b6049a3a-55a2-44be-9dc0-1af2849e2128">
 <p>
 → list
@@ -1657,8 +1662,8 @@ the names of the prepared statements.
 </div>
 </div>
 
-<div id="outline-container-org54bfeb6" class="outline-3">
-<h3 id="06ea4b19-3d57-4f08-b92d-d477bf61c456"><a id="org54bfeb6"></a><a id="ID-72bb535d-6a0c-4f59-a00d-fdcb5d84680b"></a>function find-postgresql-prepared-statement (name)</h3>
+<div id="outline-container-org59caa63" class="outline-3">
+<h3 id="06ea4b19-3d57-4f08-b92d-d477bf61c456"><a id="org59caa63"></a><a id="ID-72bb535d-6a0c-4f59-a00d-fdcb5d84680b"></a>function find-postgresql-prepared-statement (name)</h3>
 <div class="outline-text-3" id="text-06ea4b19-3d57-4f08-b92d-d477bf61c456">
 <p>
 → string
@@ -1671,8 +1676,8 @@ this session and placed in the meta slot in the connection.
 </div>
 </div>
 
-<div id="outline-container-orgd77f128" class="outline-3">
-<h3 id="b728be40-afaf-45d3-849c-3b7e27b3b0c1"><a id="orgd77f128"></a><a id="ID-4eb910d7-0fbe-48a2-9002-8075050c937d"></a>function find-postmodern-prepared-statement (name)</h3>
+<div id="outline-container-orga231665" class="outline-3">
+<h3 id="b728be40-afaf-45d3-849c-3b7e27b3b0c1"><a id="orga231665"></a><a id="ID-4eb910d7-0fbe-48a2-9002-8075050c937d"></a>function find-postmodern-prepared-statement (name)</h3>
 <div class="outline-text-3" id="text-b728be40-afaf-45d3-849c-3b7e27b3b0c1">
 <p>
 → string
@@ -1686,8 +1691,8 @@ the name.
 </div>
 </div>
 
-<div id="outline-container-orgc8d5d6b" class="outline-3">
-<h3 id="967c2e66-3ec9-4e07-9de9-1a06d758ac27"><a id="orgc8d5d6b"></a><a id="ID-96e37531-56dd-4580-9fdc-d0e2bb3fbebc"></a>function reset-prepared-statement (condition)</h3>
+<div id="outline-container-orgb62e8d6" class="outline-3">
+<h3 id="967c2e66-3ec9-4e07-9de9-1a06d758ac27"><a id="orgb62e8d6"></a><a id="ID-96e37531-56dd-4580-9fdc-d0e2bb3fbebc"></a>function reset-prepared-statement (condition)</h3>
 <div class="outline-text-3" id="text-967c2e66-3ec9-4e07-9de9-1a06d758ac27">
 <p>
 → restart
@@ -1702,8 +1707,8 @@ restart the connection.
 </div>
 </div>
 
-<div id="outline-container-orgddade05" class="outline-3">
-<h3 id="a172b4cb-826f-4bcf-9c50-70676bb7599a"><a id="orgddade05"></a><a id="ID-92d74162-757f-449d-a52a-5c9daa20c5f0"></a>function get-pid ()</h3>
+<div id="outline-container-org9bdb8e1" class="outline-3">
+<h3 id="a172b4cb-826f-4bcf-9c50-70676bb7599a"><a id="org9bdb8e1"></a><a id="ID-92d74162-757f-449d-a52a-5c9daa20c5f0"></a>function get-pid ()</h3>
 <div class="outline-text-3" id="text-a172b4cb-826f-4bcf-9c50-70676bb7599a">
 <p>
 → integer
@@ -1715,8 +1720,8 @@ Get the process id used by postgresql for this connection.
 </div>
 </div>
 
-<div id="outline-container-org15535fa" class="outline-3">
-<h3 id="b0afcff9-dfa9-466a-a3a2-06b189eac23a"><a id="org15535fa"></a><a id="ID-693e7941-c239-406f-8870-566cbb5c9209"></a>function get-pid-from-postmodern ()</h3>
+<div id="outline-container-org7900f14" class="outline-3">
+<h3 id="b0afcff9-dfa9-466a-a3a2-06b189eac23a"><a id="org7900f14"></a><a id="ID-693e7941-c239-406f-8870-566cbb5c9209"></a>function get-pid-from-postmodern ()</h3>
 <div class="outline-text-3" id="text-b0afcff9-dfa9-466a-a3a2-06b189eac23a">
 <p>
 → integer
@@ -1729,8 +1734,8 @@ postmodern connection parameters.
 </div>
 </div>
 
-<div id="outline-container-org0ab03b0" class="outline-3">
-<h3 id="10b17274-a4d8-4805-adbe-b7386fe28cfb"><a id="org0ab03b0"></a><a id="ID-09b6f356-9e36-4de6-8c74-58331bfea8de"></a>function cancel-backend (pid)</h3>
+<div id="outline-container-org5d083d4" class="outline-3">
+<h3 id="10b17274-a4d8-4805-adbe-b7386fe28cfb"><a id="org5d083d4"></a><a id="ID-09b6f356-9e36-4de6-8c74-58331bfea8de"></a>function cancel-backend (pid)</h3>
 <div class="outline-text-3" id="text-10b17274-a4d8-4805-adbe-b7386fe28cfb">
 <p>
 Polite way of terminating a query at the database (as opposed to calling
@@ -1740,8 +1745,8 @@ always work.
 </div>
 </div>
 
-<div id="outline-container-org7af3cb6" class="outline-3">
-<h3 id="203185f5-030c-48e7-8767-e765ac96f8cb"><a id="org7af3cb6"></a><a id="ID-d8baac2e-115a-485d-b212-02ae397e5117"></a>function terminate-backend (pid)</h3>
+<div id="outline-container-org7933733" class="outline-3">
+<h3 id="203185f5-030c-48e7-8767-e765ac96f8cb"><a id="org7933733"></a><a id="ID-d8baac2e-115a-485d-b212-02ae397e5117"></a>function terminate-backend (pid)</h3>
 <div class="outline-text-3" id="text-203185f5-030c-48e7-8767-e765ac96f8cb">
 <p>
 Less polite way of terminating at the database (as opposed to calling
@@ -1750,13 +1755,13 @@ close-database). Faster than (cancel-backend pid) and more reliable.
 </div>
 </div>
 </div>
-<div id="outline-container-org883e98c" class="outline-2">
-<h2 id="database-management"><a id="org883e98c"></a>Database Management</h2>
+<div id="outline-container-org37887ef" class="outline-2">
+<h2 id="database-management"><a id="org37887ef"></a>Database Management</h2>
 <div class="outline-text-2" id="text-database-management">
 </div>
 
-<div id="outline-container-orgd1476b6" class="outline-3">
-<h3 id="c3da07c5-73e2-407c-a4cf-155b3ae416b2"><a id="orgd1476b6"></a>function create-database (database-name &amp;key (encoding "UTF8") (connection-limit -1) owner limit-public-access comment collation template)</h3>
+<div id="outline-container-org4bab3e5" class="outline-3">
+<h3 id="c3da07c5-73e2-407c-a4cf-155b3ae416b2"><a id="org4bab3e5"></a>function create-database (database-name &amp;key (encoding "UTF8") (connection-limit -1) owner limit-public-access comment collation template)</h3>
 <div class="outline-text-3" id="text-c3da07c5-73e2-407c-a4cf-155b3ae416b2">
 <p>
 Creates a basic database. Besides the obvious database-name parameter, you
@@ -1778,8 +1783,8 @@ specific data.
 </div>
 </div>
 </div>
-<div id="outline-container-org4494822" class="outline-3">
-<h3 id="database-management"><a id="org4494822"></a>function drop-database (database)</h3>
+<div id="outline-container-org20a99e8" class="outline-3">
+<h3 id="database-management"><a id="org20a99e8"></a>function drop-database (database)</h3>
 <div class="outline-text-3" id="text-database-management">
 <p>
 Drop the specified database. The database parameter can be a string or a
@@ -1790,8 +1795,8 @@ and there cannot be any current connections to the database.
 </div>
 </div>
 </div>
-<div id="outline-container-orgfd63992" class="outline-2">
-<h2 id="daos"><a id="orgfd63992"></a><a id="ID-8e7cee8c-f2b9-4569-bf65-e8f3d2f9e31b"></a>Database access objects</h2>
+<div id="outline-container-orgffca37f" class="outline-2">
+<h2 id="daos"><a id="orgffca37f"></a><a id="ID-8e7cee8c-f2b9-4569-bf65-e8f3d2f9e31b"></a>Database access objects</h2>
 <div class="outline-text-2" id="text-daos">
 <p>
 Postmodern contains a simple system for defining CLOS classes that represent
@@ -1802,8 +1807,8 @@ this.
 </p>
 </div>
 
-<div id="outline-container-org7df4cd5" class="outline-3">
-<h3 id="d1d4b5c3-8c21-478e-8ac1-404e4ffdbec5"><a id="org7df4cd5"></a><a id="ID-bbf28a59-551a-4805-b2f6-b2d0bd8feaf3"></a>metaclass dao-class</h3>
+<div id="outline-container-org9f63dd4" class="outline-3">
+<h3 id="d1d4b5c3-8c21-478e-8ac1-404e4ffdbec5"><a id="org9f63dd4"></a><a id="ID-bbf28a59-551a-4805-b2f6-b2d0bd8feaf3"></a>metaclass dao-class</h3>
 <div class="outline-text-3" id="text-d1d4b5c3-8c21-478e-8ac1-404e4ffdbec5">
 <p>
 You can work directly with the database or you can use a simple
@@ -1987,8 +1992,8 @@ slot like this:
 </div>
 </div>
 
-<div id="outline-container-orgdeb3eaf" class="outline-3">
-<h3 id="9027b960-0a1a-4b64-a621-d1d4ab2906f0"><a id="orgdeb3eaf"></a>Out of Sync Dao Objects</h3>
+<div id="outline-container-org148010c" class="outline-3">
+<h3 id="9027b960-0a1a-4b64-a621-d1d4ab2906f0"><a id="org148010c"></a>Out of Sync Dao Objects</h3>
 <div class="outline-text-3" id="text-9027b960-0a1a-4b64-a621-d1d4ab2906f0">
 <p>
 What Happens when dao classes are out of sync with the database table?
@@ -2231,8 +2236,8 @@ Postgresql rejected the attempted insert with an undefined column error.
 </p>
 </div>
 </div>
-<div id="outline-container-org9d9ca98" class="outline-3">
-<h3 id="b12ed2b8-fc3f-4d3a-ba2a-3c9484d770dc"><a id="org9d9ca98"></a><a id="ID-959682ab-ee0f-4afe-8cf3-38bb5f6de672"></a>method dao-keys (class)</h3>
+<div id="outline-container-orgfd7eb47" class="outline-3">
+<h3 id="b12ed2b8-fc3f-4d3a-ba2a-3c9484d770dc"><a id="orgfd7eb47"></a><a id="ID-959682ab-ee0f-4afe-8cf3-38bb5f6de672"></a>method dao-keys (class)</h3>
 <div class="outline-text-3" id="text-b12ed2b8-fc3f-4d3a-ba2a-3c9484d770dc">
 <p>
 → list
@@ -2256,8 +2261,8 @@ The class must be quoted.
 </div>
 </div>
 
-<div id="outline-container-orgc8b4a76" class="outline-3">
-<h3 id="34196ad8-c657-4fd0-a475-e2f0b81ff86c"><a id="orgc8b4a76"></a><a id="ID-4fa1fc88-dfb8-433f-90dc-c88e8908a5a8"></a>method dao-keys (dao)</h3>
+<div id="outline-container-orgc7b063b" class="outline-3">
+<h3 id="34196ad8-c657-4fd0-a475-e2f0b81ff86c"><a id="orgc7b063b"></a><a id="ID-4fa1fc88-dfb8-433f-90dc-c88e8908a5a8"></a>method dao-keys (dao)</h3>
 <div class="outline-text-3" id="text-34196ad8-c657-4fd0-a475-e2f0b81ff86c">
 <p>
 → list
@@ -2278,9 +2283,9 @@ been defined. You can provide a quoted class-name or an instance of a dao.
 </div>
 </div>
 
-<div id="outline-container-org055dcc7" class="outline-3">
-<h3 id="org055dcc7">method find-primary-key-column</h3>
-<div class="outline-text-3" id="text-org055dcc7">
+<div id="outline-container-org36b2d69" class="outline-3">
+<h3 id="org36b2d69">method find-primary-key-column</h3>
+<div class="outline-text-3" id="text-org36b2d69">
 <p>
 → symbol
 </p>
@@ -2292,8 +2297,8 @@ that has bound either col-identity or col-primary-key.
 </div>
 </div>
 
-<div id="outline-container-org273bb85" class="outline-3">
-<h3 id="d5835157-a4ba-4bf0-abbd-214b5a90bc80"><a id="org273bb85"></a><a id="ID-4a55236e-edfb-4f07-a237-fae3453fc99d"></a>method dao-exists-p (dao)</h3>
+<div id="outline-container-orgf755100" class="outline-3">
+<h3 id="d5835157-a4ba-4bf0-abbd-214b5a90bc80"><a id="orgf755100"></a><a id="ID-4a55236e-edfb-4f07-a237-fae3453fc99d"></a>method dao-exists-p (dao)</h3>
 <div class="outline-text-3" id="text-d5835157-a4ba-4bf0-abbd-214b5a90bc80">
 <p>
 → boolean
@@ -2307,8 +2312,8 @@ unbound.
 </div>
 </div>
 
-<div id="outline-container-orgf6a464d" class="outline-3">
-<h3 id="24bce212-b7c3-4526-a869-92c0218f187d"><a id="orgf6a464d"></a><a id="ID-a812726c-52ea-4321-9bae-f9646bccc128"></a>method make-dao (type &amp;rest args &amp;key &amp;allow-other-keys)</h3>
+<div id="outline-container-orgf507dff" class="outline-3">
+<h3 id="24bce212-b7c3-4526-a869-92c0218f187d"><a id="orgf507dff"></a><a id="ID-a812726c-52ea-4321-9bae-f9646bccc128"></a>method make-dao (type &amp;rest args &amp;key &amp;allow-other-keys)</h3>
 <div class="outline-text-3" id="text-24bce212-b7c3-4526-a869-92c0218f187d">
 <p>
 → dao
@@ -2321,9 +2326,9 @@ insert it into the database, returning the created dao.
 </div>
 </div>
 
-<div id="outline-container-org5d65e55" class="outline-3">
-<h3 id="org5d65e55">method fetch-defaults (dao)</h3>
-<div class="outline-text-3" id="text-org5d65e55">
+<div id="outline-container-orgfd8e143" class="outline-3">
+<h3 id="orgfd8e143">method fetch-defaults (dao)</h3>
+<div class="outline-text-3" id="text-orgfd8e143">
 <p>
 → dao if there were unbound slots with default values, otherwise nil
 </p>
@@ -2341,9 +2346,9 @@ and bind the unbound slots which have default values. E.g.
 </div>
 </div>
 </div>
-<div id="outline-container-orgc0460c2" class="outline-3">
-<h3 id="orgc0460c2">method find-primary-key-column (class)</h3>
-<div class="outline-text-3" id="text-orgc0460c2">
+<div id="outline-container-org0347175" class="outline-3">
+<h3 id="org0347175">method find-primary-key-column (class)</h3>
+<div class="outline-text-3" id="text-org0347175">
 <p>
 → symbol
 </p>
@@ -2356,8 +2361,8 @@ Returns a symbol.
 </div>
 </div>
 
-<div id="outline-container-orga2b28d2" class="outline-3">
-<h3 id="f7351c36-cb79-43a2-8a5b-5f8aac8ea2d9"><a id="orga2b28d2"></a><a id="ID-645a03ec-739a-4ee5-b83d-dcbe43ef009a"></a>macro define-dao-finalization (((dao-name class) &amp;rest keyword-args) &amp;body body)</h3>
+<div id="outline-container-org184d3a0" class="outline-3">
+<h3 id="f7351c36-cb79-43a2-8a5b-5f8aac8ea2d9"><a id="org184d3a0"></a><a id="ID-645a03ec-739a-4ee5-b83d-dcbe43ef009a"></a>macro define-dao-finalization (((dao-name class) &amp;rest keyword-args) &amp;body body)</h3>
 <div class="outline-text-3" id="text-f7351c36-cb79-43a2-8a5b-5f8aac8ea2d9">
 <p>
 Create an :around-method for make-dao. The body is executed in a lexical
@@ -2369,8 +2374,8 @@ type serial, which are unknown before insert-dao.
 </div>
 </div>
 
-<div id="outline-container-org498695b" class="outline-3">
-<h3 id="73e62fab-5bfa-4986-b8c4-992e4d0a134b"><a id="org498695b"></a><a id="ID-6dd7dd12-0f9a-4c47-94ee-43f0886df956"></a>method get-dao (type &amp;rest keys)</h3>
+<div id="outline-container-orgcdbd97a" class="outline-3">
+<h3 id="73e62fab-5bfa-4986-b8c4-992e4d0a134b"><a id="orgcdbd97a"></a><a id="ID-6dd7dd12-0f9a-4c47-94ee-43f0886df956"></a>method get-dao (type &amp;rest keys)</h3>
 <div class="outline-text-3" id="text-73e62fab-5bfa-4986-b8c4-992e4d0a134b">
 <p>
 → dao
@@ -2408,8 +2413,8 @@ set <b>ignore-unknown-columns</b> to t.
 </div>
 </div>
 
-<div id="outline-container-orgcf96436" class="outline-3">
-<h3 id="cd11fa85-5019-4b94-a24c-d0857d633bd2"><a id="orgcf96436"></a><a id="ID-8b3533e5-2399-47e4-8fac-5345ec44c878"></a>macro select-dao (type &amp;optional (test t) &amp;rest sort)</h3>
+<div id="outline-container-org23a752a" class="outline-3">
+<h3 id="cd11fa85-5019-4b94-a24c-d0857d633bd2"><a id="org23a752a"></a><a id="ID-8b3533e5-2399-47e4-8fac-5345ec44c878"></a>macro select-dao (type &amp;optional (test t) &amp;rest sort)</h3>
 <div class="outline-text-3" id="text-cd11fa85-5019-4b94-a24c-d0857d633bd2">
 <p>
 → list
@@ -2461,8 +2466,8 @@ If for some reason, you wanted the list in reverse alphabetical order, then:
 </div>
 </div>
 </div>
-<div id="outline-container-org60a187d" class="outline-3">
-<h3 id="6273d302-4199-44a0-aa18-3d8f91affd84"><a id="org60a187d"></a><a id="ID-b1a7accd-8c3e-429b-a8c8-35f2283855c4"></a>macro do-select-dao (((type type-var) &amp;optional (test t) &amp;rest sort) &amp;body body)</h3>
+<div id="outline-container-orgaf30222" class="outline-3">
+<h3 id="6273d302-4199-44a0-aa18-3d8f91affd84"><a id="orgaf30222"></a><a id="ID-b1a7accd-8c3e-429b-a8c8-35f2283855c4"></a>macro do-select-dao (((type type-var) &amp;optional (test t) &amp;rest sort) &amp;body body)</h3>
 <div class="outline-text-3" id="text-6273d302-4199-44a0-aa18-3d8f91affd84">
 <p>
 Like select-dao, but iterates over the results rather than returning them.
@@ -2481,8 +2486,8 @@ Example:
 </div>
 </div>
 
-<div id="outline-container-orga3cf571" class="outline-3">
-<h3 id="6e5766fb-14dd-4f1e-a68a-fd14d781ac9e"><a id="orga3cf571"></a><a id="ID-134f9dcb-0784-461b-a38c-85c14d850910"></a>macro query-dao (type query &amp;rest args)</h3>
+<div id="outline-container-org036cc2b" class="outline-3">
+<h3 id="6e5766fb-14dd-4f1e-a68a-fd14d781ac9e"><a id="org036cc2b"></a><a id="ID-134f9dcb-0784-461b-a38c-85c14d850910"></a>macro query-dao (type query &amp;rest args)</h3>
 <div class="outline-text-3" id="text-6e5766fb-14dd-4f1e-a68a-fd14d781ac9e">
 <p>
 → list
@@ -2498,8 +2503,8 @@ class, or be bound through with-column-writers.
 </div>
 </div>
 
-<div id="outline-container-orgb8a49b7" class="outline-3">
-<h3 id="702edc9e-ef43-4df1-9e99-dac6047bdecc"><a id="orgb8a49b7"></a><a id="ID-8f5738c2-a11e-4c1b-91bc-b52f62502fbd"></a>function do-query-dao (((type type-var) query &amp;rest args) &amp;body body)</h3>
+<div id="outline-container-org4ed16da" class="outline-3">
+<h3 id="702edc9e-ef43-4df1-9e99-dac6047bdecc"><a id="org4ed16da"></a><a id="ID-8f5738c2-a11e-4c1b-91bc-b52f62502fbd"></a>function do-query-dao (((type type-var) query &amp;rest args) &amp;body body)</h3>
 <div class="outline-text-3" id="text-702edc9e-ef43-4df1-9e99-dac6047bdecc">
 <p>
 → list
@@ -2521,8 +2526,8 @@ Example:
 </div>
 </div>
 
-<div id="outline-container-orgb5a194c" class="outline-3">
-<h3 id="4a1219dc-d0bc-4fb7-81c9-cb734cb051cc"><a id="orgb5a194c"></a><a id="ID-a6627d60-61f4-4a9b-86e7-5c1454a4e487"></a>variable <b>ignore-unknown-columns</b></h3>
+<div id="outline-container-org57cb7b2" class="outline-3">
+<h3 id="4a1219dc-d0bc-4fb7-81c9-cb734cb051cc"><a id="org57cb7b2"></a><a id="ID-a6627d60-61f4-4a9b-86e7-5c1454a4e487"></a>variable <b>ignore-unknown-columns</b></h3>
 <div class="outline-text-3" id="text-4a1219dc-d0bc-4fb7-81c9-cb734cb051cc">
 <p>
 Normally, when get-dao, select-dao, or query-dao finds a column in the database
@@ -2532,8 +2537,8 @@ non-NIL will cause it to simply ignore the unknown column.
 </div>
 </div>
 
-<div id="outline-container-org81d8f1c" class="outline-3">
-<h3 id="4a83ef48-a40a-423c-a97c-3d6743ce940c"><a id="org81d8f1c"></a><a id="ID-6e534cce-6d6a-4710-875e-bf53aadb2045"></a>method insert-dao (dao)</h3>
+<div id="outline-container-orgefe8532" class="outline-3">
+<h3 id="4a83ef48-a40a-423c-a97c-3d6743ce940c"><a id="orgefe8532"></a><a id="ID-6e534cce-6d6a-4710-875e-bf53aadb2045"></a>method insert-dao (dao)</h3>
 <div class="outline-text-3" id="text-4a83ef48-a40a-423c-a97c-3d6743ce940c">
 <p>
 → dao
@@ -2548,8 +2553,8 @@ feature only works on PostgreSQL 8.2 and up.)
 </div>
 </div>
 
-<div id="outline-container-orgd5a9c29" class="outline-3">
-<h3 id="08306ea2-4027-40e8-a9df-8bb2fbc63b3e"><a id="orgd5a9c29"></a><a id="ID-faf45a30-c384-461f-9367-9e7c40c466a5"></a>method update-dao (dao)</h3>
+<div id="outline-container-org8db7809" class="outline-3">
+<h3 id="08306ea2-4027-40e8-a9df-8bb2fbc63b3e"><a id="org8db7809"></a><a id="ID-faf45a30-c384-461f-9367-9e7c40c466a5"></a>method update-dao (dao)</h3>
 <div class="outline-text-3" id="text-08306ea2-4027-40e8-a9df-8bb2fbc63b3e">
 <p>
 → dao
@@ -2563,8 +2568,8 @@ columns. Raises an error when no row matching the dao exists.
 </div>
 </div>
 
-<div id="outline-container-org0fda93c" class="outline-3">
-<h3 id="4697a909-970c-492b-b1d6-7e05895f8882"><a id="org0fda93c"></a><a id="ID-a61016ef-bf72-4d7f-804f-c4396098833b"></a>function save-dao (dao)</h3>
+<div id="outline-container-org9c8f4f2" class="outline-3">
+<h3 id="4697a909-970c-492b-b1d6-7e05895f8882"><a id="org9c8f4f2"></a><a id="ID-a61016ef-bf72-4d7f-804f-c4396098833b"></a>function save-dao (dao)</h3>
 <div class="outline-text-3" id="text-4697a909-970c-492b-b1d6-7e05895f8882">
 <p>
 → boolean
@@ -2596,8 +2601,8 @@ See also: upsert-dao.
 </div>
 </div>
 
-<div id="outline-container-org6a289d6" class="outline-3">
-<h3 id="62a09a7f-8583-404d-b9f3-28b1eb416b0f"><a id="org6a289d6"></a><a id="ID-0162b077-c274-48b0-9d5d-655de2482012"></a>function save-dao/transaction (dao)</h3>
+<div id="outline-container-org59c8bd9" class="outline-3">
+<h3 id="62a09a7f-8583-404d-b9f3-28b1eb416b0f"><a id="org59c8bd9"></a><a id="ID-0162b077-c274-48b0-9d5d-655de2482012"></a>function save-dao/transaction (dao)</h3>
 <div class="outline-text-3" id="text-62a09a7f-8583-404d-b9f3-28b1eb416b0f">
 <p>
 → boolean
@@ -2628,8 +2633,8 @@ See also: upsert-dao.
 </div>
 </div>
 
-<div id="outline-container-org8e7e2a6" class="outline-3">
-<h3 id="8eeaf5dd-a802-4ba0-9983-dc153ffc1dae"><a id="org8e7e2a6"></a><a id="ID-ab8ea79a-1761-402c-a1bc-3a5c4fd53c24"></a>method upsert-dao (dao)</h3>
+<div id="outline-container-org3c5c61f" class="outline-3">
+<h3 id="8eeaf5dd-a802-4ba0-9983-dc153ffc1dae"><a id="org3c5c61f"></a><a id="ID-ab8ea79a-1761-402c-a1bc-3a5c4fd53c24"></a>method upsert-dao (dao)</h3>
 <div class="outline-text-3" id="text-8eeaf5dd-a802-4ba0-9983-dc153ffc1dae">
 <p>
 → dao
@@ -2685,8 +2690,8 @@ there is no existing object to oupdate, then you insert a new object.
 </div>
 </div>
 
-<div id="outline-container-orgd869184" class="outline-3">
-<h3 id="b135af85-b194-4a5c-9c2d-be87f6827877"><a id="orgd869184"></a><a id="ID-f3371904-cd84-4392-a301-0f910bcf1b90"></a>method delete-dao (dao)</h3>
+<div id="outline-container-orgdabc546" class="outline-3">
+<h3 id="b135af85-b194-4a5c-9c2d-be87f6827877"><a id="orgdabc546"></a><a id="ID-f3371904-cd84-4392-a301-0f910bcf1b90"></a>method delete-dao (dao)</h3>
 <div class="outline-text-3" id="text-b135af85-b194-4a5c-9c2d-be87f6827877">
 <p>
 Delete the given dao from the database.
@@ -2694,8 +2699,8 @@ Delete the given dao from the database.
 </div>
 </div>
 
-<div id="outline-container-orge125ba7" class="outline-3">
-<h3 id="436e6c77-8550-4462-a956-3affe6d0970c"><a id="orge125ba7"></a><a id="ID-718c03fe-5c70-43c1-a986-bc361d1e2ee6"></a>function dao-table-name (class)</h3>
+<div id="outline-container-orga44403f" class="outline-3">
+<h3 id="436e6c77-8550-4462-a956-3affe6d0970c"><a id="orga44403f"></a><a id="ID-718c03fe-5c70-43c1-a986-bc361d1e2ee6"></a>function dao-table-name (class)</h3>
 <div class="outline-text-3" id="text-436e6c77-8550-4462-a956-3affe6d0970c">
 <p>
 → string
@@ -2708,8 +2713,8 @@ such a class).
 </div>
 </div>
 
-<div id="outline-container-org1a7fc03" class="outline-3">
-<h3 id="289d7bc0-b4a3-45e3-991b-14b9cfbdcf68"><a id="org1a7fc03"></a><a id="ID-e796fdb5-a8d9-4399-893a-6783dd925e78"></a>function dao-table-definition (class)</h3>
+<div id="outline-container-org7da6f3c" class="outline-3">
+<h3 id="289d7bc0-b4a3-45e3-991b-14b9cfbdcf68"><a id="org7da6f3c"></a><a id="ID-e796fdb5-a8d9-4399-893a-6783dd925e78"></a>function dao-table-definition (class)</h3>
 <div class="outline-text-3" id="text-289d7bc0-b4a3-45e3-991b-14b9cfbdcf68">
 <p>
 → string
@@ -2724,8 +2729,8 @@ queries to add them, in which case look to s-sql's create-table function.
 </div>
 </div>
 
-<div id="outline-container-orgf2cd8b3" class="outline-3">
-<h3 id="d8aa15a1-7dfc-47b3-ae14-70626c33bcc3"><a id="orgf2cd8b3"></a><a id="ID-52b95f7c-f8f0-4e53-8e60-622746f18e16"></a>macro with-column-writers ((&amp;rest writers) &amp;body body)</h3>
+<div id="outline-container-org68487d4" class="outline-3">
+<h3 id="d8aa15a1-7dfc-47b3-ae14-70626c33bcc3"><a id="org68487d4"></a><a id="ID-52b95f7c-f8f0-4e53-8e60-622746f18e16"></a>macro with-column-writers ((&amp;rest writers) &amp;body body)</h3>
 <div class="outline-text-3" id="text-d8aa15a1-7dfc-47b3-ae14-70626c33bcc3">
 <p>
 Provides control over the way get-dao, select-dao, and query-dao read values
@@ -2749,8 +2754,8 @@ the objects, and immediately store it in the new instances.
 </div>
 </div>
 
-<div id="outline-container-orgf124b32" class="outline-2">
-<h2 id="table-definition"><a id="orgf124b32"></a><a id="ID-1c0a254a-4a0e-4012-b519-8fe8cbf9ae02"></a>Table definition and creation</h2>
+<div id="outline-container-orgd53e536" class="outline-2">
+<h2 id="table-definition"><a id="orgd53e536"></a><a id="ID-1c0a254a-4a0e-4012-b519-8fe8cbf9ae02"></a>Table definition and creation</h2>
 <div class="outline-text-2" id="text-table-definition">
 <p>
 It can be useful to have the SQL statements needed to build an application's
@@ -2761,8 +2766,8 @@ in table definitions.
 </p>
 </div>
 
-<div id="outline-container-org50cc112" class="outline-3">
-<h3 id="16d26863-ae01-49f3-9350-8ea2d5ca363c"><a id="org50cc112"></a><a id="ID-39e40910-e25a-4db4-bd0a-b4b6d1a75630"></a>macro deftable (name &amp;body definition)</h3>
+<div id="outline-container-org0f25fb2" class="outline-3">
+<h3 id="16d26863-ae01-49f3-9350-8ea2d5ca363c"><a id="org0f25fb2"></a><a id="ID-39e40910-e25a-4db4-bd0a-b4b6d1a75630"></a>macro deftable (name &amp;body definition)</h3>
 <div class="outline-text-3" id="text-16d26863-ae01-49f3-9350-8ea2d5ca363c">
 <p>
 Define a table. name can be either a symbol or a (symbol string) list. In the
@@ -2776,8 +2781,8 @@ generally want to create your table first and then define indices on it.
 </div>
 </div>
 
-<div id="outline-container-org49f4e00" class="outline-3">
-<h3 id="d7e145ff-9666-43eb-813d-78a87116532e"><a id="org49f4e00"></a><a id="ID-3e565b16-153c-4281-8f17-3653e7a9dc5d"></a>variable <b>table-name</b></h3>
+<div id="outline-container-org1158e15" class="outline-3">
+<h3 id="d7e145ff-9666-43eb-813d-78a87116532e"><a id="org1158e15"></a><a id="ID-3e565b16-153c-4281-8f17-3653e7a9dc5d"></a>variable <b>table-name</b></h3>
 <div class="outline-text-3" id="text-d7e145ff-9666-43eb-813d-78a87116532e">
 <p>
 Used inside deftable to find the name of the table being defined.
@@ -2785,8 +2790,8 @@ Used inside deftable to find the name of the table being defined.
 </div>
 </div>
 
-<div id="outline-container-orge49c488" class="outline-3">
-<h3 id="00432de6-10f6-4e52-85d9-6c622e6c37ec"><a id="orge49c488"></a><a id="ID-551359a0-8d5b-4d4f-932d-df8759105ee1"></a>variable <b>table-symbol</b></h3>
+<div id="outline-container-org3baf43a" class="outline-3">
+<h3 id="00432de6-10f6-4e52-85d9-6c622e6c37ec"><a id="org3baf43a"></a><a id="ID-551359a0-8d5b-4d4f-932d-df8759105ee1"></a>variable <b>table-symbol</b></h3>
 <div class="outline-text-3" id="text-00432de6-10f6-4e52-85d9-6c622e6c37ec">
 <p>
 Used inside deftable to find the symbol naming the table being defined.
@@ -2794,8 +2799,8 @@ Used inside deftable to find the symbol naming the table being defined.
 </div>
 </div>
 
-<div id="outline-container-orgfd0fac3" class="outline-3">
-<h3 id="01902b36-20f9-4644-9347-fa6cbead2334"><a id="orgfd0fac3"></a><a id="ID-eb1680a7-2a82-4e6a-b31b-aeea22bf7362"></a>function !dao-def ()</h3>
+<div id="outline-container-orgef9c5b7" class="outline-3">
+<h3 id="01902b36-20f9-4644-9347-fa6cbead2334"><a id="orgef9c5b7"></a><a id="ID-eb1680a7-2a82-4e6a-b31b-aeea22bf7362"></a>function !dao-def ()</h3>
 <div class="outline-text-3" id="text-01902b36-20f9-4644-9347-fa6cbead2334">
 <p>
 Should only be used inside a deftable form. Define this table using the
@@ -2805,8 +2810,8 @@ on <b>table-symbol</b> to the definition.
 </div>
 </div>
 
-<div id="outline-container-org842b73d" class="outline-3">
-<h3 id="b0e0a7d4-1c23-4ba2-88a4-dac55a3584c8"><a id="org842b73d"></a><a id="ID-5ceae010-3712-400a-9c8c-0616b8406390"></a>function !index (&amp;rest columns), !unique-index (&amp;rest columns)</h3>
+<div id="outline-container-org2f0bcfc" class="outline-3">
+<h3 id="b0e0a7d4-1c23-4ba2-88a4-dac55a3584c8"><a id="org2f0bcfc"></a><a id="ID-5ceae010-3712-400a-9c8c-0616b8406390"></a>function !index (&amp;rest columns), !unique-index (&amp;rest columns)</h3>
 <div class="outline-text-3" id="text-b0e0a7d4-1c23-4ba2-88a4-dac55a3584c8">
 <p>
 Used inside a deftable form. Define an index on the table being defined. The
@@ -2815,8 +2820,8 @@ columns can be given as symbols or strings.
 </div>
 </div>
 
-<div id="outline-container-org0870ed5" class="outline-3">
-<h3 id="eba9236f-a947-4194-8337-4d0f828f5542"><a id="org0870ed5"></a><a id="ID-1378528c-3e7a-452b-8775-b3d84d897ebd"></a>function !foreign (target fields &amp;rest target-fields/on-delete/on-update/deferrable/initially-deferred)</h3>
+<div id="outline-container-orgc16e3bb" class="outline-3">
+<h3 id="eba9236f-a947-4194-8337-4d0f828f5542"><a id="orgc16e3bb"></a><a id="ID-1378528c-3e7a-452b-8775-b3d84d897ebd"></a>function !foreign (target fields &amp;rest target-fields/on-delete/on-update/deferrable/initially-deferred)</h3>
 <div class="outline-text-3" id="text-eba9236f-a947-4194-8337-4d0f828f5542">
 <p>
 Used insde a deftable form. Add a foreign key to the table being defined.
@@ -2839,8 +2844,8 @@ that they can be specified even when target-columns is not given.
 </div>
 </div>
 
-<div id="outline-container-org6dafb22" class="outline-3">
-<h3 id="5ccbe683-8a43-4373-9371-529a3007bd40"><a id="org6dafb22"></a><a id="ID-c4631db6-9994-40df-97b7-150df71bb121"></a>function !unique (target-fields &amp;key deferrable initially-deferred)</h3>
+<div id="outline-container-org07babde" class="outline-3">
+<h3 id="5ccbe683-8a43-4373-9371-529a3007bd40"><a id="org07babde"></a><a id="ID-c4631db6-9994-40df-97b7-150df71bb121"></a>function !unique (target-fields &amp;key deferrable initially-deferred)</h3>
 <div class="outline-text-3" id="text-5ccbe683-8a43-4373-9371-529a3007bd40">
 <p>
 Constrains one or more columns to only contain unique (combinations of) values,
@@ -2849,8 +2854,8 @@ with deferrable and initially-deferred defined as in !foreign
 </div>
 </div>
 
-<div id="outline-container-org03430d5" class="outline-3">
-<h3 id="e1834b87-e348-44ab-9361-0ad1021d1163"><a id="org03430d5"></a><a id="ID-333d4860-6cfe-4009-80f8-a480174d64e1"></a>function create-table (symbol)</h3>
+<div id="outline-container-org51520ff" class="outline-3">
+<h3 id="e1834b87-e348-44ab-9361-0ad1021d1163"><a id="org51520ff"></a><a id="ID-333d4860-6cfe-4009-80f8-a480174d64e1"></a>function create-table (symbol)</h3>
 <div class="outline-text-3" id="text-e1834b87-e348-44ab-9361-0ad1021d1163">
 <p>
 Takes the name of a dao-class and creates the table identified by symbol by
@@ -2859,8 +2864,8 @@ executing all forms in its definition as found in the <b>tables</b> list.
 </div>
 </div>
 
-<div id="outline-container-org57ef4fd" class="outline-3">
-<h3 id="eba2d105-d5c7-49c0-bfed-828e4ff53b09"><a id="org57ef4fd"></a><a id="ID-7477cdc4-59bf-47fb-9b60-25ee9c38eb66"></a>function create-all-tables ()</h3>
+<div id="outline-container-org29e9565" class="outline-3">
+<h3 id="eba2d105-d5c7-49c0-bfed-828e4ff53b09"><a id="org29e9565"></a><a id="ID-7477cdc4-59bf-47fb-9b60-25ee9c38eb66"></a>function create-all-tables ()</h3>
 <div class="outline-text-3" id="text-eba2d105-d5c7-49c0-bfed-828e4ff53b09">
 <p>
 Creates all defined tables.
@@ -2868,8 +2873,8 @@ Creates all defined tables.
 </div>
 </div>
 
-<div id="outline-container-org6bfb8e5" class="outline-3">
-<h3 id="a49e80c8-3204-4803-b263-a0cac063ea12"><a id="org6bfb8e5"></a><a id="ID-8e36190a-a3a4-4e66-8df4-0a6b6b74f617"></a>function create-package-tables (package)</h3>
+<div id="outline-container-org5de6fab" class="outline-3">
+<h3 id="a49e80c8-3204-4803-b263-a0cac063ea12"><a id="org5de6fab"></a><a id="ID-8e36190a-a3a4-4e66-8df4-0a6b6b74f617"></a>function create-package-tables (package)</h3>
 <div class="outline-text-3" id="text-a49e80c8-3204-4803-b263-a0cac063ea12">
 <p>
 Creates all tables identified by symbols interned in the given package.
@@ -2877,8 +2882,8 @@ Creates all tables identified by symbols interned in the given package.
 </div>
 </div>
 
-<div id="outline-container-org9c256aa" class="outline-3">
-<h3 id="a932fe23-c677-4bb7-8df8-6dd2adf2beff"><a id="org9c256aa"></a><a id="ID-25924943-75d9-4612-b2a3-dc94f292c2a5"></a>variables <b>table-name</b>, <b>table-symbol</b></h3>
+<div id="outline-container-org6d8edca" class="outline-3">
+<h3 id="a932fe23-c677-4bb7-8df8-6dd2adf2beff"><a id="org6d8edca"></a><a id="ID-25924943-75d9-4612-b2a3-dc94f292c2a5"></a>variables <b>table-name</b>, <b>table-symbol</b></h3>
 <div class="outline-text-3" id="text-a932fe23-c677-4bb7-8df8-6dd2adf2beff">
 <p>
 Used inside deftable to find the name of the table being defined.
@@ -2890,8 +2895,8 @@ Used inside deftable to find the symbol naming the table being defined.
 </div>
 </div>
 
-<div id="outline-container-orgbdb7357" class="outline-3">
-<h3 id="f6879b3f-12dc-44a4-b92e-03dbedd0b1cd"><a id="orgbdb7357"></a><a id="ID-0427ecce-416e-4266-a5c7-90e58e22e0b7"></a>function drop-table (table-name &amp;key if-exists cascade)</h3>
+<div id="outline-container-org43dff24" class="outline-3">
+<h3 id="f6879b3f-12dc-44a4-b92e-03dbedd0b1cd"><a id="org43dff24"></a><a id="ID-0427ecce-416e-4266-a5c7-90e58e22e0b7"></a>function drop-table (table-name &amp;key if-exists cascade)</h3>
 <div class="outline-text-3" id="text-f6879b3f-12dc-44a4-b92e-03dbedd0b1cd">
 <p>
 If a table exists, drop a table. Available additional key parameters
@@ -2900,8 +2905,8 @@ are :if-exists and :cascade.
 </div>
 </div>
 
-<div id="outline-container-orgea79f88" class="outline-3">
-<h3 id="9b329d91-58c8-4153-950f-4e58b71455dc"><a id="orgea79f88"></a><a id="ID-e76fc507-bfa6-481b-b429-128ed0ede9e3"></a>Introduction to Multi-table dao class objects</h3>
+<div id="outline-container-org4fc480f" class="outline-3">
+<h3 id="9b329d91-58c8-4153-950f-4e58b71455dc"><a id="org4fc480f"></a><a id="ID-e76fc507-bfa6-481b-b429-128ed0ede9e3"></a>Introduction to Multi-table dao class objects</h3>
 <div class="outline-text-3" id="text-9b329d91-58c8-4153-950f-4e58b71455dc">
 <p>
 Postmodern's dao-class objects are not required to be tied down to a specific
@@ -2980,8 +2985,8 @@ be the primary key for region-d).
 </p>
 </div>
 
-<div id="outline-container-org74695a5" class="outline-4">
-<h4 id="da13ef47-1c9c-4d8e-be07-26a2ffa25fdc"><a id="org74695a5"></a><a id="ID-2758d7e8-ae00-4d01-8c8b-c7ff3a827047"></a>Simple Version</h4>
+<div id="outline-container-orgd30846f" class="outline-4">
+<h4 id="da13ef47-1c9c-4d8e-be07-26a2ffa25fdc"><a id="orgd30846f"></a><a id="ID-2758d7e8-ae00-4d01-8c8b-c7ff3a827047"></a>Simple Version</h4>
 <div class="outline-text-4" id="text-da13ef47-1c9c-4d8e-be07-26a2ffa25fdc">
 <p>
 Lets start by declaring our classes and we will use the deftable make to create
@@ -3066,8 +3071,8 @@ The country-d lambda looks like this:
 </div>
 </div>
 </div>
-<div id="outline-container-org37b0ca8" class="outline-4">
-<h4 id="d8cb7f38-7ef3-4ec2-85a2-b4df7b2c4997"><a id="org37b0ca8"></a><a id="ID-933f58e1-a4da-4e7f-a227-0fac621e14b0"></a>Less Simple Version</h4>
+<div id="outline-container-orgb1775bf" class="outline-4">
+<h4 id="d8cb7f38-7ef3-4ec2-85a2-b4df7b2c4997"><a id="orgb1775bf"></a><a id="ID-933f58e1-a4da-4e7f-a227-0fac621e14b0"></a>Less Simple Version</h4>
 <div class="outline-text-4" id="text-d8cb7f38-7ef3-4ec2-85a2-b4df7b2c4997">
 <p>
 In the -n version, we are going to use the id columns as the primary key.
@@ -3437,8 +3442,8 @@ from all the foreign tables.
 </div>
 </div>
 
-<div id="outline-container-org62b251c" class="outline-2">
-<h2 id="roles"><a id="org62b251c"></a>Roles</h2>
+<div id="outline-container-org10fae2d" class="outline-2">
+<h2 id="roles"><a id="org10fae2d"></a>Roles</h2>
 <div class="outline-text-2" id="text-roles">
 <p>
 Every connection is specific to a particular database. However, creating roles
@@ -3484,8 +3489,8 @@ on, then dropping ownership of objects, then dropping the role itself.
 </p>
 </div>
 
-<div id="outline-container-orga2e3f27" class="outline-3">
-<h3 id="694123c8-957f-4b11-a344-094525d35e7f"><a id="orga2e3f27"></a>function role-exists-p (role-name)</h3>
+<div id="outline-container-org15364ea" class="outline-3">
+<h3 id="694123c8-957f-4b11-a344-094525d35e7f"><a id="org15364ea"></a>function role-exists-p (role-name)</h3>
 <div class="outline-text-3" id="text-694123c8-957f-4b11-a344-094525d35e7f">
 <p>
 → boolean
@@ -3496,8 +3501,8 @@ Does the named role exist in this database cluster? Returns t or nil.
 </p>
 </div>
 </div>
-<div id="outline-container-orgbe513b3" class="outline-3">
-<h3 id="07a9f936-c1b7-4a7d-b5a5-57cd6a24870a"><a id="orgbe513b3"></a>function create-role</h3>
+<div id="outline-container-org602bb04" class="outline-3">
+<h3 id="07a9f936-c1b7-4a7d-b5a5-57cd6a24870a"><a id="org602bb04"></a>function create-role</h3>
 <div class="outline-text-3" id="text-07a9f936-c1b7-4a7d-b5a5-57cd6a24870a">
 <p>
 (name password &amp;key (base-role :readonly) (schema :public)
@@ -3558,8 +3563,8 @@ as culturally insensitive to change the display of the name.
 </p>
 </div>
 </div>
-<div id="outline-container-orge595e24" class="outline-3">
-<h3 id="e527824a-811e-41fa-ae49-2dd24f436ed3"><a id="orge595e24"></a>function drop-role (role-name &amp;optional (new-owner "postgres") (database :all))</h3>
+<div id="outline-container-orgb6167e9" class="outline-3">
+<h3 id="e527824a-811e-41fa-ae49-2dd24f436ed3"><a id="orgb6167e9"></a>function drop-role (role-name &amp;optional (new-owner "postgres") (database :all))</h3>
 <div class="outline-text-3" id="text-e527824a-811e-41fa-ae49-2dd24f436ed3">
 <p>
 → boolean
@@ -3587,8 +3592,8 @@ successful. Will not drop the postgres role.
 </p>
 </div>
 </div>
-<div id="outline-container-org80062ab" class="outline-3">
-<h3 id="20f2425f-6a17-46b0-a8b7-22843a7f11e1"><a id="org80062ab"></a>function alter-role-search-path (role search-path)</h3>
+<div id="outline-container-org8b2da84" class="outline-3">
+<h3 id="20f2425f-6a17-46b0-a8b7-22843a7f11e1"><a id="org8b2da84"></a>function alter-role-search-path (role search-path)</h3>
 <div class="outline-text-3" id="text-20f2425f-6a17-46b0-a8b7-22843a7f11e1">
 <p>
 Changes the priority of where a role looks for tables (which schema first,
@@ -3597,8 +3602,8 @@ names either as strings or symbols.
 </p>
 </div>
 </div>
-<div id="outline-container-org838ebd2" class="outline-3">
-<h3 id="08c10e1f-96a3-4f3b-8b9c-f4a0251d43cd"><a id="org838ebd2"></a>function change-password (role password &amp;optional expiration-date)</h3>
+<div id="outline-container-org24d8867" class="outline-3">
+<h3 id="08c10e1f-96a3-4f3b-8b9c-f4a0251d43cd"><a id="org24d8867"></a>function change-password (role password &amp;optional expiration-date)</h3>
 <div class="outline-text-3" id="text-08c10e1f-96a3-4f3b-8b9c-f4a0251d43cd">
 <p>
 Alters a role's password. If the optional expiration-date parameter is provided,
@@ -3610,8 +3615,8 @@ automatic with postgresql versions 10 and above.
 </div>
 </div>
 
-<div id="outline-container-org7419b99" class="outline-3">
-<h3 id="41e66f79-aa57-4f00-b218-5f1a85c7d970"><a id="org7419b99"></a>function grant-role-permissions (role-type name &amp;key (schema :public) (tables :all) (databases :all))</h3>
+<div id="outline-container-org1a910a2" class="outline-3">
+<h3 id="41e66f79-aa57-4f00-b218-5f1a85c7d970"><a id="org1a910a2"></a>function grant-role-permissions (role-type name &amp;key (schema :public) (tables :all) (databases :all))</h3>
 <div class="outline-text-3" id="text-41e66f79-aa57-4f00-b218-5f1a85c7d970">
 <p>
 Grant-role-permissions assumes that a role has already been created, but
@@ -3640,8 +3645,8 @@ the connected database at the time of execution of this function.
 </p>
 </div>
 </div>
-<div id="outline-container-orgc341f29" class="outline-3">
-<h3 id="ac447228-8f95-4a30-840d-10a1a9a418f4"><a id="orgc341f29"></a>function grant-readonly-permissions (schema-name role-name &amp;optional (table-name nil))</h3>
+<div id="outline-container-org82e6af1" class="outline-3">
+<h3 id="ac447228-8f95-4a30-840d-10a1a9a418f4"><a id="org82e6af1"></a>function grant-readonly-permissions (schema-name role-name &amp;optional (table-name nil))</h3>
 <div class="outline-text-3" id="text-ac447228-8f95-4a30-840d-10a1a9a418f4">
 <p>
 Grants select privileges to a role for the named schema. If the optional
@@ -3653,8 +3658,8 @@ read-only role with access to only a limited number of tables.
 </p>
 </div>
 </div>
-<div id="outline-container-org3496a75" class="outline-3">
-<h3 id="1a271dc1-5e76-4b90-84d5-423a24059e8b"><a id="org3496a75"></a>function grant-editor-permissions (schema-name role-name &amp;optional (table-name nil))</h3>
+<div id="outline-container-orgd6f5829" class="outline-3">
+<h3 id="1a271dc1-5e76-4b90-84d5-423a24059e8b"><a id="orgd6f5829"></a>function grant-editor-permissions (schema-name role-name &amp;optional (table-name nil))</h3>
 <div class="outline-text-3" id="text-1a271dc1-5e76-4b90-84d5-423a24059e8b">
 <p>
 Grants select, insert, update and delete privileges to a role for the named
@@ -3666,8 +3671,8 @@ to a editor role with access to only a limited number of tables.
 </p>
 </div>
 </div>
-<div id="outline-container-org78af081" class="outline-3">
-<h3 id="4ac88ea3-bf89-462b-a9dd-cfa115234fb3"><a id="org78af081"></a>function grant-admin-permissions (schema-name role-name &amp;optional (table-name nil))</h3>
+<div id="outline-container-org4055c76" class="outline-3">
+<h3 id="4ac88ea3-bf89-462b-a9dd-cfa115234fb3"><a id="org4055c76"></a>function grant-admin-permissions (schema-name role-name &amp;optional (table-name nil))</h3>
 <div class="outline-text-3" id="text-4ac88ea3-bf89-462b-a9dd-cfa115234fb3">
 <p>
 Grants all privileges to a role for the named schema. If the optional table-name
@@ -3675,8 +3680,8 @@ parameter is provided, the privileges are only granted with respect to that tabl
 </p>
 </div>
 </div>
-<div id="outline-container-orge3b8018" class="outline-3">
-<h3 id="6e7e67b0-0fb1-461e-a842-a6e6c59f4c2f"><a id="orge3b8018"></a>function revoke-all-on-table (table-name role-name)</h3>
+<div id="outline-container-org901065d" class="outline-3">
+<h3 id="6e7e67b0-0fb1-461e-a842-a6e6c59f4c2f"><a id="org901065d"></a>function revoke-all-on-table (table-name role-name)</h3>
 <div class="outline-text-3" id="text-6e7e67b0-0fb1-461e-a842-a6e6c59f4c2f">
 <p>
 Takes a table-name which could be a string, symbol or list of strings or
@@ -3687,8 +3692,8 @@ of the function.
 </p>
 </div>
 </div>
-<div id="outline-container-org6d04ae2" class="outline-3">
-<h3 id="77975516-0416-428c-a9c8-6655b5aebedd"><a id="org6d04ae2"></a>function list-role-accessible-databases (role-name)</h3>
+<div id="outline-container-org82479ba" class="outline-3">
+<h3 id="77975516-0416-428c-a9c8-6655b5aebedd"><a id="org82479ba"></a>function list-role-accessible-databases (role-name)</h3>
 <div class="outline-text-3" id="text-77975516-0416-428c-a9c8-6655b5aebedd">
 <p>
 → list
@@ -3699,8 +3704,8 @@ Returns a list of the databases to which the specified role can connect.
 </p>
 </div>
 </div>
-<div id="outline-container-orgd11ff36" class="outline-3">
-<h3 id="a5bdaaca-11e5-438d-83a8-495cef9b85fa"><a id="orgd11ff36"></a><a id="ID-e6d13898-e158-4001-b54c-cc7e58342023"></a>function list-roles (&amp;optional (lt nil))</h3>
+<div id="outline-container-org9f0cc9c" class="outline-3">
+<h3 id="a5bdaaca-11e5-438d-83a8-495cef9b85fa"><a id="org9f0cc9c"></a><a id="ID-e6d13898-e158-4001-b54c-cc7e58342023"></a>function list-roles (&amp;optional (lt nil))</h3>
 <div class="outline-text-3" id="text-a5bdaaca-11e5-438d-83a8-495cef9b85fa">
 <p>
 → list
@@ -3715,8 +3720,8 @@ list types to :alists or :plists. This is the same as the psql function \du.
 </div>
 </div>
 
-<div id="outline-container-orgf1d6981" class="outline-3">
-<h3 id="fd161f71-a334-4959-8b42-dda5271ef6d5"><a id="orgf1d6981"></a>function list-role-permissions (&amp;optional role)</h3>
+<div id="outline-container-org6f71aae" class="outline-3">
+<h3 id="fd161f71-a334-4959-8b42-dda5271ef6d5"><a id="org6f71aae"></a>function list-role-permissions (&amp;optional role)</h3>
 <div class="outline-text-3" id="text-fd161f71-a334-4959-8b42-dda5271ef6d5">
 <p>
 → list
@@ -3732,12 +3737,12 @@ on that table in that schema.
 </div>
 </div>
 </div>
-<div id="outline-container-orgb98fb5e" class="outline-2">
-<h2 id="database-information"><a id="orgb98fb5e"></a><a id="ID-ecc7ca5e-9117-488b-aa7c-011d56409f76"></a>Database Information</h2>
+<div id="outline-container-org4786679" class="outline-2">
+<h2 id="database-information"><a id="org4786679"></a><a id="ID-ecc7ca5e-9117-488b-aa7c-011d56409f76"></a>Database Information</h2>
 <div class="outline-text-2" id="text-database-information">
 </div>
-<div id="outline-container-org59f5135" class="outline-3">
-<h3 id="22c6eb1c-c0ca-44fc-a8f1-590fda047866"><a id="org59f5135"></a>function add-comment (type name comment &amp;optional (second-name ""))</h3>
+<div id="outline-container-org8d28bd3" class="outline-3">
+<h3 id="22c6eb1c-c0ca-44fc-a8f1-590fda047866"><a id="org8d28bd3"></a>function add-comment (type name comment &amp;optional (second-name ""))</h3>
 <div class="outline-text-3" id="text-22c6eb1c-c0ca-44fc-a8f1-590fda047866">
 <p>
 Attempts to add a comment to a particular database object. The first parameter is a keyword for the type of database object. The second parameter is the name of the object. The third parameter is the comment itself. Some objects require an additional identifier. The names can be strings or symbols.
@@ -3766,20 +3771,36 @@ Example usage where two identifiers are required would be constraints:
 </div>
 </div>
 
-<div id="outline-container-org7fbc1a7" class="outline-3">
-<h3 id="d993f27b-95d6-4a5b-bdf3-3e06beed0213"><a id="org7fbc1a7"></a>function get-database-comment (database-name)</h3>
+<div id="outline-container-org5fdd515" class="outline-3">
+<h3 id="org5fdd515">find-comments (type identifier)</h3>
+<div class="outline-text-3" id="text-org5fdd515">
+<p>
+Returns the comments attached to a particular database object. The allowed
+types are :database :schema :table :columns (all the columns in a table)
+:column (for a single column).
+</p>
+
+<p>
+An example would be (find-comments :table 's2.employees) where the table employees
+is in the s2 schema.
+</p>
+</div>
+</div>
+<div id="outline-container-org48deaba" class="outline-3">
+<h3 id="d993f27b-95d6-4a5b-bdf3-3e06beed0213"><a id="org48deaba"></a>function get-database-comment (database-name)</h3>
 <div class="outline-text-3" id="text-d993f27b-95d6-4a5b-bdf3-3e06beed0213">
 <p>
 → string
 </p>
 
 <p>
-Returns the comment, if any, attached to a database.
+Returns the comment, if any, attached to a database. See also get-schema-comment,
+get-column-comments and get-database-comment.
 </p>
 </div>
 </div>
-<div id="outline-container-org9ceab48" class="outline-3">
-<h3 id="29d56bfd-15a0-40bb-b7f1-a1683b392695"><a id="org9ceab48"></a><a id="ID-9243f0ff-2001-4427-8cf9-33f9a9b6fd5c"></a>function postgresql-version ()</h3>
+<div id="outline-container-orgfe69a94" class="outline-3">
+<h3 id="29d56bfd-15a0-40bb-b7f1-a1683b392695"><a id="orgfe69a94"></a><a id="ID-9243f0ff-2001-4427-8cf9-33f9a9b6fd5c"></a>function postgresql-version ()</h3>
 <div class="outline-text-3" id="text-29d56bfd-15a0-40bb-b7f1-a1683b392695">
 <p>
 → string
@@ -3794,8 +3815,8 @@ number, use (cl-postgres:get-postgresql-version).
 </div>
 </div>
 
-<div id="outline-container-orgd0f9177" class="outline-3">
-<h3 id="29d56bfd-15a0-40bb-b7f1-a1683b392695"><a id="orgd0f9177"></a><a id="ID-9243f0ff-2001-4427-8cf9-33f9a9b6fd5c"></a>function database-version ()</h3>
+<div id="outline-container-org7064698" class="outline-3">
+<h3 id="29d56bfd-15a0-40bb-b7f1-a1683b392695"><a id="org7064698"></a><a id="ID-9243f0ff-2001-4427-8cf9-33f9a9b6fd5c"></a>function database-version ()</h3>
 <div class="outline-text-3" id="text-29d56bfd-15a0-40bb-b7f1-a1683b392695">
 <p>
 → string
@@ -3816,8 +3837,8 @@ number, use (cl-postgres:get-postgresql-version).
 </div>
 </div>
 
-<div id="outline-container-orgfe05e83" class="outline-3">
-<h3 id="69269619-9b8a-4e88-8ede-777182579d0a"><a id="orgfe05e83"></a><a id="ID-4928edd1-e74c-4e90-92d8-bd9b98ab0894"></a>function current-database ()</h3>
+<div id="outline-container-org86f991e" class="outline-3">
+<h3 id="69269619-9b8a-4e88-8ede-777182579d0a"><a id="org86f991e"></a><a id="ID-4928edd1-e74c-4e90-92d8-bd9b98ab0894"></a>function current-database ()</h3>
 <div class="outline-text-3" id="text-69269619-9b8a-4e88-8ede-777182579d0a">
 <p>
 → string
@@ -3829,8 +3850,8 @@ Returns the string name of the current database.
 </div>
 </div>
 
-<div id="outline-container-org5c93024" class="outline-3">
-<h3 id="03fec9c2-6282-4b33-abf8-4db16044cf52"><a id="org5c93024"></a><a id="ID-96e0c18f-4a1e-4cc5-b9c6-5bcd368d0d13"></a>function database-exists-p (database-name)</h3>
+<div id="outline-container-org1966321" class="outline-3">
+<h3 id="03fec9c2-6282-4b33-abf8-4db16044cf52"><a id="org1966321"></a><a id="ID-96e0c18f-4a1e-4cc5-b9c6-5bcd368d0d13"></a>function database-exists-p (database-name)</h3>
 <div class="outline-text-3" id="text-03fec9c2-6282-4b33-abf8-4db16044cf52">
 <p>
 → boolean
@@ -3842,8 +3863,8 @@ Checks to see if a particular database exists. Returns T if true, nil if not.
 </div>
 </div>
 
-<div id="outline-container-orgd97ba34" class="outline-3">
-<h3 id="d8827c9d-64ff-4334-9a14-1ca4536f8d0a"><a id="orgd97ba34"></a><a id="ID-9afb5a1e-ef10-4d54-91be-b30debc708dd"></a>function database-size (&amp;optional database-name)</h3>
+<div id="outline-container-org79c7954" class="outline-3">
+<h3 id="d8827c9d-64ff-4334-9a14-1ca4536f8d0a"><a id="org79c7954"></a><a id="ID-9afb5a1e-ef10-4d54-91be-b30debc708dd"></a>function database-size (&amp;optional database-name)</h3>
 <div class="outline-text-3" id="text-d8827c9d-64ff-4334-9a14-1ca4536f8d0a">
 <p>
 → list
@@ -3857,8 +3878,8 @@ provided, it will return the result for the currently connected database.
 </div>
 </div>
 
-<div id="outline-container-org67eb41e" class="outline-3">
-<h3 id="25b5233f-9a2c-4e39-8902-4a0b88e3b5b3"><a id="org67eb41e"></a><a id="ID-2893eb67-97ae-41cb-8987-1924855ec48a"></a>function num-records-in-database ()</h3>
+<div id="outline-container-org3c85bd9" class="outline-3">
+<h3 id="25b5233f-9a2c-4e39-8902-4a0b88e3b5b3"><a id="org3c85bd9"></a><a id="ID-2893eb67-97ae-41cb-8987-1924855ec48a"></a>function num-records-in-database ()</h3>
 <div class="outline-text-3" id="text-25b5233f-9a2c-4e39-8902-4a0b88e3b5b3">
 <p>
 → list
@@ -3871,8 +3892,8 @@ records in the currently connected database.
 </div>
 </div>
 
-<div id="outline-container-orga2691d8" class="outline-3">
-<h3 id="b5909c41-f24b-4678-8bd9-759d543c4d81"><a id="orga2691d8"></a><a id="ID-a47beb6b-fdbd-470b-ad85-541d0e6518f8"></a>function list-databases (&amp;key (order-by-size nil) (size t))</h3>
+<div id="outline-container-org541cb27" class="outline-3">
+<h3 id="b5909c41-f24b-4678-8bd9-759d543c4d81"><a id="org541cb27"></a><a id="ID-a47beb6b-fdbd-470b-ad85-541d0e6518f8"></a>function list-databases (&amp;key (order-by-size nil) (size t))</h3>
 <div class="outline-text-3" id="text-b5909c41-f24b-4678-8bd9-759d543c4d81">
 <p>
 → list
@@ -3888,8 +3909,8 @@ in a single list ordered by name. This function excludes the template databases
 </div>
 </div>
 
-<div id="outline-container-orgbf3f0cd" class="outline-3">
-<h3 id="ff1d636e-12ba-4fb0-8513-7f808617b956"><a id="orgbf3f0cd"></a><a id="ID-61f0e7e5-cf5d-4c2e-967d-588808d1a1bc"></a>function list-database-functions ()</h3>
+<div id="outline-container-org299be00" class="outline-3">
+<h3 id="ff1d636e-12ba-4fb0-8513-7f808617b956"><a id="org299be00"></a><a id="ID-61f0e7e5-cf5d-4c2e-967d-588808d1a1bc"></a>function list-database-functions ()</h3>
 <div class="outline-text-3" id="text-ff1d636e-12ba-4fb0-8513-7f808617b956">
 <p>
 → list
@@ -3906,8 +3927,8 @@ the information_schema table.
 </p>
 </div>
 </div>
-<div id="outline-container-org52c18b0" class="outline-3">
-<h3 id="5810bfc5-9338-4a6b-807f-bc72265771a0"><a id="org52c18b0"></a><a id="ID-adfb5355-fd04-4835-a2bd-337dc9402915"></a>function list-database-users ()</h3>
+<div id="outline-container-orgd1beabe" class="outline-3">
+<h3 id="5810bfc5-9338-4a6b-807f-bc72265771a0"><a id="orgd1beabe"></a><a id="ID-adfb5355-fd04-4835-a2bd-337dc9402915"></a>function list-database-users ()</h3>
 <div class="outline-text-3" id="text-5810bfc5-9338-4a6b-807f-bc72265771a0">
 <p>
 → list
@@ -3918,8 +3939,8 @@ List database users (actually 'roles' in Postgresql terminology).
 </p>
 </div>
 </div>
-<div id="outline-container-orgce92ac5" class="outline-3">
-<h3 id="36e580f9-d647-4f6d-869b-0fcd347fb9d5"><a id="orgce92ac5"></a>function list-database-access-rights (&amp;optional database-name)</h3>
+<div id="outline-container-orgb79b774" class="outline-3">
+<h3 id="36e580f9-d647-4f6d-869b-0fcd347fb9d5"><a id="orgb79b774"></a>function list-database-access-rights (&amp;optional database-name)</h3>
 <div class="outline-text-3" id="text-36e580f9-d647-4f6d-869b-0fcd347fb9d5">
 <p>
 → list
@@ -3935,8 +3956,8 @@ excludes the template databases.
 </div>
 </div>
 
-<div id="outline-container-orgc594f68" class="outline-3">
-<h3 id="3aeac559-710e-4f60-b687-33b25a6f575a"><a id="orgc594f68"></a><a id="ID-b5ebabe7-31f9-45b6-8ecb-6035febaa392"></a>function list-available-types ()</h3>
+<div id="outline-container-orgf205cf6" class="outline-3">
+<h3 id="3aeac559-710e-4f60-b687-33b25a6f575a"><a id="orgf205cf6"></a><a id="ID-b5ebabe7-31f9-45b6-8ecb-6035febaa392"></a>function list-available-types ()</h3>
 <div class="outline-text-3" id="text-3aeac559-710e-4f60-b687-33b25a6f575a">
 <p>
 → list
@@ -3950,8 +3971,8 @@ the name of the data types. E.g. (21 "smallint")
 </div>
 </div>
 
-<div id="outline-container-org3470fae" class="outline-3">
-<h3 id="da41c0fb-9479-4e23-bdf2-ba73db959e36"><a id="org3470fae"></a>function list-available-collations ()</h3>
+<div id="outline-container-orgd16a535" class="outline-3">
+<h3 id="da41c0fb-9479-4e23-bdf2-ba73db959e36"><a id="orgd16a535"></a>function list-available-collations ()</h3>
 <div class="outline-text-3" id="text-da41c0fb-9479-4e23-bdf2-ba73db959e36">
 <p>
 → list
@@ -3965,8 +3986,8 @@ See <a href="https://wiki.postgresql.org/wiki/Collations">https://wiki.postgresq
 </p>
 </div>
 </div>
-<div id="outline-container-org96e7003" class="outline-3">
-<h3 id="f6a3893a-0d39-4484-9d3d-40d0ba2e05fd"><a id="org96e7003"></a><a id="ID-353cafc2-ca5c-4197-b820-3662dbbea2e3"></a>function list-available-extensions ()</h3>
+<div id="outline-container-org04bca3d" class="outline-3">
+<h3 id="f6a3893a-0d39-4484-9d3d-40d0ba2e05fd"><a id="org04bca3d"></a><a id="ID-353cafc2-ca5c-4197-b820-3662dbbea2e3"></a>function list-available-extensions ()</h3>
 <div class="outline-text-3" id="text-f6a3893a-0d39-4484-9d3d-40d0ba2e05fd">
 <p>
 → list
@@ -3978,8 +3999,8 @@ currently connected database. The extensions may or may not be installed.
 </p>
 </div>
 </div>
-<div id="outline-container-org8fb9ad7" class="outline-3">
-<h3 id="2855d5f5-3957-49ba-9d07-f61464e6da28"><a id="org8fb9ad7"></a><a id="ID-922fca24-53d7-4883-844a-cf383ffc7322"></a>function list-installed-extensions ()</h3>
+<div id="outline-container-org4a2dc1a" class="outline-3">
+<h3 id="2855d5f5-3957-49ba-9d07-f61464e6da28"><a id="org4a2dc1a"></a><a id="ID-922fca24-53d7-4883-844a-cf383ffc7322"></a>function list-installed-extensions ()</h3>
 <div class="outline-text-3" id="text-2855d5f5-3957-49ba-9d07-f61464e6da28">
 <p>
 → list
@@ -3991,8 +4012,8 @@ database.
 </p>
 </div>
 </div>
-<div id="outline-container-orgb8eb8b3" class="outline-3">
-<h3 id="5bc847be-5de4-4e64-8feb-7256f58b1a0a"><a id="orgb8eb8b3"></a>function list-templates ()</h3>
+<div id="outline-container-org4af44d6" class="outline-3">
+<h3 id="5bc847be-5de4-4e64-8feb-7256f58b1a0a"><a id="org4af44d6"></a>function list-templates ()</h3>
 <div class="outline-text-3" id="text-5bc847be-5de4-4e64-8feb-7256f58b1a0a">
 <p>
 → list
@@ -4003,8 +4024,8 @@ Returns a list of existing database template names.
 </p>
 </div>
 </div>
-<div id="outline-container-orgc7f4297" class="outline-3">
-<h3 id="e0ce24b7-5619-4ab7-9912-48ebfca4605f"><a id="orgc7f4297"></a><a id="ID-6d41d3c5-2013-4404-aae6-2a7cd5df4b18"></a>function change-toplevel-database (new-database user password host)</h3>
+<div id="outline-container-org0634909" class="outline-3">
+<h3 id="e0ce24b7-5619-4ab7-9912-48ebfca4605f"><a id="org0634909"></a><a id="ID-6d41d3c5-2013-4404-aae6-2a7cd5df4b18"></a>function change-toplevel-database (new-database user password host)</h3>
 <div class="outline-text-3" id="text-e0ce24b7-5619-4ab7-9912-48ebfca4605f">
 <p>
 → string
@@ -4018,8 +4039,8 @@ database as a string.
 </div>
 </div>
 
-<div id="outline-container-orgcf52a85" class="outline-3">
-<h3 id="932d1dde-71e2-4f26-bac4-17a238101e24"><a id="orgcf52a85"></a><a id="ID-4d405778-1b17-4928-8d40-e239f8d4c73d"></a>function cache-hit-ratio ()</h3>
+<div id="outline-container-org7f7ac0e" class="outline-3">
+<h3 id="932d1dde-71e2-4f26-bac4-17a238101e24"><a id="org7f7ac0e"></a><a id="ID-4d405778-1b17-4928-8d40-e239f8d4c73d"></a>function cache-hit-ratio ()</h3>
 <div class="outline-text-3" id="text-932d1dde-71e2-4f26-bac4-17a238101e24">
 <p>
 → list
@@ -4034,8 +4055,8 @@ memory / total heapblocks hit. Borrowed from: <a href="https://www.citusdata.com
 </div>
 </div>
 
-<div id="outline-container-org01a816e" class="outline-3">
-<h3 id="84bc40e4-44bf-4c1e-91d2-b32ba77f86c4"><a id="org01a816e"></a><a id="ID-1d81081b-3cfe-4ef5-989f-23c5ed44d7fc"></a>function bloat-measurement ()</h3>
+<div id="outline-container-org97ac128" class="outline-3">
+<h3 id="84bc40e4-44bf-4c1e-91d2-b32ba77f86c4"><a id="org97ac128"></a><a id="ID-1d81081b-3cfe-4ef5-989f-23c5ed44d7fc"></a>function bloat-measurement ()</h3>
 <div class="outline-text-3" id="text-84bc40e4-44bf-4c1e-91d2-b32ba77f86c4">
 <p>
 → list
@@ -4049,8 +4070,8 @@ borrowed it from <a href="https://github.com/heroku/heroku-pg-extras/tree/master
 </div>
 </div>
 
-<div id="outline-container-orge1ecd2a" class="outline-3">
-<h3 id="10ec1cf5-e865-43e9-a093-8f27916af0d2"><a id="orge1ecd2a"></a><a id="ID-cdbc1e43-b4a7-4709-89f7-d93ba7ac3bae"></a>function unused-indexes ()</h3>
+<div id="outline-container-org5ea4a25" class="outline-3">
+<h3 id="10ec1cf5-e865-43e9-a093-8f27916af0d2"><a id="org5ea4a25"></a><a id="ID-cdbc1e43-b4a7-4709-89f7-d93ba7ac3bae"></a>function unused-indexes ()</h3>
 <div class="outline-text-3" id="text-10ec1cf5-e865-43e9-a093-8f27916af0d2">
 <p>
 → list
@@ -4063,8 +4084,8 @@ of scans. The code was borrowed from: <a href="https://www.citusdata.com/blog/20
 </div>
 </div>
 
-<div id="outline-container-org6cd85fb" class="outline-3">
-<h3 id="c532268f-61d7-4613-85cc-460d7d92aab0"><a id="org6cd85fb"></a><a id="ID-31ab040b-01fb-4a08-8c27-4b3bc35c9361"></a>function check-query-performance (&amp;optional (ob nil) (num-calls 100) (limit 20))</h3>
+<div id="outline-container-orgecd6ab5" class="outline-3">
+<h3 id="c532268f-61d7-4613-85cc-460d7d92aab0"><a id="orgecd6ab5"></a><a id="ID-31ab040b-01fb-4a08-8c27-4b3bc35c9361"></a>function check-query-performance (&amp;optional (ob nil) (num-calls 100) (limit 20))</h3>
 <div class="outline-text-3" id="text-c532268f-61d7-4613-85cc-460d7d92aab0">
 <p>
 → list
@@ -4091,12 +4112,12 @@ stddev_time, rows, rows/calls and the cache hit percentage.
 </div>
 </div>
 
-<div id="outline-container-org0a08a34" class="outline-2">
-<h2 id="constraints"><a id="org0a08a34"></a><a id="ID-b857f2fe-7b5c-4b13-9909-cb637f7ba367"></a>Constraints</h2>
+<div id="outline-container-org0ee69dc" class="outline-2">
+<h2 id="constraints"><a id="org0ee69dc"></a><a id="ID-b857f2fe-7b5c-4b13-9909-cb637f7ba367"></a>Constraints</h2>
 <div class="outline-text-2" id="text-constraints">
 </div>
-<div id="outline-container-org7451268" class="outline-3">
-<h3 id="e20d9e5c-b0a7-44a6-8907-ad205ec1e0b8"><a id="org7451268"></a><a id="ID-e5adb03e-a26a-40fa-bde2-05f541fc70cf"></a>function list-unique-or-primary-constraints (table-name)</h3>
+<div id="outline-container-org8115060" class="outline-3">
+<h3 id="e20d9e5c-b0a7-44a6-8907-ad205ec1e0b8"><a id="org8115060"></a><a id="ID-e5adb03e-a26a-40fa-bde2-05f541fc70cf"></a>function list-unique-or-primary-constraints (table-name)</h3>
 <div class="outline-text-3" id="text-e20d9e5c-b0a7-44a6-8907-ad205ec1e0b8">
 <p>
 → list
@@ -4109,8 +4130,8 @@ constraints into keywords if strings-p is not true.
 </div>
 </div>
 
-<div id="outline-container-orgc78d3b7" class="outline-3">
-<h3 id="4b8a62cb-647b-4c3b-b2a7-58476fff58d1"><a id="orgc78d3b7"></a><a id="ID-d641e79f-b66f-4248-9c1a-284f07182d12"></a>function list-all-constraints (table-name)</h3>
+<div id="outline-container-orge276b74" class="outline-3">
+<h3 id="4b8a62cb-647b-4c3b-b2a7-58476fff58d1"><a id="orge276b74"></a><a id="ID-d641e79f-b66f-4248-9c1a-284f07182d12"></a>function list-all-constraints (table-name)</h3>
 <div class="outline-text-3" id="text-4b8a62cb-647b-4c3b-b2a7-58476fff58d1">
 <p>
 → list
@@ -4124,8 +4145,8 @@ not true.
 </div>
 </div>
 
-<div id="outline-container-org06edf65" class="outline-3">
-<h3 id="4f692c41-549f-462d-b98c-a8f7e400f4cc"><a id="org06edf65"></a><a id="ID-8d6cff99-a479-4b98-9fd5-fd77517b61b4"></a>function describe-constraint (table-name constraint-name)</h3>
+<div id="outline-container-orgffa234a" class="outline-3">
+<h3 id="4f692c41-549f-462d-b98c-a8f7e400f4cc"><a id="orgffa234a"></a><a id="ID-8d6cff99-a479-4b98-9fd5-fd77517b61b4"></a>function describe-constraint (table-name constraint-name)</h3>
 <div class="outline-text-3" id="text-4f692c41-549f-462d-b98c-a8f7e400f4cc">
 <p>
 → list
@@ -4138,8 +4159,8 @@ table-name and the constraint name using the information_schema table.
 </div>
 </div>
 
-<div id="outline-container-orgec91218" class="outline-3">
-<h3 id="dfe5a61e-7450-47b7-a17b-0d9bd83e1706"><a id="orgec91218"></a><a id="ID-96f4c221-be13-440d-a7ac-0b446bfb06cc"></a>function describe-foreign-key-constraints ()</h3>
+<div id="outline-container-org52cad19" class="outline-3">
+<h3 id="dfe5a61e-7450-47b7-a17b-0d9bd83e1706"><a id="org52cad19"></a><a id="ID-96f4c221-be13-440d-a7ac-0b446bfb06cc"></a>function describe-foreign-key-constraints ()</h3>
 <div class="outline-text-3" id="text-dfe5a61e-7450-47b7-a17b-0d9bd83e1706">
 <p>
 → list
@@ -4151,12 +4172,12 @@ Generates a list of lists of information on the foreign key constraints
 </div>
 </div>
 </div>
-<div id="outline-container-orgb44ae7e" class="outline-2">
-<h2 id="indexes"><a id="orgb44ae7e"></a><a id="ID-a265f57e-3928-4386-92c0-ab2764f4fdc5"></a>Indexes/Indices</h2>
+<div id="outline-container-orgde3a69c" class="outline-2">
+<h2 id="indexes"><a id="orgde3a69c"></a><a id="ID-a265f57e-3928-4386-92c0-ab2764f4fdc5"></a>Indexes/Indices</h2>
 <div class="outline-text-2" id="text-indexes">
 </div>
-<div id="outline-container-org51eca5d" class="outline-3">
-<h3 id="21392a30-a33c-4330-9a96-abaebcc0af66"><a id="org51eca5d"></a><a id="ID-8724742c-e2fe-48f5-b190-7c1218f9995d"></a>function create-index (name  &amp;key unique if-not-exists concurrently on using fields)</h3>
+<div id="outline-container-orgdf6fabb" class="outline-3">
+<h3 id="21392a30-a33c-4330-9a96-abaebcc0af66"><a id="orgdf6fabb"></a><a id="ID-8724742c-e2fe-48f5-b190-7c1218f9995d"></a>function create-index (name  &amp;key unique if-not-exists concurrently on using fields)</h3>
 <div class="outline-text-3" id="text-21392a30-a33c-4330-9a96-abaebcc0af66">
 <p>
 Create an index. Slightly less sophisticated than the query version because it
@@ -4165,8 +4186,8 @@ does not have a where clause capability.
 </div>
 </div>
 
-<div id="outline-container-org755d348" class="outline-3">
-<h3 id="6bfcf7a6-6c14-4fad-82f4-5be599f1466b"><a id="org755d348"></a><a id="ID-9a3553c3-9d58-490f-93e3-2d04b5bd72bc"></a>function drop-index (name &amp;key concurrently if-exists cascade)</h3>
+<div id="outline-container-org25f97d9" class="outline-3">
+<h3 id="6bfcf7a6-6c14-4fad-82f4-5be599f1466b"><a id="org25f97d9"></a><a id="ID-9a3553c3-9d58-490f-93e3-2d04b5bd72bc"></a>function drop-index (name &amp;key concurrently if-exists cascade)</h3>
 <div class="outline-text-3" id="text-6bfcf7a6-6c14-4fad-82f4-5be599f1466b">
 <p>
 Drop an index. Available keys are :concurrently, :if-exists, and :cascade.
@@ -4174,8 +4195,8 @@ Drop an index. Available keys are :concurrently, :if-exists, and :cascade.
 </div>
 </div>
 
-<div id="outline-container-org45a6ff6" class="outline-3">
-<h3 id="42f1ee95-201b-4d66-b02e-1b35b0e1614c"><a id="org45a6ff6"></a><a id="ID-e7fa9796-6804-4446-bfda-3455432d4453"></a>function list-indices (&amp;optional strings-p)</h3>
+<div id="outline-container-org239a987" class="outline-3">
+<h3 id="42f1ee95-201b-4d66-b02e-1b35b0e1614c"><a id="org239a987"></a><a id="ID-e7fa9796-6804-4446-bfda-3455432d4453"></a>function list-indices (&amp;optional strings-p)</h3>
 <div class="outline-text-3" id="text-42f1ee95-201b-4d66-b02e-1b35b0e1614c">
 <p>
 → list
@@ -4188,8 +4209,8 @@ is not true.
 </div>
 </div>
 
-<div id="outline-container-org9a17b3f" class="outline-3">
-<h3 id="72f27f96-392f-4f33-a152-e15888a98c5d"><a id="org9a17b3f"></a><a id="ID-d57a9331-04b4-4920-9fe5-36d4b1d785bb"></a>function list-table-indices (table-name &amp;optional strings-p)</h3>
+<div id="outline-container-org89d10ad" class="outline-3">
+<h3 id="72f27f96-392f-4f33-a152-e15888a98c5d"><a id="org89d10ad"></a><a id="ID-d57a9331-04b4-4920-9fe5-36d4b1d785bb"></a>function list-table-indices (table-name &amp;optional strings-p)</h3>
 <div class="outline-text-3" id="text-72f27f96-392f-4f33-a152-e15888a98c5d">
 <p>
 → list
@@ -4202,8 +4223,8 @@ be in a separate sublist.
 </div>
 </div>
 
-<div id="outline-container-org402674d" class="outline-3">
-<h3 id="c01dc7a8-0153-4857-acad-cb7ec8eccbdc"><a id="org402674d"></a><a id="ID-82c1851f-91cc-4e4d-b802-b2ba37ec6938"></a>function index-exists-p (name)</h3>
+<div id="outline-container-org3ab35a0" class="outline-3">
+<h3 id="c01dc7a8-0153-4857-acad-cb7ec8eccbdc"><a id="org3ab35a0"></a><a id="ID-82c1851f-91cc-4e4d-b802-b2ba37ec6938"></a>function index-exists-p (name)</h3>
 <div class="outline-text-3" id="text-c01dc7a8-0153-4857-acad-cb7ec8eccbdc">
 <p>
 → boolean
@@ -4216,8 +4237,8 @@ string or a symbol.
 </div>
 </div>
 
-<div id="outline-container-org91120c1" class="outline-3">
-<h3 id="07e4d320-8201-4cc5-803d-c83ee681d103"><a id="org91120c1"></a><a id="ID-47908329-5309-4319-9c16-56821f4b6233"></a>function list-indexed-column-and-attributes (table-name)</h3>
+<div id="outline-container-org301baa5" class="outline-3">
+<h3 id="07e4d320-8201-4cc5-803d-c83ee681d103"><a id="org301baa5"></a><a id="ID-47908329-5309-4319-9c16-56821f4b6233"></a>function list-indexed-column-and-attributes (table-name)</h3>
 <div class="outline-text-3" id="text-07e4d320-8201-4cc5-803d-c83ee681d103">
 <p>
 → list
@@ -4230,8 +4251,8 @@ key.
 </div>
 </div>
 
-<div id="outline-container-org78e6ff9" class="outline-3">
-<h3 id="56922f26-5ab4-4c1a-98a2-a0ab56eff9bb"><a id="org78e6ff9"></a><a id="ID-0078a757-8cc5-46a7-956e-ddb1fe2c579b"></a>function list-index-definitions (table-name)</h3>
+<div id="outline-container-orgac9c7c2" class="outline-3">
+<h3 id="56922f26-5ab4-4c1a-98a2-a0ab56eff9bb"><a id="orgac9c7c2"></a><a id="ID-0078a757-8cc5-46a7-956e-ddb1fe2c579b"></a>function list-index-definitions (table-name)</h3>
 <div class="outline-text-3" id="text-56922f26-5ab4-4c1a-98a2-a0ab56eff9bb">
 <p>
 → list
@@ -4245,12 +4266,12 @@ the table
 </div>
 </div>
 
-<div id="outline-container-orgadbc4e3" class="outline-2">
-<h2 id="keys"><a id="orgadbc4e3"></a><a id="ID-342fdfce-eed8-4ed1-a208-37c417b5a291"></a>Keys</h2>
+<div id="outline-container-org746ecf2" class="outline-2">
+<h2 id="keys"><a id="org746ecf2"></a><a id="ID-342fdfce-eed8-4ed1-a208-37c417b5a291"></a>Keys</h2>
 <div class="outline-text-2" id="text-keys">
 </div>
-<div id="outline-container-org6ff776f" class="outline-3">
-<h3 id="5bf78e17-6506-4f49-b103-9900978f8344"><a id="org6ff776f"></a><a id="ID-87a5e1c4-fe1b-4b9a-bdcf-7dbe62bd20f1"></a>function find-primary-key-info (table-name &amp;optional (just-key nil))</h3>
+<div id="outline-container-org4271bb7" class="outline-3">
+<h3 id="5bf78e17-6506-4f49-b103-9900978f8344"><a id="org4271bb7"></a><a id="ID-87a5e1c4-fe1b-4b9a-bdcf-7dbe62bd20f1"></a>function find-primary-key-info (table-name &amp;optional (just-key nil))</h3>
 <div class="outline-text-3" id="text-5bf78e17-6506-4f49-b103-9900978f8344">
 <p>
 → list
@@ -4271,8 +4292,8 @@ fully qualified table name e.g. schema-name.table-name.
 </div>
 </div>
 
-<div id="outline-container-org7161099" class="outline-3">
-<h3 id="68d136c2-a216-4def-87f9-726f72dda631"><a id="org7161099"></a><a id="ID-cb0a151a-ad44-4a7a-896d-47903d0e718b"></a>function list-foreign-keys (table-name)</h3>
+<div id="outline-container-org7681af6" class="outline-3">
+<h3 id="68d136c2-a216-4def-87f9-726f72dda631"><a id="org7681af6"></a><a id="ID-cb0a151a-ad44-4a7a-896d-47903d0e718b"></a>function list-foreign-keys (table-name)</h3>
 <div class="outline-text-3" id="text-68d136c2-a216-4def-87f9-726f72dda631">
 <p>
 → list
@@ -4287,8 +4308,8 @@ Returns a list of sublists of foreign key info in the form of
 </div>
 </div>
 
-<div id="outline-container-org8d7bb98" class="outline-2">
-<h2 id="schema"><a id="org8d7bb98"></a><a id="ID-eef5ba67-cfe2-47dc-b432-2a75b45765d8"></a>Schema/Schemata</h2>
+<div id="outline-container-org29894b8" class="outline-2">
+<h2 id="schema"><a id="org29894b8"></a><a id="ID-eef5ba67-cfe2-47dc-b432-2a75b45765d8"></a>Schema/Schemata</h2>
 <div class="outline-text-2" id="text-schema">
 <p>
 Schema allow you to separate tables into differnet name spaces. In different
@@ -4300,8 +4321,8 @@ functions allow you to create, drop schemata and to set the search path.
 </p>
 </div>
 
-<div id="outline-container-org676f43a" class="outline-3">
-<h3 id="9b1b791c-5e04-4512-91cb-9b44fac7b76e"><a id="org676f43a"></a><a id="ID-70159647-6efd-4fcc-acf0-86b24594822b"></a>macro with-schema ((namespace &amp;key :strict t :if-not-exist :create :drop-after) &amp;body body)</h3>
+<div id="outline-container-org7be137d" class="outline-3">
+<h3 id="9b1b791c-5e04-4512-91cb-9b44fac7b76e"><a id="org7be137d"></a><a id="ID-70159647-6efd-4fcc-acf0-86b24594822b"></a>macro with-schema ((namespace &amp;key :strict t :if-not-exist :create :drop-after) &amp;body body)</h3>
 <div class="outline-text-3" id="text-9b1b791c-5e04-4512-91cb-9b44fac7b76e">
 <p>
 A macro to set the schema search path (namespace) of the postgresql database to
@@ -4346,8 +4367,8 @@ example :
 </div>
 </div>
 
-<div id="outline-container-org4e3ac3d" class="outline-3">
-<h3 id="cb98d8fa-8750-4d3c-b7c2-a060205609d6"><a id="org4e3ac3d"></a><a id="ID-8fa081ea-d959-457d-89ae-980bbb997148"></a>function list-schemata ()</h3>
+<div id="outline-container-org4b10735" class="outline-3">
+<h3 id="cb98d8fa-8750-4d3c-b7c2-a060205609d6"><a id="org4b10735"></a><a id="ID-8fa081ea-d959-457d-89ae-980bbb997148"></a>function list-schemata ()</h3>
 <div class="outline-text-3" id="text-cb98d8fa-8750-4d3c-b7c2-a060205609d6">
 <p>
 → list
@@ -4371,8 +4392,8 @@ pg_tables relations.
 </div>
 </div>
 
-<div id="outline-container-orgc206d65" class="outline-3">
-<h3 id="612d3bfd-36e2-4b27-a3e9-9f4e4cf15428"><a id="orgc206d65"></a><a id="ID-06eff6ed-5de0-4947-9dd1-26ae7dedd360"></a>function list-schemas ()</h3>
+<div id="outline-container-org613c93d" class="outline-3">
+<h3 id="612d3bfd-36e2-4b27-a3e9-9f4e4cf15428"><a id="org613c93d"></a><a id="ID-06eff6ed-5de0-4947-9dd1-26ae7dedd360"></a>function list-schemas ()</h3>
 <div class="outline-text-3" id="text-612d3bfd-36e2-4b27-a3e9-9f4e4cf15428">
 <p>
 → list
@@ -4384,8 +4405,8 @@ List schemas in the current database, excluding the pg_* system schemas.
 </div>
 </div>
 
-<div id="outline-container-orgab5e087" class="outline-3">
-<h3 id="a8a3a0df-edf5-4f17-bb97-a3d76973d078"><a id="orgab5e087"></a><a id="ID-f52064e9-e859-416e-bb67-20f5de49613e"></a>function schema-exists-p (schema)</h3>
+<div id="outline-container-org235ddcd" class="outline-3">
+<h3 id="a8a3a0df-edf5-4f17-bb97-a3d76973d078"><a id="org235ddcd"></a><a id="ID-f52064e9-e859-416e-bb67-20f5de49613e"></a>function schema-exists-p (schema)</h3>
 <div class="outline-text-3" id="text-a8a3a0df-edf5-4f17-bb97-a3d76973d078">
 <p>
 → boolean
@@ -4398,8 +4419,8 @@ otherwise. The name provided can be either a string or quoted symbol.
 </div>
 </div>
 
-<div id="outline-container-orgca8976e" class="outline-3">
-<h3 id="06e76060-e646-4fe8-b1b3-142afb2e370b"><a id="orgca8976e"></a><a id="ID-3d4619fa-faef-47b2-b6ab-61b36e8b52b2"></a>function create-schema (schema)</h3>
+<div id="outline-container-org0b80eee" class="outline-3">
+<h3 id="06e76060-e646-4fe8-b1b3-142afb2e370b"><a id="org0b80eee"></a><a id="ID-3d4619fa-faef-47b2-b6ab-61b36e8b52b2"></a>function create-schema (schema)</h3>
 <div class="outline-text-3" id="text-06e76060-e646-4fe8-b1b3-142afb2e370b">
 <p>
 Creates a new schema. Raises an error if the schema is already exists.
@@ -4407,8 +4428,8 @@ Creates a new schema. Raises an error if the schema is already exists.
 </div>
 </div>
 
-<div id="outline-container-org1e26851" class="outline-3">
-<h3 id="79d7fdbb-54d7-48e1-821d-9379e3940577"><a id="org1e26851"></a><a id="ID-cc7fe0f4-31b5-435c-9b8d-22564f7e0ad5"></a>function drop-schema (schema &amp;key (if-exists nil) (cascade nil))</h3>
+<div id="outline-container-orgc4d44b7" class="outline-3">
+<h3 id="79d7fdbb-54d7-48e1-821d-9379e3940577"><a id="orgc4d44b7"></a><a id="ID-cc7fe0f4-31b5-435c-9b8d-22564f7e0ad5"></a>function drop-schema (schema &amp;key (if-exists nil) (cascade nil))</h3>
 <div class="outline-text-3" id="text-79d7fdbb-54d7-48e1-821d-9379e3940577">
 <p>
 Drops an existing database schema. Accepts :if-exists and/or :cascade arguments
@@ -4418,8 +4439,8 @@ parameter.
 </div>
 </div>
 
-<div id="outline-container-orgd91c43c" class="outline-3">
-<h3 id="b8999d95-0ef5-492e-af5b-cfbdc91278e6"><a id="orgd91c43c"></a><a id="ID-639f826f-aed2-4a2d-811c-fe862953d195"></a>function get-search-path ()</h3>
+<div id="outline-container-orgf97b6a9" class="outline-3">
+<h3 id="b8999d95-0ef5-492e-af5b-cfbdc91278e6"><a id="orgf97b6a9"></a><a id="ID-639f826f-aed2-4a2d-811c-fe862953d195"></a>function get-search-path ()</h3>
 <div class="outline-text-3" id="text-b8999d95-0ef5-492e-af5b-cfbdc91278e6">
 <p>
 Returns the default schema search path for the current session.
@@ -4427,8 +4448,8 @@ Returns the default schema search path for the current session.
 </div>
 </div>
 
-<div id="outline-container-orgaff79ae" class="outline-3">
-<h3 id="125a3594-080f-40eb-997d-d7ef927420e6"><a id="orgaff79ae"></a><a id="ID-1fa0b1a6-af88-4083-b3f1-16b8b79aca3c"></a>function set-search-path (path)</h3>
+<div id="outline-container-org355f2b4" class="outline-3">
+<h3 id="125a3594-080f-40eb-997d-d7ef927420e6"><a id="org355f2b4"></a><a id="ID-1fa0b1a6-af88-4083-b3f1-16b8b79aca3c"></a>function set-search-path (path)</h3>
 <div class="outline-text-3" id="text-125a3594-080f-40eb-997d-d7ef927420e6">
 <p>
 This changes the postgresql runtime parameter controlling what order schemas are
@@ -4438,8 +4459,8 @@ function is used by with-schema.
 </p>
 </div>
 </div>
-<div id="outline-container-org4d58455" class="outline-3">
-<h3 id="cfacd9fe-b640-4aee-985b-149f4b9ce930"><a id="org4d58455"></a><a id="ID-1aa410f7-b60b-4c95-bc4e-dacefe8cc04c"></a>function split-fully-qualified-tablename (name)</h3>
+<div id="outline-container-orgcb979e1" class="outline-3">
+<h3 id="cfacd9fe-b640-4aee-985b-149f4b9ce930"><a id="orgcb979e1"></a><a id="ID-1aa410f7-b60b-4c95-bc4e-dacefe8cc04c"></a>function split-fully-qualified-tablename (name)</h3>
 <div class="outline-text-3" id="text-cfacd9fe-b640-4aee-985b-149f4b9ce930">
 <p>
 → list
@@ -4450,14 +4471,27 @@ qualified, it will assume that the schema should be \"public\".
 </p>
 </div>
 </div>
-</div>
 
-<div id="outline-container-org44418bc" class="outline-2">
-<h2 id="sequences"><a id="org44418bc"></a><a id="ID-62e4d0bd-e12f-47c6-8373-a174a7d8d7b1"></a>Sequences</h2>
+<div id="outline-container-org3b9444c" class="outline-3">
+<h3 id="org3b9444c">function get-schema-comment (schema-name)</h3>
+<div class="outline-text-3" id="text-org3b9444c">
+<p>
+→ string
+</p>
+
+<p>
+Retrieves the comment, if any attached to the schema. See also get-schema-comment,
+get-column-comments and get-database-comment.
+</p>
+</div>
+</div>
+</div>
+<div id="outline-container-orgd554f57" class="outline-2">
+<h2 id="sequences"><a id="orgd554f57"></a><a id="ID-62e4d0bd-e12f-47c6-8373-a174a7d8d7b1"></a>Sequences</h2>
 <div class="outline-text-2" id="text-sequences">
 </div>
-<div id="outline-container-orgea92b8b" class="outline-3">
-<h3 id="4d295beb-7a6d-402e-a831-00db88584cb4"><a id="orgea92b8b"></a><a id="ID-37802810-069f-4219-a36a-1e4f754dd5f8"></a>function create-sequence (name &amp;key temp if-not-exists increment min-value max-value start cache)</h3>
+<div id="outline-container-org9700d15" class="outline-3">
+<h3 id="4d295beb-7a6d-402e-a831-00db88584cb4"><a id="org9700d15"></a><a id="ID-37802810-069f-4219-a36a-1e4f754dd5f8"></a>function create-sequence (name &amp;key temp if-not-exists increment min-value max-value start cache)</h3>
 <div class="outline-text-3" id="text-4d295beb-7a6d-402e-a831-00db88584cb4">
 <p>
   Create a sequence. Available additional key parameters
@@ -4468,8 +4502,8 @@ details on usage.
 </div>
 </div>
 
-<div id="outline-container-org6c64c59" class="outline-3">
-<h3 id="47336489-34f5-401b-be21-2d7cb0b47e85"><a id="org6c64c59"></a><a id="ID-3001c5dd-da96-4263-b427-c04368e8cf41"></a>function sequence-next (sequence)</h3>
+<div id="outline-container-org4768c3e" class="outline-3">
+<h3 id="47336489-34f5-401b-be21-2d7cb0b47e85"><a id="org4768c3e"></a><a id="ID-3001c5dd-da96-4263-b427-c04368e8cf41"></a>function sequence-next (sequence)</h3>
 <div class="outline-text-3" id="text-47336489-34f5-401b-be21-2d7cb0b47e85">
 <p>
 → integer
@@ -4483,8 +4517,8 @@ string according to S-SQL rules.
 </div>
 </div>
 
-<div id="outline-container-org9a7ee21" class="outline-3">
-<h3 id="e316b343-ad9c-4610-b074-0d554e4b63ed"><a id="org9a7ee21"></a><a id="ID-1998fd52-d0e1-439b-9cfa-d3f72c8a3609"></a>function drop-sequence (name &amp;key if-exists cascade)</h3>
+<div id="outline-container-orgd93f325" class="outline-3">
+<h3 id="e316b343-ad9c-4610-b074-0d554e4b63ed"><a id="orgd93f325"></a><a id="ID-1998fd52-d0e1-439b-9cfa-d3f72c8a3609"></a>function drop-sequence (name &amp;key if-exists cascade)</h3>
 <div class="outline-text-3" id="text-e316b343-ad9c-4610-b074-0d554e4b63ed">
 <p>
 → list
@@ -4497,8 +4531,8 @@ and :cascade.
 </div>
 </div>
 
-<div id="outline-container-orge333523" class="outline-3">
-<h3 id="320f409d-dfc2-4145-b106-0e642b21fa95"><a id="orge333523"></a><a id="ID-8f8b89c8-9d01-460f-b60f-020e8658bbe7"></a>function list-sequences (&amp;optional strings-p)</h3>
+<div id="outline-container-org5868a79" class="outline-3">
+<h3 id="320f409d-dfc2-4145-b106-0e642b21fa95"><a id="org5868a79"></a><a id="ID-8f8b89c8-9d01-460f-b60f-020e8658bbe7"></a>function list-sequences (&amp;optional strings-p)</h3>
 <div class="outline-text-3" id="text-320f409d-dfc2-4145-b106-0e642b21fa95">
 <p>
 → list
@@ -4511,8 +4545,8 @@ the names will be given as strings, otherwise as keywords.
 </div>
 </div>
 
-<div id="outline-container-org89c701d" class="outline-3">
-<h3 id="da78ff64-0fb8-41a7-b17e-1f24ec8abe63"><a id="org89c701d"></a><a id="ID-e64dd37f-81c2-43f8-88fe-8444771b7631"></a>function sequence-exists-p (name)</h3>
+<div id="outline-container-orga72f122" class="outline-3">
+<h3 id="da78ff64-0fb8-41a7-b17e-1f24ec8abe63"><a id="orga72f122"></a><a id="ID-e64dd37f-81c2-43f8-88fe-8444771b7631"></a>function sequence-exists-p (name)</h3>
 <div class="outline-text-3" id="text-da78ff64-0fb8-41a7-b17e-1f24ec8abe63">
 <p>
 → boolean
@@ -4526,12 +4560,12 @@ string or a symbol.
 </div>
 </div>
 
-<div id="outline-container-org7b63aea" class="outline-2">
-<h2 id="tables"><a id="org7b63aea"></a><a id="ID-5a351917-b940-4c94-a3dc-2795f9a76211"></a>Tables</h2>
+<div id="outline-container-orgcbfb929" class="outline-2">
+<h2 id="tables"><a id="orgcbfb929"></a><a id="ID-5a351917-b940-4c94-a3dc-2795f9a76211"></a>Tables</h2>
 <div class="outline-text-2" id="text-tables">
 </div>
-<div id="outline-container-org39016c6" class="outline-3">
-<h3 id="ba11f8df-3297-4720-a267-02896b49575a"><a id="org39016c6"></a><a id="ID-bd228cd6-3651-48ca-a9c5-a27737fbaacc"></a>function list-tables (&amp;optional strings-p)</h3>
+<div id="outline-container-org5e98108" class="outline-3">
+<h3 id="ba11f8df-3297-4720-a267-02896b49575a"><a id="org5e98108"></a><a id="ID-bd228cd6-3651-48ca-a9c5-a27737fbaacc"></a>function list-tables (&amp;optional strings-p)</h3>
 <div class="outline-text-3" id="text-ba11f8df-3297-4720-a267-02896b49575a">
 <p>
 → list
@@ -4545,8 +4579,8 @@ returned as lowercase strings if strings-p is true.
 </div>
 </div>
 
-<div id="outline-container-org571518f" class="outline-3">
-<h3 id="ad67dcb1-7123-47dc-9402-e5adcecc7e6a"><a id="org571518f"></a>function list-all-tables (&amp;optional (fully-qualified-names-only nil))</h3>
+<div id="outline-container-orga1441eb" class="outline-3">
+<h3 id="ad67dcb1-7123-47dc-9402-e5adcecc7e6a"><a id="orga1441eb"></a>function list-all-tables (&amp;optional (fully-qualified-names-only nil))</h3>
 <div class="outline-text-3" id="text-ad67dcb1-7123-47dc-9402-e5adcecc7e6a">
 <p>
 :ID:       bd228cd6-3651-48ca-a9c5-a27737fbaacc
@@ -4571,8 +4605,8 @@ and rowsecurity(&amp;optional strings-p).
 </div>
 </div>
 
-<div id="outline-container-orgf5446d2" class="outline-3">
-<h3 id="37cd0ae4-b9b2-4776-a58e-dc396e639161"><a id="orgf5446d2"></a><a id="ID-6e7c1873-ad5b-4cd0-9389-b6389cb7ea05"></a>function list-tables-in-schema (&amp;optional (schema-name "public") (strings-p nil))</h3>
+<div id="outline-container-org8331bca" class="outline-3">
+<h3 id="37cd0ae4-b9b2-4776-a58e-dc396e639161"><a id="org8331bca"></a><a id="ID-6e7c1873-ad5b-4cd0-9389-b6389cb7ea05"></a>function list-tables-in-schema (&amp;optional (schema-name "public") (strings-p nil))</h3>
 <div class="outline-text-3" id="text-37cd0ae4-b9b2-4776-a58e-dc396e639161">
 <p>
 → list
@@ -4587,8 +4621,8 @@ will be returned as strings with underscores converted to hyphens.
 </div>
 </div>
 
-<div id="outline-container-org8103dfa" class="outline-3">
-<h3 id="5d66ed97-c2b2-4ac5-aede-d6fb70a983c8"><a id="org8103dfa"></a><a id="ID-d911f929-14c6-4279-96e7-a9dfee4d1f59"></a>function list-table-sizes (&amp;key (schema "public") (order-by-size nil) (size t))</h3>
+<div id="outline-container-orga515fea" class="outline-3">
+<h3 id="5d66ed97-c2b2-4ac5-aede-d6fb70a983c8"><a id="orga515fea"></a><a id="ID-d911f929-14c6-4279-96e7-a9dfee4d1f59"></a>function list-table-sizes (&amp;key (schema "public") (order-by-size nil) (size t))</h3>
 <div class="outline-text-3" id="text-5d66ed97-c2b2-4ac5-aede-d6fb70a983c8">
 <p>
 → list
@@ -4607,8 +4641,8 @@ result in order of size instead of by table name.
 </div>
 </div>
 
-<div id="outline-container-org4e43442" class="outline-3">
-<h3 id="55bb44d8-2732-4257-aabd-d38c5e72ef0f"><a id="org4e43442"></a><a id="ID-ece4d92b-dd60-434e-b864-e42c743deaa6"></a>function table-exists-p (name)</h3>
+<div id="outline-container-org310cbec" class="outline-3">
+<h3 id="55bb44d8-2732-4257-aabd-d38c5e72ef0f"><a id="org310cbec"></a><a id="ID-ece4d92b-dd60-434e-b864-e42c743deaa6"></a>function table-exists-p (name)</h3>
 <div class="outline-text-3" id="text-55bb44d8-2732-4257-aabd-d38c5e72ef0f">
 <p>
 → boolean
@@ -4626,8 +4660,8 @@ controlled by being within a with-schema form.
 </div>
 </div>
 
-<div id="outline-container-org5573ac3" class="outline-3">
-<h3 id="bb623170-32c2-43b4-807d-66c34efe9c40"><a id="org5573ac3"></a><a id="ID-bff3f942-2652-401f-9db0-10cc5214191d"></a>function table-size (table-name)</h3>
+<div id="outline-container-org3dfeb9a" class="outline-3">
+<h3 id="bb623170-32c2-43b4-807d-66c34efe9c40"><a id="org3dfeb9a"></a><a id="ID-bff3f942-2652-401f-9db0-10cc5214191d"></a>function table-size (table-name)</h3>
 <div class="outline-text-3" id="text-bb623170-32c2-43b4-807d-66c34efe9c40">
 <p>
 → list
@@ -4640,8 +4674,8 @@ a string or quoted.
 </div>
 </div>
 
-<div id="outline-container-orgd2fed41" class="outline-3">
-<h3 id="ee444ea2-f49f-41c9-905c-177d89770254"><a id="orgd2fed41"></a><a id="ID-45344f09-e8f2-4f82-a0f8-297623478ad8"></a>function table-description (name &amp;optional schema-name)</h3>
+<div id="outline-container-org85f78a1" class="outline-3">
+<h3 id="ee444ea2-f49f-41c9-905c-177d89770254"><a id="org85f78a1"></a><a id="ID-45344f09-e8f2-4f82-a0f8-297623478ad8"></a>function table-description (name &amp;optional schema-name)</h3>
 <div class="outline-text-3" id="text-ee444ea2-f49f-41c9-905c-177d89770254">
 <p>
 → list
@@ -4661,8 +4695,8 @@ is not provided, the table will be assumed to be in the public schema.
 </div>
 </div>
 
-<div id="outline-container-org36ea37b" class="outline-3">
-<h3 id="795b7f54-85ee-4c77-b962-9176f93ad7ac"><a id="org36ea37b"></a><a id="ID-b35cf2c1-7dd0-4676-8f09-2d5679683942"></a>function table-description-plus (table-name)</h3>
+<div id="outline-container-org73d0435" class="outline-3">
+<h3 id="795b7f54-85ee-4c77-b962-9176f93ad7ac"><a id="org73d0435"></a><a id="ID-b35cf2c1-7dd0-4676-8f09-2d5679683942"></a>function table-description-plus (table-name)</h3>
 <div class="outline-text-3" id="text-795b7f54-85ee-4c77-b962-9176f93ad7ac">
 <p>
 → list
@@ -4682,8 +4716,115 @@ is not provided, the table will be assumed to be in the public schema.
 </div>
 </div>
 
-<div id="outline-container-orga0044d5" class="outline-3">
-<h3 id="74baf413-72fb-4f17-abb0-1e7535af33ab"><a id="orga0044d5"></a><a id="ID-c867f758-86e5-4242-a825-a273c86acfd0"></a>function list-columns (table-name)</h3>
+<div id="outline-container-orgc0b234d" class="outline-3">
+<h3 id="orgc0b234d">function table-description-menu (table-name &amp;key char-max-length data-type-length</h3>
+<div class="outline-text-3" id="text-orgc0b234d">
+<p>
+                                            has-default default-value not-null
+                                            numeric-precision numeric-scale
+                                            storage primary primary-key-name
+                                            unique unique-key-name fkey fkey-name
+                                            fkey-col-id fkey-table fkey-local-col-id
+                                            identity generated collation
+                                            col-comments locally-defined inheritance-count
+                                            stat-collection)
+→ list string list
+</p>
+
+<p>
+Takes a fully qualified table name which can be either a string or a symbol.
+</p>
+
+<p>
+Returns three values.
+</p>
+
+<ol class="org-ol">
+<li>A list of plists of each row's parameters. This will always</li>
+</ol>
+<p>
+include :column-name and :data-type-name but all other parameters can be set or unset
+and are set by default (set to t).
+</p>
+
+<ol class="org-ol">
+<li>The comment string attached to the table itself (if any).</li>
+
+<li>A list of the check constraints applied to the rows in the table. See documentation for</li>
+</ol>
+<p>
+list-check-constraints for an example.
+</p>
+
+<p>
+The available keyword parameters are:
+</p>
+
+<ul class="org-ul">
+<li>data-type-length (For a fixed-size type, typlen is the number of bytes in the internal representation of the type. But for a variable-length type, typlen is negative. -1 indicates a “varlena” type (one that has a length word), -2 indicates a null-terminated C string.)</li>
+<li>char-max-length (Typically used for something like a varchar and shows the maximum length)</li>
+<li>has-default (value T if this column has a default value and :NULL if not)</li>
+<li>default-value (value is the default value as string. A default of 9.99 will still be a string)</li>
+<li>not-null (value is T if the column must have a value or :NULL otherwise)</li>
+<li>numeric-precision (value is the total number of digits for a numeric type if that precision was specified)</li>
+<li>numeric-scale (value is the number of digits in the fraction part of a numeric type if that scale was specified)</li>
+<li>storage (value is the storage setting for a column. Result can be plain, extended, main or external)</li>
+<li>primary (value is T if the column is the primary key for the table, :NULL otherwise)</li>
+<li>primary-key-name (value is the name of the primary-key itself, not the column, if the column is the primary key for the table, :NULL otherwise)</li>
+<li>unique (value is T if the column is subject to a unique key, :NULL otherwise)</li>
+<li>unique-key-name (value is the name of the unique-key itself, not the column, applied to the column, :NULL otherwise)</li>
+<li>fkey (value is T if the column is a foreign key, :NULL otherwise)</li>
+<li>fkey-name (value is the name of the foreign key, :NULL otherwise)</li>
+<li>fkey-col-id (value is the column id of the foreign table used as the foreign key. Probably easier to use the Postmodern function list-foreign-keys if you are looking for the name of the columns)</li>
+<li>fkey-table (value is the name of the foreign table, :NULL otherwise)</li>
+<li>fkey-local-col-id (value is the column id of this column. Probably easier to use the Postmodern function list-foreign-keys if you are looking for the name of the columns involved in the foreign key)</li>
+<li>identity (if the column is an identity column, the values can be 'generated always' or 'generated by default'. Otherwise :NULL)</li>
+<li>generated (columns can be generated, if this column is generated and stored on disk, the value will be 'stored', otherwise :NULL)</li>
+<li>collation (columns with collations which are not the default collation for the database will show that collation here, otherwise :NULL)</li>
+<li>col-comments (value is any comment that has been applied to the column, :NULL otherwise)</li>
+<li>locally-defined (value is T if locally defined. It might be both locally defined and inherited)</li>
+<li>inheritance-count (the number of direct ancestors this column has inherited)</li>
+<li>stat-collection (stat-collection returns the value of attstattarget which controls the level of detail of statistics accumulated for this column by ANALYZE. A zero value indicates that no statistics should be collected. A negative value says to use the system default statistics target. The exact meaning of positive values is data type-dependent. For scalar data types, attstattarget is both the target number of most common values to collect, and the target number of histogram bins to create. Attstorage is normally a copy of pg_type.typstorage of this column's type. For TOAST-able data types, this can be altered after column creation to control storage policy.)</li>
+</ul>
+</div>
+</div>
+<div id="outline-container-orgc3abe89" class="outline-3">
+<h3 id="orgc3abe89">function list-check-constraints (table-name)</h3>
+<div class="outline-text-3" id="text-orgc3abe89">
+<p>
+→ list
+</p>
+
+<p>
+Takes a fully qualified table name and returns a list of lists of check constraints
+where each sublist has the form of (check-constraint-name check)
+</p>
+
+<p>
+Example:
+</p>
+
+<div class="org-src-container">
+<pre class="src src-lisp">(query (<span style="color: #98fb98; font-weight: bold;">:create-table</span> 'employees2
+                      ((did <span style="color: #98fb98; font-weight: bold;">:type</span> (or integer db-null)
+                            <span style="color: #98fb98; font-weight: bold;">:primary-key</span> <span style="color: #cd8162;">"generated by default as identity"</span>)
+                       (name <span style="color: #98fb98; font-weight: bold;">:type</span> (varchar 40) <span style="color: #98fb98; font-weight: bold;">:check</span> (<span style="color: #98fb98; font-weight: bold;">:&lt;&gt;</span> 'name <span style="color: #cd8162;">""</span>))
+                       (birth-date <span style="color: #98fb98; font-weight: bold;">:type</span> date <span style="color: #98fb98; font-weight: bold;">:check</span> (<span style="color: #98fb98; font-weight: bold;">:&gt;</span> 'birth-date <span style="color: #cd8162;">"1900-01-01"</span>))
+                       (start-date <span style="color: #98fb98; font-weight: bold;">:type</span> date <span style="color: #98fb98; font-weight: bold;">:check</span> (<span style="color: #98fb98; font-weight: bold;">:&gt;</span> 'start-date 'birth-date))
+                       (salary <span style="color: #98fb98; font-weight: bold;">:type</span> numeric <span style="color: #98fb98; font-weight: bold;">:check</span> (<span style="color: #98fb98; font-weight: bold;">:&gt;</span> 'salary 0)))))
+
+(list-check-constraints 'employees2)
+
+((<span style="color: #cd8162;">"employees2_birth_date_check"</span> <span style="color: #cd8162;">"CHECK (birth_date &gt; '1900-01-01'::date)"</span>)
+ (<span style="color: #cd8162;">"employees2_check"</span> <span style="color: #cd8162;">"CHECK (start_date &gt; birth_date)"</span>)
+ (<span style="color: #cd8162;">"employees2_name_check"</span> <span style="color: #cd8162;">"CHECK (name::text &lt;&gt; ''::text)"</span>)
+ (<span style="color: #cd8162;">"employees2_salary_check"</span> <span style="color: #cd8162;">"CHECK (salary &gt; 0::numeric)"</span>))
+</pre>
+</div>
+</div>
+</div>
+<div id="outline-container-org0178bdb" class="outline-3">
+<h3 id="74baf413-72fb-4f17-abb0-1e7535af33ab"><a id="org0178bdb"></a><a id="ID-c867f758-86e5-4242-a825-a273c86acfd0"></a>function list-columns (table-name)</h3>
 <div class="outline-text-3" id="text-74baf413-72fb-4f17-abb0-1e7535af33ab">
 <p>
 → list
@@ -4698,8 +4839,8 @@ qualified with the schema will be assumed to be in the public schema.
 </div>
 </div>
 
-<div id="outline-container-org4930c27" class="outline-3">
-<h3 id="9ada61bd-a670-49f3-8c04-cf025cde431f"><a id="org4930c27"></a><a id="ID-8dc78de4-32aa-4b28-98c7-02a22ffe036f"></a>function list-columns-with-types (table-name)</h3>
+<div id="outline-container-org61c238f" class="outline-3">
+<h3 id="9ada61bd-a670-49f3-8c04-cf025cde431f"><a id="org61c238f"></a><a id="ID-8dc78de4-32aa-4b28-98c7-02a22ffe036f"></a>function list-columns-with-types (table-name)</h3>
 <div class="outline-text-3" id="text-9ada61bd-a670-49f3-8c04-cf025cde431f">
 <p>
 → list
@@ -4715,8 +4856,8 @@ with the schema will be assumed to be in the public schema.
 </div>
 </div>
 
-<div id="outline-container-orgc023b26" class="outline-3">
-<h3 id="11e937a0-91f6-4475-b393-8f4f2e5d9659"><a id="orgc023b26"></a><a id="ID-491edd0a-7da3-4289-bcea-9482cdfb6df9"></a>function column-exists-p (table-name column-name &amp;optional schema-name)</h3>
+<div id="outline-container-org9bfb917" class="outline-3">
+<h3 id="11e937a0-91f6-4475-b393-8f4f2e5d9659"><a id="org9bfb917"></a><a id="ID-491edd0a-7da3-4289-bcea-9482cdfb6df9"></a>function column-exists-p (table-name column-name &amp;optional schema-name)</h3>
 <div class="outline-text-3" id="text-11e937a0-91f6-4475-b393-8f4f2e5d9659">
 <p>
 → boolean
@@ -4731,8 +4872,8 @@ to be the public schema.
 </div>
 </div>
 
-<div id="outline-container-org2ae32b3" class="outline-3">
-<h3 id="8ab55683-e44b-44df-bb11-67909d402383"><a id="org2ae32b3"></a>function get-table-oid (table-name &amp;optional schema-name)</h3>
+<div id="outline-container-orgef668b2" class="outline-3">
+<h3 id="8ab55683-e44b-44df-bb11-67909d402383"><a id="orgef668b2"></a>function get-table-oid (table-name &amp;optional schema-name)</h3>
 <div class="outline-text-3" id="text-8ab55683-e44b-44df-bb11-67909d402383">
 <p>
 → integer
@@ -4744,21 +4885,35 @@ for tables in all schemas.
 </p>
 </div>
 </div>
-<div id="outline-container-orgde7365d" class="outline-3">
-<h3 id="e8d6e402-5c76-4533-9b5c-a823b9582c26"><a id="orgde7365d"></a>function get-table-comment (table-name &amp;optional schema-name)</h3>
+<div id="outline-container-org2af7eec" class="outline-3">
+<h3 id="e8d6e402-5c76-4533-9b5c-a823b9582c26"><a id="org2af7eec"></a>function get-table-comment (table-name &amp;optional schema-name)</h3>
 <div class="outline-text-3" id="text-e8d6e402-5c76-4533-9b5c-a823b9582c26">
 <p>
 → string
 </p>
 
 <p>
-Retrieves the comment, if any attached to the table.
+Retrieves the comment, if any attached to the table. See also get-schema-comment,
+get-column-comments and get-database-comment
 </p>
 </div>
 </div>
-<div id="outline-container-org8f67d37" class="outline-3">
-<h3 id="org8f67d37">function rename-table (old-name new-name)</h3>
-<div class="outline-text-3" id="text-org8f67d37">
+<div id="outline-container-org81e00a6" class="outline-3">
+<h3 id="e8d6e402-5c76-4533-9b5c-a823b9582c26"><a id="org81e00a6"></a>function get-column-comments (database schema table)</h3>
+<div class="outline-text-3" id="text-e8d6e402-5c76-4533-9b5c-a823b9582c26">
+<p>
+→ string
+</p>
+
+<p>
+Retrieves a list of lists of column names and the comments, if any, attached
+to the columns of a table.
+</p>
+</div>
+</div>
+<div id="outline-container-orgede774c" class="outline-3">
+<h3 id="orgede774c">function rename-table (old-name new-name)</h3>
+<div class="outline-text-3" id="text-orgede774c">
 <p>
 → boolean
 </p>
@@ -4772,9 +4927,9 @@ tables from one schema to another. Returns t if successful
 </div>
 </div>
 
-<div id="outline-container-org0ca0bf5" class="outline-3">
-<h3 id="org0ca0bf5">function rename-column (table-name old-name new-name)</h3>
-<div class="outline-text-3" id="text-org0ca0bf5">
+<div id="outline-container-orgb61ef23" class="outline-3">
+<h3 id="orgb61ef23">function rename-column (table-name old-name new-name)</h3>
+<div class="outline-text-3" id="text-orgb61ef23">
 <p>
 → boolean
 </p>
@@ -4787,12 +4942,12 @@ Returns t if successful
 </div>
 </div>
 </div>
-<div id="outline-container-org4dfcafd" class="outline-2">
-<h2 id="tablespaces"><a id="org4dfcafd"></a><a id="ID-1772a1eb-bc79-4c5f-90d5-2fc10ae49569"></a>Tablespaces</h2>
+<div id="outline-container-orgc92e65f" class="outline-2">
+<h2 id="tablespaces"><a id="orgc92e65f"></a><a id="ID-1772a1eb-bc79-4c5f-90d5-2fc10ae49569"></a>Tablespaces</h2>
 <div class="outline-text-2" id="text-tablespaces">
 </div>
-<div id="outline-container-org46f6a42" class="outline-3">
-<h3 id="70537823-781b-47dd-8c38-9936756c666c"><a id="org46f6a42"></a><a id="ID-44a29c6a-0002-4660-920f-a9fee4c29471"></a>function list-tablespaces ()</h3>
+<div id="outline-container-org7f51bde" class="outline-3">
+<h3 id="70537823-781b-47dd-8c38-9936756c666c"><a id="org7f51bde"></a><a id="ID-44a29c6a-0002-4660-920f-a9fee4c29471"></a>function list-tablespaces ()</h3>
 <div class="outline-text-3" id="text-70537823-781b-47dd-8c38-9936756c666c">
 <p>
 → list
@@ -4828,12 +4983,12 @@ expensive, slower disk system.
 </div>
 </div>
 
-<div id="outline-container-orgf1e5af7" class="outline-2">
-<h2 id="triggers"><a id="orgf1e5af7"></a><a id="ID-39786cca-6778-4f0b-9187-1f3216b97cda"></a>Triggers</h2>
+<div id="outline-container-orgcfd7eed" class="outline-2">
+<h2 id="triggers"><a id="orgcfd7eed"></a><a id="ID-39786cca-6778-4f0b-9187-1f3216b97cda"></a>Triggers</h2>
 <div class="outline-text-2" id="text-triggers">
 </div>
-<div id="outline-container-org7eebec8" class="outline-3">
-<h3 id="7327ab9a-b79e-4180-8165-434fd4c8d383"><a id="org7eebec8"></a><a id="ID-10c51511-c1e4-4710-8407-3508fb96333e"></a>function describe-triggers ()</h3>
+<div id="outline-container-org9dfde3f" class="outline-3">
+<h3 id="7327ab9a-b79e-4180-8165-434fd4c8d383"><a id="org9dfde3f"></a><a id="ID-10c51511-c1e4-4710-8407-3508fb96333e"></a>function describe-triggers ()</h3>
 <div class="outline-text-3" id="text-7327ab9a-b79e-4180-8165-434fd4c8d383">
 <p>
 → list
@@ -4844,8 +4999,8 @@ List detailed information on the triggers from the information_schema table.
 </p>
 </div>
 </div>
-<div id="outline-container-org26faf59" class="outline-3">
-<h3 id="3bcdabed-dd01-4457-bc18-284598aee0a4"><a id="org26faf59"></a><a id="ID-68de46b8-a646-4c1d-9362-747ab1d6cc04"></a>function list-triggers (&amp;optional table-name)</h3>
+<div id="outline-container-org0f4300b" class="outline-3">
+<h3 id="3bcdabed-dd01-4457-bc18-284598aee0a4"><a id="org0f4300b"></a><a id="ID-68de46b8-a646-4c1d-9362-747ab1d6cc04"></a>function list-triggers (&amp;optional table-name)</h3>
 <div class="outline-text-3" id="text-3bcdabed-dd01-4457-bc18-284598aee0a4">
 <p>
 → list
@@ -4862,8 +5017,8 @@ See <a href="https://www.postgresql.org/docs/current/trigger-definition.html">ht
 </div>
 </div>
 
-<div id="outline-container-orgd8d195a" class="outline-3">
-<h3 id="fc3761c2-fc2e-42e4-86f2-0e918c891b5e"><a id="orgd8d195a"></a><a id="ID-10c51511-c1e4-4710-8407-3508fb96333e"></a>function list-detailed-triggers ()</h3>
+<div id="outline-container-org0d2b75d" class="outline-3">
+<h3 id="fc3761c2-fc2e-42e4-86f2-0e918c891b5e"><a id="org0d2b75d"></a><a id="ID-10c51511-c1e4-4710-8407-3508fb96333e"></a>function list-detailed-triggers ()</h3>
 <div class="outline-text-3" id="text-fc3761c2-fc2e-42e4-86f2-0e918c891b5e">
 <p>
 → list
@@ -4872,12 +5027,12 @@ See <a href="https://www.postgresql.org/docs/current/trigger-definition.html">ht
 </div>
 </div>
 
-<div id="outline-container-orgf3a1c78" class="outline-2">
-<h2 id="views"><a id="orgf3a1c78"></a><a id="ID-a9641e8e-3769-4af4-bdd0-3153e0dd7728"></a>Views</h2>
+<div id="outline-container-org31c0e87" class="outline-2">
+<h2 id="views"><a id="org31c0e87"></a><a id="ID-a9641e8e-3769-4af4-bdd0-3153e0dd7728"></a>Views</h2>
 <div class="outline-text-2" id="text-views">
 </div>
-<div id="outline-container-org7bebe64" class="outline-3">
-<h3 id="4fd820d9-857e-48fa-a62b-e2d72313a10c"><a id="org7bebe64"></a><a id="ID-9e9e757e-9efa-4445-9fe1-b66e78f025a8"></a>function list-views (&amp;optional strings-p)</h3>
+<div id="outline-container-org29e4bbb" class="outline-3">
+<h3 id="4fd820d9-857e-48fa-a62b-e2d72313a10c"><a id="org29e4bbb"></a><a id="ID-9e9e757e-9efa-4445-9fe1-b66e78f025a8"></a>function list-views (&amp;optional strings-p)</h3>
 <div class="outline-text-3" id="text-4fd820d9-857e-48fa-a62b-e2d72313a10c">
 <p>
 → list
@@ -4890,8 +5045,8 @@ is T, the names will be returned as strings, otherwise as keywords.
 </div>
 </div>
 
-<div id="outline-container-org2a8c48a" class="outline-3">
-<h3 id="f9ba3cce-95e0-45a0-9ede-5654bb71e98e"><a id="org2a8c48a"></a><a id="ID-24cd0fc5-8fb0-4b57-9504-71d9520abf6f"></a>function view-exists-p (name)</h3>
+<div id="outline-container-org5f0c670" class="outline-3">
+<h3 id="f9ba3cce-95e0-45a0-9ede-5654bb71e98e"><a id="org5f0c670"></a><a id="ID-24cd0fc5-8fb0-4b57-9504-71d9520abf6f"></a>function view-exists-p (name)</h3>
 <div class="outline-text-3" id="text-f9ba3cce-95e0-45a0-9ede-5654bb71e98e">
 <p>
 → boolean
@@ -4904,8 +5059,8 @@ symbol for the view name.
 </div>
 </div>
 
-<div id="outline-container-org5154c50" class="outline-3">
-<h3 id="bbf87da5-981c-42ad-b97e-38c7fafbf8ca"><a id="org5154c50"></a><a id="ID-51f383ba-fe58-4a5f-bf31-ac79b18170b7"></a>function describe-views (&amp;optional (schema "public")</h3>
+<div id="outline-container-org9dd6c1c" class="outline-3">
+<h3 id="bbf87da5-981c-42ad-b97e-38c7fafbf8ca"><a id="org9dd6c1c"></a><a id="ID-51f383ba-fe58-4a5f-bf31-ac79b18170b7"></a>function describe-views (&amp;optional (schema "public")</h3>
 <div class="outline-text-3" id="text-bbf87da5-981c-42ad-b97e-38c7fafbf8ca">
 <p>
 → list
@@ -4920,12 +5075,12 @@ public schema.
 </div>
 </div>
 
-<div id="outline-container-org19d116e" class="outline-2">
-<h2 id="misc-utility-functions"><a id="org19d116e"></a><a id="ID-73c18602-c501-4399-ac07-cab915309777"></a>Miscellaneous Utility Functions</h2>
+<div id="outline-container-org87e93af" class="outline-2">
+<h2 id="misc-utility-functions"><a id="org87e93af"></a><a id="ID-73c18602-c501-4399-ac07-cab915309777"></a>Miscellaneous Utility Functions</h2>
 <div class="outline-text-2" id="text-misc-utility-functions">
 </div>
-<div id="outline-container-org1c5813f" class="outline-3">
-<h3 id="9e576b29-c33d-425d-8759-e8e5e8367593"><a id="org1c5813f"></a><a id="ID-1df6bd25-618b-4a00-8ec2-cc5b0548b045"></a>function coalesce (&amp;rest arguments)</h3>
+<div id="outline-container-org49b431b" class="outline-3">
+<h3 id="9e576b29-c33d-425d-8759-e8e5e8367593"><a id="org49b431b"></a><a id="ID-1df6bd25-618b-4a00-8ec2-cc5b0548b045"></a>function coalesce (&amp;rest arguments)</h3>
 <div class="outline-text-3" id="text-9e576b29-c33d-425d-8759-e8e5e8367593">
 <p>
 → value
@@ -4939,8 +5094,8 @@ when given only one argument, for transforming :nulls to NIL.
 </div>
 </div>
 
-<div id="outline-container-orgeb6258f" class="outline-3">
-<h3 id="441f2929-9c04-4b01-8b85-7c474e200755"><a id="orgeb6258f"></a><a id="ID-37df40a0-86b4-4aef-828e-68663f74927e"></a>function execute-file (filename &amp;optional (print nil))</h3>
+<div id="outline-container-org183c8c9" class="outline-3">
+<h3 id="441f2929-9c04-4b01-8b85-7c474e200755"><a id="org183c8c9"></a><a id="ID-37df40a0-86b4-4aef-828e-68663f74927e"></a>function execute-file (filename &amp;optional (print nil))</h3>
 <div class="outline-text-3" id="text-441f2929-9c04-4b01-8b85-7c474e200755">
 <p>
 This function will execute sql queries stored in a file. Each sql statement in
@@ -4968,8 +5123,8 @@ queries.
 </p>
 </div>
 </div>
-<div id="outline-container-org6d114da" class="outline-3">
-<h3 id="fcf022af-ae93-470d-be11-23a25acf0bb9"><a id="org6d114da"></a>function num-records-in-database ()</h3>
+<div id="outline-container-org56bd5f2" class="outline-3">
+<h3 id="fcf022af-ae93-470d-be11-23a25acf0bb9"><a id="org56bd5f2"></a>function num-records-in-database ()</h3>
 <div class="outline-text-3" id="text-fcf022af-ae93-470d-be11-23a25acf0bb9">
 <p>
 → list
@@ -4981,8 +5136,8 @@ records in the currently connected database.
 </p>
 </div>
 </div>
-<div id="outline-container-org00b8c99" class="outline-3">
-<h3 id="1870a515-3f02-45c6-b42c-97659580f257"><a id="org00b8c99"></a>function postgres-array-string-to-list (str)</h3>
+<div id="outline-container-org5a78c07" class="outline-3">
+<h3 id="1870a515-3f02-45c6-b42c-97659580f257"><a id="org5a78c07"></a>function postgres-array-string-to-list (str)</h3>
 <div class="outline-text-3" id="text-1870a515-3f02-45c6-b42c-97659580f257">
 <p>
 → array
@@ -4995,8 +5150,8 @@ Takes a postgresql array in the form of a string like
 </p>
 </div>
 </div>
-<div id="outline-container-org27e7a1c" class="outline-3">
-<h3 id="6fa88adf-cd17-40a8-beb2-0ecea529f6db"><a id="org27e7a1c"></a>function postgres-array-string-to-array (str)</h3>
+<div id="outline-container-orgb009d3a" class="outline-3">
+<h3 id="6fa88adf-cd17-40a8-beb2-0ecea529f6db"><a id="orgb009d3a"></a>function postgres-array-string-to-array (str)</h3>
 <div class="outline-text-3" id="text-6fa88adf-cd17-40a8-beb2-0ecea529f6db">
 <p>
   "Takes a postgresql array in the form of a string like
@@ -5006,12 +5161,12 @@ Takes a postgresql array in the form of a string like
 </div>
 </div>
 </div>
-<div id="outline-container-org7ab96b2" class="outline-2">
-<h2 id="b9ec79c0-8e2e-4bad-adcd-e8aa9b6c9a27"><a id="org7ab96b2"></a><a id="ID-cd3d88e6-1e81-4675-bd17-409efdc39730"></a>Imported From s-sql</h2>
+<div id="outline-container-orgc4d309e" class="outline-2">
+<h2 id="b9ec79c0-8e2e-4bad-adcd-e8aa9b6c9a27"><a id="orgc4d309e"></a><a id="ID-cd3d88e6-1e81-4675-bd17-409efdc39730"></a>Imported From s-sql</h2>
 <div class="outline-text-2" id="text-b9ec79c0-8e2e-4bad-adcd-e8aa9b6c9a27">
 </div>
-<div id="outline-container-orga3947f3" class="outline-3">
-<h3 id="8c74e736-6b4f-4996-88c4-f087f46cff05"><a id="orga3947f3"></a><a id="ID-9de76637-62f7-4c7c-a5d1-1f37491b3db3"></a>macro sql (form)</h3>
+<div id="outline-container-orgfe2b452" class="outline-3">
+<h3 id="8c74e736-6b4f-4996-88c4-f087f46cff05"><a id="orgfe2b452"></a><a id="ID-9de76637-62f7-4c7c-a5d1-1f37491b3db3"></a>macro sql (form)</h3>
 <div class="outline-text-3" id="text-8c74e736-6b4f-4996-88c4-f087f46cff05">
 <p>
 → string
@@ -5041,8 +5196,8 @@ would throw an error. For the later case you need to use sql-compile.
 </div>
 </div>
 
-<div id="outline-container-org5ec34ca" class="outline-3">
-<h3 id="ace3cbb6-04f0-435b-b2d9-55e2612ea01b"><a id="org5ec34ca"></a><a id="ID-8d161d2a-06cb-4334-9ee6-86e805eb5295"></a>function sql-compile (form)</h3>
+<div id="outline-container-orgef4b91d" class="outline-3">
+<h3 id="ace3cbb6-04f0-435b-b2d9-55e2612ea01b"><a id="orgef4b91d"></a><a id="ID-8d161d2a-06cb-4334-9ee6-86e805eb5295"></a>function sql-compile (form)</h3>
 <div class="outline-text-3" id="text-ace3cbb6-04f0-435b-b2d9-55e2612ea01b">
 <p>
 → string
@@ -5073,24 +5228,24 @@ would throw an error. For the later case you need to use sql.
 </div>
 </div>
 
-<div id="outline-container-org228c246" class="outline-3">
-<h3 id="55a205bf-c9f4-450c-aa86-45cce006ee79"><a id="org228c246"></a><a id="ID-3b558b7d-532c-4375-a80a-4526112ae132"></a>deftype smallint ()</h3>
+<div id="outline-container-orgbc567a7" class="outline-3">
+<h3 id="55a205bf-c9f4-450c-aa86-45cce006ee79"><a id="orgbc567a7"></a><a id="ID-3b558b7d-532c-4375-a80a-4526112ae132"></a>deftype smallint ()</h3>
 <div class="outline-text-3" id="text-55a205bf-c9f4-450c-aa86-45cce006ee79">
 <p>
 '(signed-byte 16)
 </p>
 </div>
 </div>
-<div id="outline-container-org55018a2" class="outline-3">
-<h3 id="80a15f41-d550-4f3b-adc5-4558d3ddf166"><a id="org55018a2"></a><a id="ID-d5d5048e-f212-4b5a-ae63-c18d2a411279"></a>deftype bigint ()</h3>
+<div id="outline-container-org2dae424" class="outline-3">
+<h3 id="80a15f41-d550-4f3b-adc5-4558d3ddf166"><a id="org2dae424"></a><a id="ID-d5d5048e-f212-4b5a-ae63-c18d2a411279"></a>deftype bigint ()</h3>
 <div class="outline-text-3" id="text-80a15f41-d550-4f3b-adc5-4558d3ddf166">
 <p>
 '(signed-byte 64)
 </p>
 </div>
 </div>
-<div id="outline-container-orgf68eb86" class="outline-3">
-<h3 id="4a38ba2c-b03b-4887-905b-1bf85cd3f607"><a id="orgf68eb86"></a><a id="ID-4eb58260-f8e3-4562-bfff-17211cdd98da"></a>deftype numeric (&amp;optional precision/scale scale)</h3>
+<div id="outline-container-orgd398ee4" class="outline-3">
+<h3 id="4a38ba2c-b03b-4887-905b-1bf85cd3f607"><a id="orgd398ee4"></a><a id="ID-4eb58260-f8e3-4562-bfff-17211cdd98da"></a>deftype numeric (&amp;optional precision/scale scale)</h3>
 <div class="outline-text-3" id="text-4a38ba2c-b03b-4887-905b-1bf85cd3f607">
 <p>
 (declare (ignore precision/scale scale))
@@ -5098,32 +5253,32 @@ would throw an error. For the later case you need to use sql.
 </p>
 </div>
 </div>
-<div id="outline-container-org05d42df" class="outline-3">
-<h3 id="8e094b66-fcc0-4f6e-91dd-5f3c63a7e8a0"><a id="org05d42df"></a><a id="ID-b4ec051b-d257-47c6-9876-25aec64f967a"></a>deftype double-precision ()</h3>
+<div id="outline-container-orgcdaa7df" class="outline-3">
+<h3 id="8e094b66-fcc0-4f6e-91dd-5f3c63a7e8a0"><a id="orgcdaa7df"></a><a id="ID-b4ec051b-d257-47c6-9876-25aec64f967a"></a>deftype double-precision ()</h3>
 <div class="outline-text-3" id="text-8e094b66-fcc0-4f6e-91dd-5f3c63a7e8a0">
 <p>
 'double-float
 </p>
 </div>
 </div>
-<div id="outline-container-orgc2a0ad0" class="outline-3">
-<h3 id="f4e4e8ac-2d8c-4dea-991f-af57fa589932"><a id="orgc2a0ad0"></a><a id="ID-2532e5a0-cbb5-490a-b142-e971ad0730f7"></a>deftype bytea ()</h3>
+<div id="outline-container-orgb08588f" class="outline-3">
+<h3 id="f4e4e8ac-2d8c-4dea-991f-af57fa589932"><a id="orgb08588f"></a><a id="ID-2532e5a0-cbb5-490a-b142-e971ad0730f7"></a>deftype bytea ()</h3>
 <div class="outline-text-3" id="text-f4e4e8ac-2d8c-4dea-991f-af57fa589932">
 <p>
 '(array (unsigned-byte 8))
 </p>
 </div>
 </div>
-<div id="outline-container-orga45d87e" class="outline-3">
-<h3 id="a18ec054-2fcb-482f-bda5-988ab94e9763"><a id="orga45d87e"></a><a id="ID-d2867c78-0b66-4b45-882e-115a1192de11"></a>deftype text ()</h3>
+<div id="outline-container-org0260aeb" class="outline-3">
+<h3 id="a18ec054-2fcb-482f-bda5-988ab94e9763"><a id="org0260aeb"></a><a id="ID-d2867c78-0b66-4b45-882e-115a1192de11"></a>deftype text ()</h3>
 <div class="outline-text-3" id="text-a18ec054-2fcb-482f-bda5-988ab94e9763">
 <p>
 'string
 </p>
 </div>
 </div>
-<div id="outline-container-org8974aa3" class="outline-3">
-<h3 id="d4aa0266-7d2d-4207-909f-8b5767be03fd"><a id="org8974aa3"></a><a id="ID-eecec060-840e-42c3-9b6e-74789b19f3ac"></a>deftype varchar (length)</h3>
+<div id="outline-container-orge77ec2b" class="outline-3">
+<h3 id="d4aa0266-7d2d-4207-909f-8b5767be03fd"><a id="orge77ec2b"></a><a id="ID-eecec060-840e-42c3-9b6e-74789b19f3ac"></a>deftype varchar (length)</h3>
 <div class="outline-text-3" id="text-d4aa0266-7d2d-4207-909f-8b5767be03fd">
 <p>
 (declare (ignore length))
@@ -5131,16 +5286,16 @@ would throw an error. For the later case you need to use sql.
 </p>
 </div>
 </div>
-<div id="outline-container-orgaf2aa3b" class="outline-3">
-<h3 id="20cabfe5-d425-422d-a91a-06e7c4cf0a30"><a id="orgaf2aa3b"></a><a id="ID-cc755c1e-af5f-4958-9e18-7b47831cd786"></a>deftype serial ()</h3>
+<div id="outline-container-orgcf0db71" class="outline-3">
+<h3 id="20cabfe5-d425-422d-a91a-06e7c4cf0a30"><a id="orgcf0db71"></a><a id="ID-cc755c1e-af5f-4958-9e18-7b47831cd786"></a>deftype serial ()</h3>
 <div class="outline-text-3" id="text-20cabfe5-d425-422d-a91a-06e7c4cf0a30">
 <p>
 'integer
 </p>
 </div>
 </div>
-<div id="outline-container-orgb4d6128" class="outline-3">
-<h3 id="15d4e630-03c8-4fe0-9b1e-b42a2b42910b"><a id="orgb4d6128"></a><a id="ID-db403045-9608-45f9-8f17-aa3dd951d614"></a>deftype serial8 ()</h3>
+<div id="outline-container-orgc212c51" class="outline-3">
+<h3 id="15d4e630-03c8-4fe0-9b1e-b42a2b42910b"><a id="orgc212c51"></a><a id="ID-db403045-9608-45f9-8f17-aa3dd951d614"></a>deftype serial8 ()</h3>
 <div class="outline-text-3" id="text-15d4e630-03c8-4fe0-9b1e-b42a2b42910b">
 <p>
 'integer
@@ -5148,8 +5303,8 @@ would throw an error. For the later case you need to use sql.
 </div>
 </div>
 
-<div id="outline-container-orgd73ae3d" class="outline-3">
-<h3 id="f862411e-45cb-4f24-9caa-15edbe804999"><a id="orgd73ae3d"></a><a id="ID-fb204ed8-0ac7-4c74-ad47-ff9e95b75561"></a>deftype db-null ()</h3>
+<div id="outline-container-org70cbed2" class="outline-3">
+<h3 id="f862411e-45cb-4f24-9caa-15edbe804999"><a id="org70cbed2"></a><a id="ID-fb204ed8-0ac7-4c74-ad47-ff9e95b75561"></a>deftype db-null ()</h3>
 <div class="outline-text-3" id="text-f862411e-45cb-4f24-9caa-15edbe804999">
 <p>
 Type for representing NULL values. Use like (or integer db-null) for declaring a
@@ -5159,16 +5314,16 @@ type to be an integer that may be null."
 </div>
 </div>
 
-<div id="outline-container-orgf63de22" class="outline-3">
-<h3 id="24878142-d801-4fb0-b58b-b59454ee414d"><a id="orgf63de22"></a><a id="ID-408c0a66-6772-4999-8759-bebeee43646c"></a>function from-sql-name (str)</h3>
+<div id="outline-container-org49d36f4" class="outline-3">
+<h3 id="24878142-d801-4fb0-b58b-b59454ee414d"><a id="org49d36f4"></a><a id="ID-408c0a66-6772-4999-8759-bebeee43646c"></a>function from-sql-name (str)</h3>
 <div class="outline-text-3" id="text-24878142-d801-4fb0-b58b-b59454ee414d">
 <p>
 Convert a string to a symbol, upcasing and replacing underscores with hyphens.
 </p>
 </div>
 </div>
-<div id="outline-container-orgb58c073" class="outline-3">
-<h3 id="0205cc17-d05d-4ac1-96eb-1c2431e948c8"><a id="orgb58c073"></a><a id="ID-d9c23921-9839-422d-aeea-df8bfc11df47"></a>function parse-queries (file-content)</h3>
+<div id="outline-container-org88f68d5" class="outline-3">
+<h3 id="0205cc17-d05d-4ac1-96eb-1c2431e948c8"><a id="org88f68d5"></a><a id="ID-d9c23921-9839-422d-aeea-df8bfc11df47"></a>function parse-queries (file-content)</h3>
 <div class="outline-text-3" id="text-0205cc17-d05d-4ac1-96eb-1c2431e948c8">
 <p>
 → list
@@ -5179,16 +5334,16 @@ Read SQL queries in given string and split them, returns a list.
 </p>
 </div>
 </div>
-<div id="outline-container-orgfd3e38b" class="outline-3">
-<h3 id="de3bb099-ed34-423a-9bcd-535e1a5f588b"><a id="orgfd3e38b"></a><a id="ID-b871c68d-2b31-444d-8c2d-9d7093fef956"></a>function read-queries (filename)</h3>
+<div id="outline-container-org41f69c8" class="outline-3">
+<h3 id="de3bb099-ed34-423a-9bcd-535e1a5f588b"><a id="org41f69c8"></a><a id="ID-b871c68d-2b31-444d-8c2d-9d7093fef956"></a>function read-queries (filename)</h3>
 <div class="outline-text-3" id="text-de3bb099-ed34-423a-9bcd-535e1a5f588b">
 <p>
 Read SQL queries in a given file and split them, returns a list.
 </p>
 </div>
 </div>
-<div id="outline-container-orgfe43df8" class="outline-3">
-<h3 id="a6245312-f133-481b-8aed-2bd7c4d4b972"><a id="orgfe43df8"></a><a id="ID-02edac61-f915-4d5f-b52e-d4b7ace29352"></a>function sql-escape-string (string)</h3>
+<div id="outline-container-org82b5675" class="outline-3">
+<h3 id="a6245312-f133-481b-8aed-2bd7c4d4b972"><a id="org82b5675"></a><a id="ID-02edac61-f915-4d5f-b52e-d4b7ace29352"></a>function sql-escape-string (string)</h3>
 <div class="outline-text-3" id="text-a6245312-f133-481b-8aed-2bd7c4d4b972">
 <p>
 → string
@@ -5208,8 +5363,8 @@ Read SQL queries in a given file and split them, returns a list.
 </div>
 
 
-<div id="outline-container-org04b3d18" class="outline-3">
-<h3 id="73012d8f-1e5d-4518-8df8-368a4fae3441"><a id="org04b3d18"></a><a id="ID-8b533d2c-53ec-4f34-b19a-fd68bbef9384"></a>method sql-escape (arg)</h3>
+<div id="outline-container-org4ef71d3" class="outline-3">
+<h3 id="73012d8f-1e5d-4518-8df8-368a4fae3441"><a id="org4ef71d3"></a><a id="ID-8b533d2c-53ec-4f34-b19a-fd68bbef9384"></a>method sql-escape (arg)</h3>
 <div class="outline-text-3" id="text-73012d8f-1e5d-4518-8df8-368a4fae3441">
 <p>
 A generalisation of sql-escape-string looks at the type of the value passed, and
@@ -5232,8 +5387,8 @@ converted to SQL names. Examples:
 </div>
 </div>
 </div>
-<div id="outline-container-orgb65733b" class="outline-3">
-<h3 id="1723409d-0013-459a-a89c-236d1c7f2fb5"><a id="orgb65733b"></a>macro register-sql-operators (arity &amp;rest names)</h3>
+<div id="outline-container-org6031dee" class="outline-3">
+<h3 id="1723409d-0013-459a-a89c-236d1c7f2fb5"><a id="org6031dee"></a>macro register-sql-operators (arity &amp;rest names)</h3>
 <div class="outline-text-3" id="text-1723409d-0013-459a-a89c-236d1c7f2fb5">
 <p>
 Define simple operators. Arity is one of :unary (like
@@ -5248,8 +5403,8 @@ string.
 </p>
 </div>
 </div>
-<div id="outline-container-orge8efca5" class="outline-3">
-<h3 id="678a9397-e784-42bf-ba21-7d1d8a5816e2"><a id="orge8efca5"></a><a id="ID-fc3763af-74e4-44ed-903e-7c32be128bd3"></a>variable <b>escape-sql-names-p</b></h3>
+<div id="outline-container-orgddddce4" class="outline-3">
+<h3 id="678a9397-e784-42bf-ba21-7d1d8a5816e2"><a id="orgddddce4"></a><a id="ID-fc3763af-74e4-44ed-903e-7c32be128bd3"></a>variable <b>escape-sql-names-p</b></h3>
 <div class="outline-text-3" id="text-678a9397-e784-42bf-ba21-7d1d8a5816e2">
 <p>
 Determines whether double quotes are added around column, table, and ** function
@@ -5279,8 +5434,8 @@ downcase unquoted identifiers. This will be revisited in the future if requested
 </div>
 </div>
 
-<div id="outline-container-org8fff1b1" class="outline-3">
-<h3 id="3cbda7a6-974c-475d-a87c-90353ac15b75"><a id="org8fff1b1"></a><a id="ID-1b4f5a57-87f7-42f5-ae3c-eff5b41122b3"></a>function to-sql-name (name &amp;optional (escape-p <b>escape-sql-names-p</b>) (ignore-reserved-words nil))</h3>
+<div id="outline-container-orgc58a6df" class="outline-3">
+<h3 id="3cbda7a6-974c-475d-a87c-90353ac15b75"><a id="orgc58a6df"></a><a id="ID-1b4f5a57-87f7-42f5-ae3c-eff5b41122b3"></a>function to-sql-name (name &amp;optional (escape-p <b>escape-sql-names-p</b>) (ignore-reserved-words nil))</h3>
 <div class="outline-text-3" id="text-3cbda7a6-974c-475d-a87c-90353ac15b75">
 <p>
 Convert a symbol or string into a name that can be a sql table, column, or
@@ -5299,8 +5454,8 @@ to be reserved words, but it is not recommended.
 </div>
 </div>
 
-<div id="outline-container-org9431d97" class="outline-3">
-<h3 id="2970d836-dcaa-4b49-aa95-27aa9d3d4f3f"><a id="org9431d97"></a><a id="ID-800c314e-4ff7-435e-84ea-fe6d3ec71353"></a>condition sql-error</h3>
+<div id="outline-container-org08b834c" class="outline-3">
+<h3 id="2970d836-dcaa-4b49-aa95-27aa9d3d4f3f"><a id="org08b834c"></a><a id="ID-800c314e-4ff7-435e-84ea-fe6d3ec71353"></a>condition sql-error</h3>
 <div class="outline-text-3" id="text-2970d836-dcaa-4b49-aa95-27aa9d3d4f3f">
 <p>
 No documentation provided.
@@ -5310,12 +5465,12 @@ No documentation provided.
 </div>
 
 
-<div id="outline-container-org2d802f1" class="outline-2">
-<h2 id="5ccb5ff2-0d42-48d4-90c0-2ef6e7f8f1c7"><a id="org2d802f1"></a><a id="ID-800ef5ef-fa19-428d-83b9-f38581e38d09"></a>Conditions Imported From cl-postgres</h2>
+<div id="outline-container-org43f3e72" class="outline-2">
+<h2 id="5ccb5ff2-0d42-48d4-90c0-2ef6e7f8f1c7"><a id="org43f3e72"></a><a id="ID-800ef5ef-fa19-428d-83b9-f38581e38d09"></a>Conditions Imported From cl-postgres</h2>
 <div class="outline-text-2" id="text-5ccb5ff2-0d42-48d4-90c0-2ef6e7f8f1c7">
 </div>
-<div id="outline-container-orge6c4ef0" class="outline-3">
-<h3 id="b16b281c-2103-4f65-bb48-d9ac0083a302"><a id="orge6c4ef0"></a><a id="ID-5d0fdf49-8efa-4e7e-8b9d-925cb19630e1"></a>condition database-connection-error</h3>
+<div id="outline-container-org2aa6cda" class="outline-3">
+<h3 id="b16b281c-2103-4f65-bb48-d9ac0083a302"><a id="org2aa6cda"></a><a id="ID-5d0fdf49-8efa-4e7e-8b9d-925cb19630e1"></a>condition database-connection-error</h3>
 <div class="outline-text-3" id="text-b16b281c-2103-4f65-bb48-d9ac0083a302">
 <p>
 Conditions of this type are signalled when an error occurs that breaks the
@@ -5324,8 +5479,8 @@ connection socket. They offer a :reconnect restart.
 </div>
 </div>
 
-<div id="outline-container-org12c0d92" class="outline-3">
-<h3 id="06f35002-f176-4bae-b9cc-271b8b3b2cf1"><a id="org12c0d92"></a><a id="ID-0ce0752e-d58b-4072-9de1-8c791ab627d0"></a>condition database-error</h3>
+<div id="outline-container-orgb9259be" class="outline-3">
+<h3 id="06f35002-f176-4bae-b9cc-271b8b3b2cf1"><a id="orgb9259be"></a><a id="ID-0ce0752e-d58b-4072-9de1-8c791ab627d0"></a>condition database-error</h3>
 <div class="outline-text-3" id="text-06f35002-f176-4bae-b9cc-271b8b3b2cf1">
 <p>
 This is the condition type that will be used to signal virtually all
@@ -5333,8 +5488,8 @@ database-related errors (though in some cases socket errors may be raised when
 a connection fails on the IP level).
 </p>
 </div>
-<div id="outline-container-orgc04aa05" class="outline-4">
-<h4 id="15654c72-6edc-4fec-8526-d15dbfda6e44"><a id="orgc04aa05"></a>reader database-error-code</h4>
+<div id="outline-container-org6c0a456" class="outline-4">
+<h4 id="15654c72-6edc-4fec-8526-d15dbfda6e44"><a id="org6c0a456"></a>reader database-error-code</h4>
 <div class="outline-text-4" id="text-15654c72-6edc-4fec-8526-d15dbfda6e44">
 <p>
 Code: the Postgresql SQLSTATE code for the error
@@ -5344,8 +5499,8 @@ Code: the Postgresql SQLSTATE code for the error
 </div>
 </div>
 
-<div id="outline-container-org2232643" class="outline-4">
-<h4 id="94776637-29c8-4966-9105-c00e13c1ec1d"><a id="org2232643"></a>accessor database-error-message</h4>
+<div id="outline-container-org2bfe7b0" class="outline-4">
+<h4 id="94776637-29c8-4966-9105-c00e13c1ec1d"><a id="org2bfe7b0"></a>accessor database-error-message</h4>
 <div class="outline-text-4" id="text-94776637-29c8-4966-9105-c00e13c1ec1d">
 <p>
 Message: the primary human-readable error message. This should be accurate
@@ -5354,8 +5509,8 @@ but terse (typically one line). Always present.
 </div>
 </div>
 
-<div id="outline-container-org885c4f1" class="outline-4">
-<h4 id="b01df60b-76be-43a3-9d80-13722658bb55"><a id="org885c4f1"></a>reader database-error-detail</h4>
+<div id="outline-container-org34691ee" class="outline-4">
+<h4 id="b01df60b-76be-43a3-9d80-13722658bb55"><a id="org34691ee"></a>reader database-error-detail</h4>
 <div class="outline-text-4" id="text-b01df60b-76be-43a3-9d80-13722658bb55">
 <p>
 Detail: an optional secondary error message carrying
@@ -5365,8 +5520,8 @@ available.
 </div>
 </div>
 
-<div id="outline-container-org5ecd739" class="outline-4">
-<h4 id="91ab0c67-4276-4eb1-8de9-4028f7f778f7"><a id="org5ecd739"></a>reader database-error-query</h4>
+<div id="outline-container-org42543c9" class="outline-4">
+<h4 id="91ab0c67-4276-4eb1-8de9-4028f7f778f7"><a id="org42543c9"></a>reader database-error-query</h4>
 <div class="outline-text-4" id="text-91ab0c67-4276-4eb1-8de9-4028f7f778f7">
 <p>
 Query that led to the error, or NIL if no query was involved.
@@ -5374,8 +5529,8 @@ Query that led to the error, or NIL if no query was involved.
 </div>
 </div>
 
-<div id="outline-container-org2c7f425" class="outline-4">
-<h4 id="3262d3c4-53a7-4f81-9d09-ccee5bf59b66"><a id="org2c7f425"></a>reader database-error-cause</h4>
+<div id="outline-container-orgc915ec5" class="outline-4">
+<h4 id="3262d3c4-53a7-4f81-9d09-ccee5bf59b66"><a id="orgc915ec5"></a>reader database-error-cause</h4>
 <div class="outline-text-4" id="text-3262d3c4-53a7-4f81-9d09-ccee5bf59b66">
 <p>
 The condition that caused this error, or NIL when it was not caused by another condition.
@@ -5384,8 +5539,8 @@ The condition that caused this error, or NIL when it was not caused by another c
 </div>
 </div>
 
-<div id="outline-container-orgb611528" class="outline-3">
-<h3 id="77cc7700-9573-4280-ba3a-cb368fa96dcc"><a id="orgb611528"></a><a id="ID-300b1531-c01f-4674-b08c-4624d5502a5c"></a>function database-error-constraint-name (err)</h3>
+<div id="outline-container-org679ac6e" class="outline-3">
+<h3 id="77cc7700-9573-4280-ba3a-cb368fa96dcc"><a id="org679ac6e"></a><a id="ID-300b1531-c01f-4674-b08c-4624d5502a5c"></a>function database-error-constraint-name (err)</h3>
 <div class="outline-text-3" id="text-77cc7700-9573-4280-ba3a-cb368fa96dcc">
 <p>
 Given a database-error for an integrity violation, will attempt to
@@ -5394,8 +5549,8 @@ extract the constraint name.
 </div>
 </div>
 
-<div id="outline-container-orgeb84b3d" class="outline-3">
-<h3 id="52fe59d2-396d-4c36-9a94-5ef452702d79"><a id="orgeb84b3d"></a><a id="ID-91e02238-2910-47d1-9fdd-c466147fe69c"></a>function database-error-extract-name (err)</h3>
+<div id="outline-container-orgffa0cc3" class="outline-3">
+<h3 id="52fe59d2-396d-4c36-9a94-5ef452702d79"><a id="orgffa0cc3"></a><a id="ID-91e02238-2910-47d1-9fdd-c466147fe69c"></a>function database-error-extract-name (err)</h3>
 <div class="outline-text-3" id="text-52fe59d2-396d-4c36-9a94-5ef452702d79">
 <p>
 Given a database-error, will extract the critical name from the error message.

--- a/doc/postmodern.org
+++ b/doc/postmodern.org
@@ -2429,13 +2429,22 @@ Example usage where two identifiers are required would be constraints:
               'country-locations)
 #+END_SRC
 
+** find-comments (type identifier)
+
+Returns the comments attached to a particular database object. The allowed
+types are :database :schema :table :columns (all the columns in a table)
+:column (for a single column).
+
+An example would be (find-comments :table 's2.employees) where the table employees
+is in the s2 schema.
 ** function get-database-comment (database-name)
    :PROPERTIES:
    :CUSTOM_ID: d993f27b-95d6-4a5b-bdf3-3e06beed0213
    :END:
 → string
 
-Returns the comment, if any, attached to a database.
+Returns the comment, if any, attached to a database. See also get-schema-comment,
+get-column-comments and get-database-comment.
 ** function postgresql-version ()
    :PROPERTIES:
    :ID:       9243f0ff-2001-4427-8cf9-33f9a9b6fd5c
@@ -2936,6 +2945,11 @@ return the tablename and the schema name. The name can be a symbol or a string.
 Returns a list of form '(table schema database. If the tablename is not fully
 qualified, it will assume that the schema should be \"public\".
 
+** function get-schema-comment (schema-name)
+→ string
+
+Retrieves the comment, if any attached to the schema. See also get-schema-comment,
+get-column-comments and get-database-comment.
 * Sequences
   :PROPERTIES:
   :ID:       62e4d0bd-e12f-47c6-8373-a174a7d8d7b1
@@ -3110,6 +3124,80 @@ Table can be either a string or quoted. Table-names can be fully qualified with
 the schema or not. If the table-name is not fully qualified and a schema name
 is not provided, the table will be assumed to be in the public schema.
 
+** function table-description-menu (table-name &key char-max-length data-type-length
+                                            has-default default-value not-null
+                                            numeric-precision numeric-scale
+                                            storage primary primary-key-name
+                                            unique unique-key-name fkey fkey-name
+                                            fkey-col-id fkey-table fkey-local-col-id
+                                            identity generated collation
+                                            col-comments locally-defined inheritance-count
+                                            stat-collection)
+→ list string list
+
+Takes a fully qualified table name which can be either a string or a symbol.
+
+Returns three values.
+
+1. A list of plists of each row's parameters. This will always
+include :column-name and :data-type-name but all other parameters can be set or unset
+and are set by default (set to t).
+
+2. The comment string attached to the table itself (if any).
+
+3. A list of the check constraints applied to the rows in the table. See documentation for
+list-check-constraints for an example.
+
+The available keyword parameters are:
+
+- data-type-length (For a fixed-size type, typlen is the number of bytes in the internal representation of the type. But for a variable-length type, typlen is negative. -1 indicates a “varlena” type (one that has a length word), -2 indicates a null-terminated C string.)
+- char-max-length (Typically used for something like a varchar and shows the maximum length)
+- has-default (value T if this column has a default value and :NULL if not)
+- default-value (value is the default value as string. A default of 9.99 will still be a string)
+- not-null (value is T if the column must have a value or :NULL otherwise)
+- numeric-precision (value is the total number of digits for a numeric type if that precision was specified)
+- numeric-scale (value is the number of digits in the fraction part of a numeric type if that scale was specified)
+- storage (value is the storage setting for a column. Result can be plain, extended, main or external)
+- primary (value is T if the column is the primary key for the table, :NULL otherwise)
+- primary-key-name (value is the name of the primary-key itself, not the column, if the column is the primary key for the table, :NULL otherwise)
+- unique (value is T if the column is subject to a unique key, :NULL otherwise)
+- unique-key-name (value is the name of the unique-key itself, not the column, applied to the column, :NULL otherwise)
+- fkey (value is T if the column is a foreign key, :NULL otherwise)
+- fkey-name (value is the name of the foreign key, :NULL otherwise)
+- fkey-col-id (value is the column id of the foreign table used as the foreign key. Probably easier to use the Postmodern function list-foreign-keys if you are looking for the name of the columns)
+- fkey-table (value is the name of the foreign table, :NULL otherwise)
+- fkey-local-col-id (value is the column id of this column. Probably easier to use the Postmodern function list-foreign-keys if you are looking for the name of the columns involved in the foreign key)
+- identity (if the column is an identity column, the values can be 'generated always' or 'generated by default'. Otherwise :NULL)
+- generated (columns can be generated, if this column is generated and stored on disk, the value will be 'stored', otherwise :NULL)
+- collation (columns with collations which are not the default collation for the database will show that collation here, otherwise :NULL)
+- col-comments (value is any comment that has been applied to the column, :NULL otherwise)
+- locally-defined (value is T if locally defined. It might be both locally defined and inherited)
+- inheritance-count (the number of direct ancestors this column has inherited)
+- stat-collection (stat-collection returns the value of attstattarget which controls the level of detail of statistics accumulated for this column by ANALYZE. A zero value indicates that no statistics should be collected. A negative value says to use the system default statistics target. The exact meaning of positive values is data type-dependent. For scalar data types, attstattarget is both the target number of most common values to collect, and the target number of histogram bins to create. Attstorage is normally a copy of pg_type.typstorage of this column's type. For TOAST-able data types, this can be altered after column creation to control storage policy.)
+** function list-check-constraints (table-name)
+→ list
+
+Takes a fully qualified table name and returns a list of lists of check constraints
+where each sublist has the form of (check-constraint-name check)
+
+Example:
+
+#+BEGIN_SRC lisp
+(query (:create-table 'employees2
+                      ((did :type (or integer db-null)
+                            :primary-key "generated by default as identity")
+                       (name :type (varchar 40) :check (:<> 'name ""))
+                       (birth-date :type date :check (:> 'birth-date "1900-01-01"))
+                       (start-date :type date :check (:> 'start-date 'birth-date))
+                       (salary :type numeric :check (:> 'salary 0)))))
+
+(list-check-constraints 'employees2)
+
+(("employees2_birth_date_check" "CHECK (birth_date > '1900-01-01'::date)")
+ ("employees2_check" "CHECK (start_date > birth_date)")
+ ("employees2_name_check" "CHECK (name::text <> ''::text)")
+ ("employees2_salary_check" "CHECK (salary > 0::numeric)"))
+#+END_SRC
 ** function list-columns (table-name)
    :PROPERTIES:
    :ID:       c867f758-86e5-4242-a825-a273c86acfd0
@@ -3161,7 +3249,16 @@ for tables in all schemas.
    :END:
 → string
 
-Retrieves the comment, if any attached to the table.
+Retrieves the comment, if any attached to the table. See also get-schema-comment,
+get-column-comments and get-database-comment
+** function get-column-comments (database schema table)
+   :PROPERTIES:
+   :CUSTOM_ID: e8d6e402-5c76-4533-9b5c-a823b9582c26
+   :END:
+→ string
+
+Retrieves a list of lists of column names and the comments, if any, attached
+to the columns of a table.
 ** function rename-table (old-name new-name)
 → boolean
 

--- a/postmodern.asd
+++ b/postmodern.asd
@@ -59,6 +59,7 @@
                          (:file "test-dao" :depends-on ("test-package")
                           :if-feature :postmodern-use-mop)
                          (:file "test-return-types" :depends-on ("test-package"))
+                         (:file "test-table-info" :depends-on ("test-package"))
                          (:file "test-return-types-timestamps" :depends-on ("test-package"))
                          (:file "test-transactions" :depends-on ("test-package"))
                          (:file "test-roles" :depends-on ("test-package"))

--- a/postmodern/package.lisp
+++ b/postmodern/package.lisp
@@ -135,6 +135,7 @@
    #:list-templates
    #:list-available-collations
    #:list-database-access-rights
+   #:find-comments
 
    ;; extensions
    #:list-available-extensions
@@ -178,6 +179,7 @@
    #:drop-schema
    #:with-schema
    #:schema-exists-p
+   #:get-schema-comment
    ;; sequences
    #:sequence-next
    #:list-sequences
@@ -190,13 +192,18 @@
    #:table-exists-p
    #:table-description
    #:table-description-plus
+   #:table-description-menu
    #:list-table-sizes
    #:table-size
    #:list-tables-in-schema
    #:drop-table
    #:get-table-oid
    #:get-table-comment
+   #:get-column-comments
+   #:get-column-comment
+   #:get-all-table-comments
    #:rename-table
+   #:list-check-constraints
    ;; tablespaces
    #:list-tablespaces
    ;; triggers
@@ -205,6 +212,7 @@
    #:list-detailed-triggers
    ;; util
    #:add-comment
+   #:find-comments
    #:list-available-types
    #:cache-hit-ratio
    #:bloat-measurement

--- a/postmodern/roles.lisp
+++ b/postmodern/roles.lisp
@@ -223,7 +223,7 @@ a single string name or :current, :all or \"all\"."
          (list (current-database)))
         ((or (eq databases :all)
              (equalp databases "all"))
-         (list-databases :names-only t))
+         (mapcar #'to-sql-name (list-databases :names-only t)))
         ((listp databases)
          (intersection (mapcar #'to-sql-name databases)
                        (list-databases :names-only t)

--- a/postmodern/tests/test-dao.lisp
+++ b/postmodern/tests/test-dao.lisp
@@ -502,7 +502,8 @@ so there is a single source of type truth."
                                                  :id 1 :username "turkey" :department-id 43)))
        ;; still no turkey to update
        (is (equal (query "select * from users1")
-               '((1 "goose" 17) (1 "duck" 3) (1 "chicken" 3) (1 "penguin" 43))))))))
+                  '((1 "goose" 17) (1 "duck" 3) (1 "chicken" 3) (1 "penguin" 43))))))
+    (query (:drop-table :if-exists 'users1 :cascade))))
 
 (test dao-create-table-with-references
   (is (equal (dao-table-definition 'test-data-col-identity-with-references)

--- a/postmodern/tests/test-roles.lisp
+++ b/postmodern/tests/test-roles.lisp
@@ -139,7 +139,6 @@
           (with-connection (list x superuser-name superuser-password host)
             (test-db-creation-helper)
             ;; YES CREATE THE ROLES ONLY ONCE, BUT WHAT ABOUT THE PERMISSIONS?
-
             (when (= y 1) (test-create-roles))
             ;; Create table in same database, but subsequent to creation of the roles
             (query (:create-table 't3

--- a/postmodern/tests/test-table-info.lisp
+++ b/postmodern/tests/test-table-info.lisp
@@ -1,0 +1,398 @@
+;;;; -*- Mode: LISP; Syntax: Ansi-Common-Lisp; Base: 10; Package: POSTMODERN-TESTS; -*-
+(in-package :postmodern-tests)
+
+;; Adjust the above to some db/user/pass/host combination that refers
+;; to a valid postgresql database in which no table named test_data
+;; currently exists. Then after loading the file, run the tests with
+;; (fiveam:run! :postmodern)
+
+(fiveam:def-suite :postmodern
+  :description "Test suite for postmodern subdirectory files")
+
+(fiveam:in-suite :postmodern)
+
+(fiveam:def-suite :postmodern-table-info
+  :description "Test suite for postmodern table information functions"
+  :in :postmodern)
+
+(fiveam:in-suite :postmodern-table-info)
+
+(defun create-products ()
+  (drop-table "products" :if-exists t :cascade t)
+  (query "CREATE TABLE products (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    price NUMERIC(5,2) default 9.9);"))
+
+(defun create-customers-and-contacts ()
+  (drop-table "s1.customers" :if-exists t :cascade t)
+  (drop-table "s1.contacts" :if-exists t :cascade t)
+  (drop-schema "s1" :if-exists t :cascade t)
+  (create-schema "s1")
+  (query "CREATE TABLE s1.customers(
+   customer_id INT GENERATED ALWAYS AS IDENTITY,
+   customer_name VARCHAR(255) NOT NULL,
+   PRIMARY KEY(customer_id))")
+
+  (query "CREATE TABLE s1.contacts (
+   contact_id INT GENERATED ALWAYS AS IDENTITY,
+   customer_id INT,
+   contact_name VARCHAR(255) NOT NULL,
+   phone VARCHAR(25),
+   email VARCHAR(100) UNIQUE,
+   PRIMARY KEY(contact_id),
+   CONSTRAINT fk_customer
+      FOREIGN KEY(customer_id)
+	  REFERENCES s1.customers(customer_id))")
+  (pomo:add-comment :database "Test" "This is a test database for reporting purposes")
+  (pomo:add-comment :schema "s1" "This is a comment about the s1 schema which is external looking")
+  (pomo:add-comment :table "s1.customers" "This is a test comment for the s1.customers table for reporting purposes"))
+
+(defun create-employees ()
+  (drop-table "s2.employees" :if-exists t :cascade t)
+  (drop-schema "s2" :if-exists t :cascade t)
+  (create-schema "s2")
+  (query "CREATE TABLE s2.employees (
+         	id SERIAL PRIMARY KEY,
+         	first_name VARCHAR (50),
+          last_name VARCHAR (50),
+          birth_date DATE CHECK (birth_date > '1900-01-01'),
+        	start_date DATE CHECK (start_date > birth_date),
+         	salary numeric CHECK(salary > 0));")
+
+  (query "CREATE UNIQUE INDEX CONCURRENTLY employee_idx
+        ON s2.employees (id)")
+
+  (query "ALTER TABLE s2.employees
+        ADD CONSTRAINT unique_employee_id
+        UNIQUE USING INDEX employee_idx")
+  (pomo:add-comment :schema "s2" "This is a comment about the s2 schema which is internal looking")
+  (pomo:add-comment :table "s2.employees" "This is a test comment for the s2.employees table for reporting purposes")
+  (pomo:add-comment :column "s2.employees.birth_date" "This is a test comment for the s2.employees.birth_date column for reporting purposes. There is a check that the start_date needs to occur after the birth_date.")
+  (pomo:add-comment :column "s2.employees.start_date" "This is a test comment for the s2.employees.start_date column for reporting purposes. There is a check that the start_date needs to occur after the birth_date.")
+  (pomo:add-comment :column "s2.employees.salary" "This is a test comment for the s2.employees.salary column for reporting purposes. There is a check that the salary needs to be greater than 0."))
+
+(test using-employees
+  (with-test-connection
+    (create-employees)
+    (multiple-value-bind (rows overview check-constraints)
+        (table-description-menu "s2.employees"
+                                :char-max-length nil :data-type-length nil
+                                :has-default nil :default-value nil :not-null nil
+                                :numeric-precision nil :numeric-scale nil
+                                :storage nil :primary nil :primary-key-name nil
+                                :unique nil :unique-key-name nil :fkey nil :fkey-name nil
+                                :fkey-col-id nil :fkey-table nil :fkey-local-col-id nil
+                                :identity nil :generated nil :collation nil
+                                :col-comments t :locally-defined nil :inheritance-count nil
+                                :stat-collection nil)
+      (is (equal (get-schema-comment "s2")
+                 "This is a comment about the s2 schema which is internal looking"))
+      (is (equal overview "This is a test comment for the s2.employees table for reporting purposes"))
+      (is (equal check-constraints
+                 '(("employees_birth_date_check" "CHECK (birth_date > '1900-01-01'::date)")
+                   ("employees_check" "CHECK (start_date > birth_date)")
+                   ("employees_salary_check" "CHECK (salary > 0::numeric)"))))
+      (is (equal rows
+                  '((:COLUMN-NAME "id" :DATA-TYPE-NAME "int4" :COL-COMMENTS :NULL)
+                    (:COLUMN-NAME "id" :DATA-TYPE-NAME "int4" :COL-COMMENTS :NULL)
+                    (:COLUMN-NAME "first_name" :DATA-TYPE-NAME "varchar" :COL-COMMENTS :NULL)
+                    (:COLUMN-NAME "last_name" :DATA-TYPE-NAME "varchar" :COL-COMMENTS :NULL)
+                    (:COLUMN-NAME "birth_date" :DATA-TYPE-NAME "date" :COL-COMMENTS
+                     "This is a test comment for the s2.employees.birth_date column for reporting purposes. There is a check that the start_date needs to occur after the birth_date.")
+                    (:COLUMN-NAME "birth_date" :DATA-TYPE-NAME "date" :COL-COMMENTS
+                     "This is a test comment for the s2.employees.birth_date column for reporting purposes. There is a check that the start_date needs to occur after the birth_date.")
+                    (:COLUMN-NAME "start_date" :DATA-TYPE-NAME "date" :COL-COMMENTS
+                     "This is a test comment for the s2.employees.start_date column for reporting purposes. There is a check that the start_date needs to occur after the birth_date.")
+                    (:COLUMN-NAME "salary" :DATA-TYPE-NAME "numeric" :COL-COMMENTS
+                     "This is a test comment for the s2.employees.salary column for reporting purposes. There is a check that the salary needs to be greater than 0.")))))
+    (is (equal (list-check-constraints "s2.employees")
+               '(("employees_birth_date_check" "CHECK (birth_date > '1900-01-01'::date)")
+                 ("employees_check" "CHECK (start_date > birth_date)")
+                 ("employees_salary_check" "CHECK (salary > 0::numeric)"))))
+    (is (equal (list-columns "s2.employees")
+               '("id" "first_name" "last_name" "birth_date" "start_date" "salary")))
+    (is (equal (list-columns-with-types "s2.employees")
+               '(("id" "int4") ("first_name" "varchar") ("last_name" "varchar")
+                 ("birth_date" "date") ("start_date" "date") ("salary" "numeric"))))
+    (is (equal (column-exists-p "s2.employees" "id")
+               t))
+    (is (equal (get-column-comments 's2.employees)
+               '(("birth_date"
+                  "This is a test comment for the s2.employees.birth_date column for reporting purposes. There is a check that the start_date needs to occur after the birth_date.")
+                 ("start_date"
+                  "This is a test comment for the s2.employees.start_date column for reporting purposes. There is a check that the start_date needs to occur after the birth_date.")
+                 ("salary"
+                  "This is a test comment for the s2.employees.salary column for reporting purposes. There is a check that the salary needs to be greater than 0."))))
+    (is (equal (find-comments :schema 's2)
+               "This is a comment about the s2 schema which is internal looking"))
+    (is (equal (find-comments :table 's2.employees)
+               "This is a test comment for the s2.employees table for reporting purposes"))
+    (is (equal (find-comments :columns 's2.employees)
+               '(("birth_date"
+                  "This is a test comment for the s2.employees.birth_date column for reporting purposes. There is a check that the start_date needs to occur after the birth_date.")
+                 ("start_date"
+                  "This is a test comment for the s2.employees.start_date column for reporting purposes. There is a check that the start_date needs to occur after the birth_date.")
+                 ("salary"
+                  "This is a test comment for the s2.employees.salary column for reporting purposes. There is a check that the salary needs to be greater than 0."))))
+    (is (equal (get-column-comment 's2.employees.birth-date)
+               "This is a test comment for the s2.employees.birth_date column for reporting purposes. There is a check that the start_date needs to occur after the birth_date."))
+    (is (not (get-column-comment 's2.employees.id)))
+    (is (not (get-column-comment 's2.employees)))
+    (drop-table 's2.employees)
+    (drop-schema 's2)))
+
+(test table-schema-names
+  (multiple-value-bind (tn sn)
+      (pomo::table-schema-names "t1" nil)
+    (is (equal tn "t1"))
+    (is (equal sn "public")))
+  (multiple-value-bind (tn sn)
+      (pomo::table-schema-names "t1" "s2")
+    (is (equal tn "t1"))
+    (is (equal sn "s2")))
+  (multiple-value-bind (tn sn)
+      (pomo::table-schema-names "s1.t1" nil)
+    (is (equal tn "t1"))
+    (is (equal sn "s1")))
+  (signals error (pomo::table-schema-names "s1.t1" "s2")))
+
+(test table-inheritance
+  (with-test-connection
+    (drop-table "cities" :if-exists t :cascade t)
+    (query "CREATE TABLE cities (
+    name            text,
+    population      float,
+    altitude        int  );")
+    (query "CREATE TABLE capitals (
+    state           char(2))
+    INHERITS (cities);")
+    (is (equalp (table-description-menu
+                 "capitals" :char-max-length nil :data-type-length nil
+                 :has-default nil :default-value nil :not-null nil
+                 :numeric-precision nil :numeric-scale nil
+                 :storage nil :primary nil :primary-key-name nil
+                 :unique nil :unique-key-name nil :fkey nil :fkey-name nil
+                 :fkey-col-id nil :fkey-table nil :fkey-local-col-id nil
+                 :identity nil :generated nil :collation nil
+                 :col-comments nil
+                 :stat-collection nil :inheritance-count t
+                 :locally-defined t)
+                '((:COLUMN-NAME "name" :DATA-TYPE-NAME "text" :LOCALLY-DEFINED :NULL
+                   :INHERITANCE-COUNT 1)
+                  (:COLUMN-NAME "population" :DATA-TYPE-NAME "float8" :LOCALLY-DEFINED :NULL
+                   :INHERITANCE-COUNT 1)
+                  (:COLUMN-NAME "altitude" :DATA-TYPE-NAME "int4" :LOCALLY-DEFINED :NULL
+                   :INHERITANCE-COUNT 1)
+                  (:COLUMN-NAME "state" :DATA-TYPE-NAME "bpchar" :LOCALLY-DEFINED T
+                   :INHERITANCE-COUNT 0))))
+    (drop-table 'cities :cascade t)
+    (drop-table 'capitals :cascade t)))
+
+(test using-products
+  (with-test-connection
+    (create-products)
+    (multiple-value-bind (rows overview)
+        (table-description-menu "products"
+                                :char-max-length nil :data-type-length nil
+                                :has-default nil :default-value nil :not-null nil
+                                :numeric-precision nil :numeric-scale nil
+                                :storage t :primary nil :primary-key-name nil
+                                :unique nil :unique-key-name nil :fkey nil :fkey-name nil
+                                :fkey-col-id nil :fkey-table nil :fkey-local-col-id nil
+                                :identity nil :generated nil :collation nil
+                                :col-comments nil :locally-defined nil :inheritance-count nil
+                                :stat-collection nil)
+      (declare (ignore overview))
+      (is (equalp rows
+                  '((:COLUMN-NAME "id" :DATA-TYPE-NAME "int4" :STORAGE "plain")
+                    (:COLUMN-NAME "name" :DATA-TYPE-NAME "varchar" :STORAGE "extended")
+                    (:COLUMN-NAME "price" :DATA-TYPE-NAME "numeric" :STORAGE "main")))))
+    (multiple-value-bind (rows overview)
+        (table-description-menu "products"
+                                :char-max-length nil :data-type-length nil
+                                :has-default nil :default-value nil :not-null nil
+                                :numeric-precision nil :numeric-scale nil
+                                :storage nil :primary t :primary-key-name t
+                                :unique nil :unique-key-name nil :fkey nil :fkey-name nil
+                                :fkey-col-id nil :fkey-table nil :fkey-local-col-id nil
+                                :identity nil :generated nil :collation nil
+                                :col-comments nil :locally-defined nil :inheritance-count nil
+                                :stat-collection nil)
+      (declare (ignore overview))
+      (is (equalp rows
+                  '((:COLUMN-NAME "id" :DATA-TYPE-NAME "int4" :PRIMARY "Primary" :PRIMARY-KEY-NAME
+                     "products_pkey")
+                    (:COLUMN-NAME "name" :DATA-TYPE-NAME "varchar" :PRIMARY "" :PRIMARY-KEY-NAME
+                     :NULL)
+                    (:COLUMN-NAME "price" :DATA-TYPE-NAME "numeric" :PRIMARY "" :PRIMARY-KEY-NAME
+                     :NULL)))))
+    (multiple-value-bind (rows overview)
+        (table-description-menu "products"
+                                :char-max-length t :data-type-length t
+                                :has-default t :default-value t :not-null nil
+                                :numeric-precision nil :numeric-scale nil
+                                :storage nil :primary nil :primary-key-name nil
+                                :unique nil :unique-key-name nil :fkey nil :fkey-name nil
+                                :fkey-col-id nil :fkey-table nil :fkey-local-col-id nil
+                                :identity nil :generated nil :collation nil
+                                :col-comments nil :locally-defined nil :inheritance-count nil
+                                :stat-collection nil)
+      (declare (ignore overview))
+      (is (equalp rows
+                  '((:COLUMN-NAME "id" :DATA-TYPE-NAME "int4" :CHARACTER-MAXIMUM-LENGTH :NULL
+                     :DATA-TYPE-LENGTH 4 :HAS-DEFAULT T :DEFAULT-VALUE
+                     "nextval('products_id_seq'::regclass)")
+                    (:COLUMN-NAME "name" :DATA-TYPE-NAME "varchar" :CHARACTER-MAXIMUM-LENGTH 100
+                     :DATA-TYPE-LENGTH -1 :HAS-DEFAULT :NULL :DEFAULT-VALUE :NULL)
+                    (:COLUMN-NAME "price" :DATA-TYPE-NAME "numeric" :CHARACTER-MAXIMUM-LENGTH
+                     :NULL :DATA-TYPE-LENGTH -1 :HAS-DEFAULT T :DEFAULT-VALUE "9.9")))))
+    (multiple-value-bind (rows overview)
+        (table-description-menu "products"
+                                :char-max-length nil :data-type-length nil
+                                :has-default nil :default-value nil :not-null t
+                                :numeric-precision nil :numeric-scale nil
+                                :storage nil :primary nil :primary-key-name nil
+                                :unique nil :unique-key-name nil :fkey nil :fkey-name nil
+                                :fkey-col-id nil :fkey-table nil :fkey-local-col-id nil
+                                :identity nil :generated nil :collation nil
+                                :col-comments nil :locally-defined nil :inheritance-count nil
+                                :stat-collection nil)
+      (declare (ignore overview))
+      (is (equalp
+           rows
+           '((:COLUMN-NAME "id" :DATA-TYPE-NAME "int4" :NOT-NULL T)
+             (:COLUMN-NAME "name" :DATA-TYPE-NAME "varchar" :NOT-NULL T)
+             (:COLUMN-NAME "price" :DATA-TYPE-NAME "numeric" :NOT-NULL :NULL)))))
+    (multiple-value-bind (rows overview)
+        (table-description-menu "products"
+                                :char-max-length nil :data-type-length nil
+                                :has-default nil :default-value nil :not-null nil
+                                :numeric-precision t :numeric-scale t
+                                :storage nil :primary nil :primary-key-name nil
+                                :unique nil :unique-key-name nil :fkey nil :fkey-name nil
+                                :fkey-col-id nil :fkey-table nil :fkey-local-col-id nil
+                                :identity nil :generated nil :collation nil
+                                :col-comments nil :locally-defined nil :inheritance-count nil
+                                :stat-collection nil)
+      (declare (ignore overview))
+      (is (equalp rows
+                  '((:COLUMN-NAME "id" :DATA-TYPE-NAME "int4" :NUMERIC-PRECISION :NULL
+                     :NUMERIC-SCALE :NULL)
+                    (:COLUMN-NAME "name" :DATA-TYPE-NAME "varchar" :NUMERIC-PRECISION :NULL
+                     :NUMERIC-SCALE :NULL)
+                    (:COLUMN-NAME "price" :DATA-TYPE-NAME "numeric" :NUMERIC-PRECISION 5
+                     :NUMERIC-SCALE 2)))))
+    (drop-table 'products :cascade t)))
+
+(test using-customer-contacts
+  (with-test-connection
+    (create-customers-and-contacts)
+    (is (equalp (table-description-menu "s1.contacts"
+                                        :char-max-length nil :data-type-length nil
+                                        :has-default nil :default-value nil :not-null nil
+                                        :numeric-precision nil :numeric-scale nil
+                                        :storage nil :primary nil :primary-key-name nil
+                                        :unique t :unique-key-name t :fkey nil :fkey-name nil
+                                        :fkey-col-id nil :fkey-table nil :fkey-local-col-id nil
+                                        :identity nil :generated nil :collation nil
+                                        :col-comments nil :locally-defined nil :inheritance-count nil
+                                        :stat-collection nil)
+                '((:COLUMN-NAME "contact_id" :DATA-TYPE-NAME "int4" :UNIQUE :NULL
+                   :UNIQUE-KEY-NAME :NULL)
+                  (:COLUMN-NAME "customer_id" :DATA-TYPE-NAME "int4" :UNIQUE :NULL
+                   :UNIQUE-KEY-NAME :NULL)
+                  (:COLUMN-NAME "contact_name" :DATA-TYPE-NAME "varchar" :UNIQUE :NULL
+                   :UNIQUE-KEY-NAME :NULL)
+                  (:COLUMN-NAME "phone" :DATA-TYPE-NAME "varchar" :UNIQUE :NULL :UNIQUE-KEY-NAME
+                                                                          :NULL)
+                  (:COLUMN-NAME "email" :DATA-TYPE-NAME "varchar" :UNIQUE T :UNIQUE-KEY-NAME
+                   "contacts_email_key"))))
+    (is (equalp (table-description-menu
+                 "s1.contacts" :char-max-length nil :data-type-length nil
+                 :has-default nil :default-value nil :not-null nil
+                 :numeric-precision nil :numeric-scale nil
+                 :storage nil :primary nil :primary-key-name nil
+                 :unique nil :unique-key-name nil :fkey t :fkey-name t
+                 :fkey-col-id t :fkey-table t :fkey-local-col-id t
+                 :identity nil :generated nil :collation nil
+                 :col-comments nil :locally-defined nil :inheritance-count nil
+                 :stat-collection nil)
+                '((:COLUMN-NAME "contact_id" :DATA-TYPE-NAME "int4" :FKEY :NULL :FKEY-NAME :NULL
+                   :FKEY-COL-ID :NULL :FKEY-TABLE :NULL :FKEY-LOCAL-COL-ID :NULL)
+                  (:COLUMN-NAME "customer_id" :DATA-TYPE-NAME "int4" :FKEY T :FKEY-NAME
+                   "fk_customer" :FKEY-COL-ID #(1) :FKEY-TABLE "customers" :FKEY-LOCAL-COL-ID
+                   #(2))
+                  (:COLUMN-NAME "contact_name" :DATA-TYPE-NAME "varchar"
+                   :FKEY :NULL :FKEY-NAME
+                         :NULL :FKEY-COL-ID :NULL :FKEY-TABLE :NULL :FKEY-LOCAL-COL-ID :NULL)
+                  (:COLUMN-NAME "phone" :DATA-TYPE-NAME "varchar" :FKEY :NULL :FKEY-NAME :NULL
+                   :FKEY-COL-ID :NULL :FKEY-TABLE :NULL :FKEY-LOCAL-COL-ID :NULL)
+                  (:COLUMN-NAME "email" :DATA-TYPE-NAME "varchar" :FKEY :NULL :FKEY-NAME :NULL
+                   :FKEY-COL-ID :NULL :FKEY-TABLE :NULL :FKEY-LOCAL-COL-ID :NULL))))
+    (is (equalp (table-description-menu
+                 "s1.contacts"
+                 :char-max-length nil :data-type-length nil
+                 :has-default nil :default-value nil :not-null nil
+                 :numeric-precision nil :numeric-scale nil
+                 :storage nil :primary nil :primary-key-name nil
+                 :unique nil :unique-key-name nil :fkey nil :fkey-name nil
+                 :fkey-col-id nil :fkey-table nil :fkey-local-col-id nil
+                 :identity nil :generated nil :collation nil
+                 :col-comments nil :locally-defined nil :inheritance-count nil
+                 :stat-collection t)
+                '((:COLUMN-NAME "contact_id" :DATA-TYPE-NAME "int4" :STAT-COLLECTION :NULL)
+                  (:COLUMN-NAME "customer_id" :DATA-TYPE-NAME "int4" :STAT-COLLECTION :NULL)
+                  (:COLUMN-NAME "contact_name" :DATA-TYPE-NAME "varchar" :STAT-COLLECTION :NULL)
+                  (:COLUMN-NAME "phone" :DATA-TYPE-NAME "varchar" :STAT-COLLECTION :NULL)
+                  (:COLUMN-NAME "email" :DATA-TYPE-NAME "varchar" :STAT-COLLECTION :NULL))))
+    (is (equal (get-schema-comment "s1")
+               "This is a comment about the s1 schema which is external looking"))
+    (drop-table 's1.customers :cascade t)
+    (drop-table 's1.contacts :cascade t)
+    (drop-schema 's1 :cascade t)))
+
+(test identity-and-generated
+  (with-test-connection
+    (drop-table "people" :if-exists t :cascade t)
+    (query "CREATE TABLE people (
+            height_cm numeric,
+            height_in numeric GENERATED ALWAYS AS (height_cm / 2.54) STORED);")
+    (is (equalp
+         (table-description-menu "people"
+                                 :char-max-length nil :data-type-length nil
+                                 :has-default nil :default-value nil :not-null nil
+                                 :numeric-precision nil :numeric-scale nil
+                                 :storage nil :primary nil :primary-key-name nil
+                                 :unique nil :unique-key-name nil :fkey nil :fkey-name nil
+                                 :fkey-col-id nil :fkey-table nil :fkey-local-col-id nil
+                                 :identity t :generated t :collation nil
+                                 :col-comments nil :locally-defined nil :inheritance-count nil
+                                 :stat-collection nil)
+         '((:COLUMN-NAME "height_cm" :DATA-TYPE-NAME "numeric"
+            :IDENTITY :NULL :GENERATED :NULL)
+           (:COLUMN-NAME "height_in" :DATA-TYPE-NAME "numeric"
+            :IDENTITY :NULL :GENERATED "stored"))))
+    (drop-table 'people :cascade t)))
+
+(test table-collation
+  (with-test-connection
+    (drop-table "test_collations" :if-exists t :cascade t)
+    (query "CREATE TABLE test_collations (
+    a text COLLATE \"C\",
+    b text COLLATE \"POSIX\");")
+
+    (is (equalp
+         (table-description-menu "test_collations"
+                                 :char-max-length nil :data-type-length nil
+                                 :has-default nil :default-value nil :not-null nil
+                                 :numeric-precision nil :numeric-scale nil
+                                 :storage nil :primary nil :primary-key-name nil
+                                 :unique nil :unique-key-name nil :fkey nil :fkey-name nil
+                                 :fkey-col-id nil :fkey-table nil :fkey-local-col-id nil
+                                 :identity nil :generated nil :collation t
+                                 :col-comments nil :locally-defined nil :inheritance-count nil
+                                 :stat-collection nil)
+         '((:COLUMN-NAME "a" :DATA-TYPE-NAME "text" :COLLATION "C")
+           (:COLUMN-NAME "b" :DATA-TYPE-NAME "text" :COLLATION "POSIX"))))
+    (drop-table 'test-collations :cascade t)))

--- a/postmodern/tests/test-transactions.lisp
+++ b/postmodern/tests/test-transactions.lisp
@@ -224,7 +224,8 @@
           (is (equal (query "select * from test_data")
                      '((0) (1) (2))))))
       (is (equal (query "select * from test_data")
-                 '((0) (1) (2)))))))
+                 '((0) (1) (2))))
+      (execute (:drop-table 'test-data)))))
 
 (test savepoint-rollback-from-inside
   (let ((x 1)
@@ -261,4 +262,5 @@
           (is (equal (query "select * from test_data")
                      '((0) (1))))))
       (is (equal (query "select * from test_data")
-                 '((0) (1)))))))
+                 '((0) (1))))
+      (execute (:drop-table 'test-data)))))

--- a/postmodern/tests/tests.lisp
+++ b/postmodern/tests/tests.lisp
@@ -33,12 +33,6 @@
 (defmacro protect (&body body)
   `(unwind-protect (progn ,@(butlast body)) ,(car (last body))))
 
-(fiveam:def-suite :postmodern-base
-  :description "Base test suite for postmodern"
-  :in :postmodern)
-
-(fiveam:in-suite :postmodern-base)
-
 (test connect-sanely
   (with-test-connection
     (is (not (null *database*)))))
@@ -533,12 +527,12 @@
       (execute (:drop-table 'test-uniq)))
     (query (:create-table 'uniq.gracie ((id :type integer))))
     (is (equal (list-tables-in-schema "uniq")
-               '(("gracie"))))
+               '("gracie")))
     (is (equal (list-tables-in-schema 'uniq)
-               '(("gracie"))))
+               '("gracie")))
     (query (:create-table "uniq.george" ((id :type integer))))
     (is (equal (list-tables-in-schema "uniq")
-               '(("george") ("gracie"))))
+               '("george" "gracie")))
     (is (table-exists-p "test.uniq.george"))
     (is (table-exists-p "uniq.george"))
     (is (table-exists-p "george" "uniq"))
@@ -549,15 +543,12 @@
     (drop-schema 'uniq :cascade 't)
     (is (not (schema-exists-p 'uniq)))
     (create-schema 'uniq)
-    (is (not (set-difference (list-schemas)
-                             '("public" "information_schema" "uniq")
-                             :test #'equal)))
+    (format t "List-schemas ~a~%" (list-schemas))
+    (is (equal "uniq" (find "uniq" (list-schemas) :test #'equal)))
     (drop-schema "uniq" :cascade 't)
     (is (not (schema-exists-p "uniq")))
     (create-schema "uniq")
-    (is (not (set-difference (list-schemas)
-                             '("public" "information_schema" "uniq")
-                             :test #'equal)))
+    (is (equal "uniq" (find "uniq" (list-schemas) :test #'equal)))
     (drop-schema 'uniq :cascade 't)
     (is (equal (get-search-path)
                "\"$user\", public"))
@@ -660,7 +651,8 @@ and second the string name for the datatype."
     (is (equal (sql (:drop-index :concurrently 'george-idx))
                "DROP INDEX CONCURRENTLY george_idx"))
     (is (equal (sql (:drop-index 'george-idx))
-               "DROP INDEX george_idx"))))
+               "DROP INDEX george_idx"))
+    (query (:drop-table :if-exists 'george :cascade))))
 
 (test sequence
   "Sequence testing"

--- a/s-sql/tests/test-intervals.lisp
+++ b/s-sql/tests/test-intervals.lisp
@@ -114,7 +114,8 @@
                                         ("6 years")
                                         ("5 months")
                                         ("5 months 12 hours"))))
-    (is-true (table-exists-p 'interval))))
+    (is-true (table-exists-p 'interval))
+    (query (:drop-table 'interval))))
 
 (test intervals
   "Testing intervals"

--- a/s-sql/tests/tests.lisp
+++ b/s-sql/tests/tests.lisp
@@ -62,7 +62,8 @@
     (is (equal (query (:select 'nullable :from 'null-test :where (:= 'id 2)) :single)
                :null))
     (is (equal (query (:select '* :from 'null-test :where (:= 'id 2)))
-               '((2 :null))))))
+               '((2 :null))))
+    (query (:drop-table :if-exists 'null-test :cascade))))
 
 (defun build-recipe-tables ()
   "Build recipe tables uses in array tests"


### PR DESCRIPTION
Adds new utility functions

- table-description-menu which allows you to pick and choose
what table characteristics you want returned. See giant docstring for details.

- get-schema-comment which takes a schema name and returns the schema comment
as a string

- list-check-constraints which takes a fully qualified table name and returns
a list of lists of check constraints where each sublist has the form
of (check-constraint-name check).

Example: (list-check-constraints "s2.employees")
(("employees_birth_date_check" "CHECK (birth_date > '1900-01-01'::date)")
 ("employees_check" "CHECK (start_date > birth_date)")
 ("employees_salary_check" "CHECK (salary > 0::numeric)"))

Now exports
get-column-comments (the parameter string has changed if you were using the internal version)
get-all-table-comments

Bug Fixes:

Fixes a bug when trying to connect to a database using ssl. If the keyword :try was used,
the connection would not fall back to non-ssl connections.
