### PR TITLE
Add Table Updating DAO

### DIFF
--- a/postmodern/package.lisp
+++ b/postmodern/package.lisp
@@ -35,6 +35,7 @@
    #:list-connections
    #:query
    #:execute
+   #:execute-statements
    #:doquery
    #:parse-queries
    #:read-queries

--- a/postmodern/package.lisp
+++ b/postmodern/package.lisp
@@ -14,7 +14,7 @@
    #:insert-dao #:update-dao #:save-dao #:save-dao/transaction #:upsert-dao
    #:delete-dao #:make-dao
    #:define-dao-finalization
-   #:dao-table-name #:dao-table-definition
+   #:dao-table-name #:dao-table-definition #:dao-table-update
    #:\!dao-def #:*ignore-unknown-columns*)
 
   (:export

--- a/postmodern/query.lisp
+++ b/postmodern/query.lisp
@@ -195,6 +195,10 @@ is deprecated.)"
   `(let ((rows (nth-value 1 (query ,query ,@args :none))))
      (if rows (values rows rows) 0)))
 
+(defun execute-statements (statements)
+  (dolist (statement statements)
+    (execute statement)))
+
 (defmacro doquery (query (&rest names) &body body)
   "Execute the given query (a string or a list starting with a keyword),
 iterating over the rows in the result. The body will be executed with the values

--- a/postmodern/util.lisp
+++ b/postmodern/util.lisp
@@ -671,7 +671,8 @@ is not provided, the table will be assumed to be in the public schema."
                           (princ-to-string default)))
                     "serial")
                    ;; varchar
-                   ((string= "character varying" type)
+                   ((alexandria:starts-with-subseq
+                     "character varying" type)
                     (format nil "varchar(~a)" max-length))
                    (:else type))
                  ;; nullable


### PR DESCRIPTION
Preface: I do not believe this is a complete pull request. It is missing updates to the readme (I'm happy to do that if you like the idea), I don't think the test is working right, and I am probably missing some corner cases. That said, I think this is a really useful feature and I would appreciate someone taking a look at it. Maybe with a little work, it can get merged in.

This is a functionality like `dao-table-definition`  where is takes a dao and produces a database table. The added feature that this table updating dao adds is being able to update an existing database table. Add or remove a slot to your dao? `dao-table-update` will add the column in the database. Change a column type, nullability, or key? `dao-table-update` has you covered (unless you pick an incompatible type).

This helps keep your dao definition and the equivalent table in the database image the same without having to open up the database shell to do ALTER TABLE statements.