### PR TITLE
Fix for Azure Single Instance connections

### DIFF
--- a/cl-postgres/public.lisp
+++ b/cl-postgres/public.lisp
@@ -26,6 +26,7 @@ all the configuration parameters for the connection."))
    (available :initform t :accessor connection-available)
    (parameters :accessor connection-parameters)
    (timestamp-format :accessor connection-timestamp-format))
+  (:default-initargs :application-name "postmodern-default")
   (:documentation "Representation of a database connection. Contains
 login information in order to be able to automatically re-establish a
 connection when it is somehow closed."))
@@ -105,7 +106,7 @@ connected."
 
 (defun open-database (database user password host
                       &optional (port 5432) (use-ssl :no)
-                        (service "postgres") (application-name "")
+                        (service "postgres") (application-name "postmodern-default")
                         (use-binary nil))
   "Create and open a connection for the specified server, database, and user.
 use-ssl may be :no, :try, :yes, or :full; where :try means 'if the server


### PR DESCRIPTION
Microsoft Azure's Single Instance Postgresql gateway does not properly handle Postgresql connections when the application name is an empty string. We now use "postmodern-default" as the application name if the user has not specified anything else. I have been told that Azure's "flexible PG server" gateway did not have this problem.

Sidenote: The test suite was run calling a Postgresql database running on an Azure server instance 8,000 km away from the location of the server running the Postmodern code. Yes, the speed of light did make the test responses slower. 