### PR TITLE
Fixes a bug in the execute-file function

### DIFF
--- a/cl-postgres.asd
+++ b/cl-postgres.asd
@@ -27,6 +27,7 @@
     :components ((:file "package")
                  (:file "features")
                  (:file "config")
+                 (:file "oid" :depends-on ("package" "config"))
                  (:file "errors" :depends-on ("package"))
                  (:file "data-types" :depends-on ("package" "config"))
                  (:file "sql-string" :depends-on ("package" "config" "data-types"))
@@ -36,7 +37,6 @@
                  (:file "communicate"
                   :depends-on (#.*string-file* "sql-string" "config"))
                  (:file "messages" :depends-on ("communicate" "config"))
-                 (:file "oid" :depends-on ("package" "config"))
                  (:file "ieee-floats" :depends-on ("config"))
                  (:file "interpret"
                   :depends-on ("oid" "communicate" "ieee-floats" "config"))

--- a/cl-postgres/tests/tests-saslprep.lisp
+++ b/cl-postgres/tests/tests-saslprep.lisp
@@ -24,12 +24,12 @@
   (is (not (cl-postgres::code-point-printable-ascii-p 163))))
 
 (test char-mapped-to-nothing-p
-  (is (not (cl-postgres::char-mapped-to-nothing-p #\LATIN_CAPITAL_LETTER_O_WITH_DIAERESIS)))
-  (is (cl-postgres::char-mapped-to-nothing-p #\ZERO_WIDTH_SPACE)))
+  (is (not (cl-postgres::char-mapped-to-nothing-p (code-char 214))))
+  (is (cl-postgres::char-mapped-to-nothing-p (code-char 8203))))
 
 (test char-mapped-to-space-p
-  (is (not (cl-postgres::char-mapped-to-space-p #\LATIN_CAPITAL_LETTER_O_WITH_DIAERESIS)))
-  (is (cl-postgres::char-mapped-to-space-p #\ZERO_WIDTH_SPACE))
+  (is (not (cl-postgres::char-mapped-to-space-p (code-char 214))))
+  (is (cl-postgres::char-mapped-to-space-p (code-char 8203)))
   (is (cl-postgres::char-mapped-to-space-p (code-char 5760))))
 
 (test string-mapped-to-nothing-p
@@ -56,8 +56,8 @@
 
 (test saslprep-normalize
   (is (equal (cl-postgres::saslprep-normalize
-              (coerce (vector #\a #\LATIN_CAPITAL_LETTER_O_WITH_DIAERESIS
-                              (code-char 8193) #\c #\ZERO_WIDTH_SPACE
+              (coerce (vector #\a (code-char 214)
+                              (code-char 8193) #\c (code-char 8203)
                               (code-char 65025)
                               (code-char 1214) #\d)
                       'string))

--- a/doc/postmodern.html
+++ b/doc/postmodern.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- 2021-08-03 Tue 10:58 -->
+<!-- 2021-08-18 Wed 11:32 -->
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Postmodern Reference Manual</title>
@@ -246,7 +246,7 @@
 <h2>Table of Contents</h2>
 <div id="text-table-of-contents">
 <ul>
-<li><a href="#orgad53c85">Overview</a></li>
+<li><a href="#org5bfa418">Overview</a></li>
 <li><a href="#connecting">Connecting</a>
 <ul>
 <li><a href="#class-database-connection">class database-connection</a></li>
@@ -335,7 +335,7 @@
 <li><a href="#database-information">Database Information</a>
 <ul>
 <li><a href="#funciton-add-comment">function add-comment (type name comment &amp;optional (second-name ""))</a></li>
-<li><a href="#orgc966fe7">find-comments (type identifier)</a></li>
+<li><a href="#org6913271">find-comments (type identifier)</a></li>
 <li><a href="#function-get-database-comment">function get-database-comment (database-name)</a></li>
 <li><a href="#function-postgresql-version">function postgresql-version ()</a></li>
 <li><a href="#function-database-version">function database-version ()</a></li>
@@ -427,7 +427,7 @@
 <li><a href="#function-get-table-comment">function get-table-comment (table-name &amp;optional schema-name)</a></li>
 <li><a href="#function-get-column-comments">function get-column-comments (database schema table)</a></li>
 <li><a href="#rename-table">function rename-table (old-name new-name)</a></li>
-<li><a href="#orga7fad51">function rename-column (table-name old-name new-name)</a></li>
+<li><a href="#orgbe3919b">function rename-column (table-name old-name new-name)</a></li>
 </ul>
 </li>
 <li><a href="#tablespaces">Tablespaces</a>
@@ -494,9 +494,9 @@
 </div>
 </nav>
 
-<div id="outline-container-orgad53c85" class="outline-2">
-<h2 id="orgad53c85">Overview</h2>
-<div class="outline-text-2" id="text-orgad53c85">
+<div id="outline-container-org5bfa418" class="outline-2">
+<h2 id="org5bfa418">Overview</h2>
+<div class="outline-text-2" id="text-org5bfa418">
 <p>
 This is the reference manual for the component named postmodern, which is part
 of a library of the same name.
@@ -1000,9 +1000,9 @@ instead. Any of the following formats can be used, with the default being :rows:
 Some Examples:
 </p>
 </div>
-<div id="outline-container-org2841140" class="outline-4">
-<h4 id="org2841140">Default</h4>
-<div class="outline-text-4" id="text-org2841140">
+<div id="outline-container-org7873dd9" class="outline-4">
+<h4 id="org7873dd9">Default</h4>
+<div class="outline-text-4" id="text-org7873dd9">
 <p>
 The default is :lists
 </p>
@@ -1013,9 +1013,9 @@ The default is :lists
 </div>
 </div>
 </div>
-<div id="outline-container-org1f4a021" class="outline-4">
-<h4 id="org1f4a021">Single</h4>
-<div class="outline-text-4" id="text-org1f4a021">
+<div id="outline-container-org10cda81" class="outline-4">
+<h4 id="org10cda81">Single</h4>
+<div class="outline-text-4" id="text-org10cda81">
 <p>
 Returns a single field. Will throw an error if the queries returns more than one field or more than one row
 </p>
@@ -1026,9 +1026,9 @@ Returns a single field. Will throw an error if the queries returns more than one
 </div>
 </div>
 </div>
-<div id="outline-container-org54ebbc9" class="outline-4">
-<h4 id="org54ebbc9">List</h4>
-<div class="outline-text-4" id="text-org54ebbc9">
+<div id="outline-container-org4f183cd" class="outline-4">
+<h4 id="org4f183cd">List</h4>
+<div class="outline-text-4" id="text-org4f183cd">
 <p>
 Returns a list containing the selected fields. Will throw an error if the query returns more than one row
 </p>
@@ -1039,9 +1039,9 @@ Returns a list containing the selected fields. Will throw an error if the query 
 </div>
 </div>
 </div>
-<div id="outline-container-org9673d2c" class="outline-4">
-<h4 id="org9673d2c">Lists</h4>
-<div class="outline-text-4" id="text-org9673d2c">
+<div id="outline-container-org16cef7b" class="outline-4">
+<h4 id="org16cef7b">Lists</h4>
+<div class="outline-text-4" id="text-org16cef7b">
 <p>
 This is the default
 </p>
@@ -1052,9 +1052,9 @@ This is the default
 </div>
 </div>
 </div>
-<div id="outline-container-orgbb292ae" class="outline-4">
-<h4 id="orgbb292ae">Alist</h4>
-<div class="outline-text-4" id="text-orgbb292ae">
+<div id="outline-container-org4d21548" class="outline-4">
+<h4 id="org4d21548">Alist</h4>
+<div class="outline-text-4" id="text-org4d21548">
 <p>
 Returns an alist containing the field name as a keyword and the selected fields. Will throw an error if the query returns more than one row.
 </p>
@@ -1065,9 +1065,9 @@ Returns an alist containing the field name as a keyword and the selected fields.
 </div>
 </div>
 </div>
-<div id="outline-container-orgdca0df5" class="outline-4">
-<h4 id="orgdca0df5">Str-alist</h4>
-<div class="outline-text-4" id="text-orgdca0df5">
+<div id="outline-container-org07246b0" class="outline-4">
+<h4 id="org07246b0">Str-alist</h4>
+<div class="outline-text-4" id="text-org07246b0">
 <p>
 Returns an alist containing the field name as a lower case string and the selected fields. Will throw an error if the query returns more than one row.
 </p>
@@ -1078,9 +1078,9 @@ Returns an alist containing the field name as a lower case string and the select
 </div>
 </div>
 </div>
-<div id="outline-container-org20423b3" class="outline-4">
-<h4 id="org20423b3">Alists</h4>
-<div class="outline-text-4" id="text-org20423b3">
+<div id="outline-container-orgd254966" class="outline-4">
+<h4 id="orgd254966">Alists</h4>
+<div class="outline-text-4" id="text-orgd254966">
 <p>
 Returns a list of alists containing the field name as a keyword and the selected fields.
 </p>
@@ -1092,9 +1092,9 @@ Returns a list of alists containing the field name as a keyword and the selected
 </div>
 </div>
 </div>
-<div id="outline-container-org847d465" class="outline-4">
-<h4 id="org847d465">Str-alists</h4>
-<div class="outline-text-4" id="text-org847d465">
+<div id="outline-container-org3bce759" class="outline-4">
+<h4 id="org3bce759">Str-alists</h4>
+<div class="outline-text-4" id="text-org3bce759">
 <p>
 Returns a list of alists containing the field name as a lower case string and the selected fields.
 </p>
@@ -1106,9 +1106,9 @@ Returns a list of alists containing the field name as a lower case string and th
 </div>
 </div>
 </div>
-<div id="outline-container-org473427a" class="outline-4">
-<h4 id="org473427a">Plist</h4>
-<div class="outline-text-4" id="text-org473427a">
+<div id="outline-container-org1e2a92c" class="outline-4">
+<h4 id="org1e2a92c">Plist</h4>
+<div class="outline-text-4" id="text-org1e2a92c">
 <p>
 Returns a plist containing the field name as a keyword and the selected fields. Will throw an error if the query returns more than one row.
 </p>
@@ -1119,9 +1119,9 @@ Returns a plist containing the field name as a keyword and the selected fields. 
 </div>
 </div>
 </div>
-<div id="outline-container-orgc2253da" class="outline-4">
-<h4 id="orgc2253da">Plists</h4>
-<div class="outline-text-4" id="text-orgc2253da">
+<div id="outline-container-org3dfd1b4" class="outline-4">
+<h4 id="org3dfd1b4">Plists</h4>
+<div class="outline-text-4" id="text-org3dfd1b4">
 <p>
 Returns a list of plists containing the field name as a keyword and the selected fields.
 </p>
@@ -1132,9 +1132,9 @@ Returns a list of plists containing the field name as a keyword and the selected
 </div>
 </div>
 </div>
-<div id="outline-container-org0cadffa" class="outline-4">
-<h4 id="org0cadffa">Vectors</h4>
-<div class="outline-text-4" id="text-org0cadffa">
+<div id="outline-container-org91f5657" class="outline-4">
+<h4 id="org91f5657">Vectors</h4>
+<div class="outline-text-4" id="text-org91f5657">
 <p>
 Returns a vector of vectors where each internal vector is a returned row from the query. The field names are not included. NOTE: It will return an empty vector instead of NIL if there is no result.
 </p>
@@ -1152,9 +1152,9 @@ Returns a vector of vectors where each internal vector is a returned row from th
 </div>
 </div>
 </div>
-<div id="outline-container-org9d426b6" class="outline-4">
-<h4 id="org9d426b6">Array-hash</h4>
-<div class="outline-text-4" id="text-org9d426b6">
+<div id="outline-container-org34781e4" class="outline-4">
+<h4 id="org34781e4">Array-hash</h4>
+<div class="outline-text-4" id="text-org34781e4">
 <p>
 Returns a vector of hashtables where each hash table is a returned row from the query with field name as the key expressed as a lower case string.
 </p>
@@ -1172,9 +1172,9 @@ Returns a vector of hashtables where each hash table is a returned row from the 
 </div>
 </div>
 </div>
-<div id="outline-container-orgbe4cfcd" class="outline-4">
-<h4 id="orgbe4cfcd">Dao</h4>
-<div class="outline-text-4" id="text-orgbe4cfcd">
+<div id="outline-container-org346d5d3" class="outline-4">
+<h4 id="org346d5d3">Dao</h4>
+<div class="outline-text-4" id="text-org346d5d3">
 <p>
 Returns a list of daos of the type specified
 </p>
@@ -1188,9 +1188,9 @@ Returns a list of daos of the type specified
 </div>
 </div>
 </div>
-<div id="outline-container-orgcac67df" class="outline-4">
-<h4 id="orgcac67df">Column</h4>
-<div class="outline-text-4" id="text-orgcac67df">
+<div id="outline-container-org6d2acc0" class="outline-4">
+<h4 id="org6d2acc0">Column</h4>
+<div class="outline-text-4" id="text-org6d2acc0">
 <p>
 Returns a list of field values of a single field. Will throw an error if more than one field is selected
 </p>
@@ -1204,9 +1204,9 @@ Returns a list of field values of a single field. Will throw an error if more th
 </div>
 </div>
 </div>
-<div id="outline-container-org54de871" class="outline-4">
-<h4 id="org54de871">Json-strs</h4>
-<div class="outline-text-4" id="text-org54de871">
+<div id="outline-container-org574f0cd" class="outline-4">
+<h4 id="org574f0cd">Json-strs</h4>
+<div class="outline-text-4" id="text-org574f0cd">
 <p>
 Return a list of strings where the row returned is a json object expressed as a string
 </p>
@@ -1244,9 +1244,9 @@ The following is an example with a simple-date timestamp.
 </div>
 </div>
 </div>
-<div id="outline-container-org354070e" class="outline-4">
-<h4 id="org354070e">Json-str</h4>
-<div class="outline-text-4" id="text-org354070e">
+<div id="outline-container-orgddc5227" class="outline-4">
+<h4 id="orgddc5227">Json-str</h4>
+<div class="outline-text-4" id="text-orgddc5227">
 <p>
 Return a single string where the row returned is a json object expressed as a string
 </p>
@@ -1261,9 +1261,9 @@ As with :json-strs, this will also work for either simple-date or local-time tim
 </div>
 </div>
 
-<div id="outline-container-org14fd5e7" class="outline-4">
-<h4 id="org14fd5e7">Json-array-str</h4>
-<div class="outline-text-4" id="text-org14fd5e7">
+<div id="outline-container-orgcd2770a" class="outline-4">
+<h4 id="orgcd2770a">Json-array-str</h4>
+<div class="outline-text-4" id="text-orgcd2770a">
 <p>
 Return a string containing a json array, each element in the array is a selected row expressed as a json object. NOTE: If there is no result, this will return a string with an empty json array.
 </p>
@@ -1280,9 +1280,9 @@ As with :json-strs, this will also work for either simple-date or local-time tim
 </p>
 </div>
 </div>
-<div id="outline-container-org86cb495" class="outline-4">
-<h4 id="org86cb495">Second value returned</h4>
-<div class="outline-text-4" id="text-org86cb495">
+<div id="outline-container-org7439ead" class="outline-4">
+<h4 id="org7439ead">Second value returned</h4>
+<div class="outline-text-4" id="text-org7439ead">
 <p>
 If the database returns information about the amount rows that were affected,
 such as with updating or deleting queries, this is returned as a second value.
@@ -2332,9 +2332,9 @@ Example usage where two identifiers are required would be constraints:
 </div>
 </div>
 
-<div id="outline-container-orgc966fe7" class="outline-3">
-<h3 id="orgc966fe7">find-comments (type identifier)</h3>
-<div class="outline-text-3" id="text-orgc966fe7">
+<div id="outline-container-org6913271" class="outline-3">
+<h3 id="org6913271">find-comments (type identifier)</h3>
+<div class="outline-text-3" id="text-org6913271">
 <p>
 Returns the comments attached to a particular database object. The allowed
 types are :database :schema :table :columns (all the columns in a table)
@@ -3507,9 +3507,9 @@ tables from one schema to another. Returns t if successful
 </div>
 </div>
 
-<div id="outline-container-orga7fad51" class="outline-3">
-<h3 id="orga7fad51">function rename-column (table-name old-name new-name)</h3>
-<div class="outline-text-3" id="text-orga7fad51">
+<div id="outline-container-orgbe3919b" class="outline-3">
+<h3 id="orgbe3919b">function rename-column (table-name old-name new-name)</h3>
+<div class="outline-text-3" id="text-orgbe3919b">
 <p>
 → boolean
 </p>
@@ -3694,6 +3694,10 @@ the test file test-execute-file-broken-transaction.sql as an example.
 <p>
 For debugging purposes, if the optional print parameter is set to t, format will
 print the count of the query and the query to the REPL.
+</p>
+
+<p>
+This function does not handle nested multiple line comments.
 </p>
 
 <p>

--- a/doc/postmodern.html
+++ b/doc/postmodern.html
@@ -3707,6 +3707,12 @@ print the count of the query and the query to the REPL.
 </p>
 
 <p>
+The default setting is to remove sql comments from the file before executing
+the sql code. If that causes problems, the remove-comments parameter can be
+set to nil.
+</p>
+
+<p>
 IMPORTANT NOTE: This utility function assumes that the file containing the sql
 queries can be trusted and bypasses the normal postmodern parameterization of
 queries.
@@ -3916,7 +3922,10 @@ Read SQL queries in given string and split them, returns a list.
 <h3 id="function-read-queries">function read-queries (filename)</h3>
 <div class="outline-text-3" id="text-function-read-queries">
 <p>
-Read SQL queries in a given file and split them, returns a list.
+Read SQL queries in a given file and split them, returns a list. Track included
+files so there is no accidental infinite loop. The default setting is to remove
+sql comments from the file before executing the sql code. If that causes problems,
+the remove-comments parameter can be set to nil.
 </p>
 </div>
 </div>

--- a/doc/postmodern.html
+++ b/doc/postmodern.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- 2021-08-18 Wed 11:32 -->
+<!-- 2021-08-28 Sat 14:31 -->
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Postmodern Reference Manual</title>
@@ -246,7 +246,7 @@
 <h2>Table of Contents</h2>
 <div id="text-table-of-contents">
 <ul>
-<li><a href="#org5bfa418">Overview</a></li>
+<li><a href="#org0e37726">Overview</a></li>
 <li><a href="#connecting">Connecting</a>
 <ul>
 <li><a href="#class-database-connection">class database-connection</a></li>
@@ -335,7 +335,7 @@
 <li><a href="#database-information">Database Information</a>
 <ul>
 <li><a href="#funciton-add-comment">function add-comment (type name comment &amp;optional (second-name ""))</a></li>
-<li><a href="#org6913271">find-comments (type identifier)</a></li>
+<li><a href="#orgd9ef66f">find-comments (type identifier)</a></li>
 <li><a href="#function-get-database-comment">function get-database-comment (database-name)</a></li>
 <li><a href="#function-postgresql-version">function postgresql-version ()</a></li>
 <li><a href="#function-database-version">function database-version ()</a></li>
@@ -427,7 +427,7 @@
 <li><a href="#function-get-table-comment">function get-table-comment (table-name &amp;optional schema-name)</a></li>
 <li><a href="#function-get-column-comments">function get-column-comments (database schema table)</a></li>
 <li><a href="#rename-table">function rename-table (old-name new-name)</a></li>
-<li><a href="#orgbe3919b">function rename-column (table-name old-name new-name)</a></li>
+<li><a href="#org1cca6d2">function rename-column (table-name old-name new-name)</a></li>
 </ul>
 </li>
 <li><a href="#tablespaces">Tablespaces</a>
@@ -494,9 +494,9 @@
 </div>
 </nav>
 
-<div id="outline-container-org5bfa418" class="outline-2">
-<h2 id="org5bfa418">Overview</h2>
-<div class="outline-text-2" id="text-org5bfa418">
+<div id="outline-container-org0e37726" class="outline-2">
+<h2 id="org0e37726">Overview</h2>
+<div class="outline-text-2" id="text-org0e37726">
 <p>
 This is the reference manual for the component named postmodern, which is part
 of a library of the same name.
@@ -1000,9 +1000,9 @@ instead. Any of the following formats can be used, with the default being :rows:
 Some Examples:
 </p>
 </div>
-<div id="outline-container-org7873dd9" class="outline-4">
-<h4 id="org7873dd9">Default</h4>
-<div class="outline-text-4" id="text-org7873dd9">
+<div id="outline-container-org781b9bb" class="outline-4">
+<h4 id="org781b9bb">Default</h4>
+<div class="outline-text-4" id="text-org781b9bb">
 <p>
 The default is :lists
 </p>
@@ -1013,9 +1013,9 @@ The default is :lists
 </div>
 </div>
 </div>
-<div id="outline-container-org10cda81" class="outline-4">
-<h4 id="org10cda81">Single</h4>
-<div class="outline-text-4" id="text-org10cda81">
+<div id="outline-container-org38a95c1" class="outline-4">
+<h4 id="org38a95c1">Single</h4>
+<div class="outline-text-4" id="text-org38a95c1">
 <p>
 Returns a single field. Will throw an error if the queries returns more than one field or more than one row
 </p>
@@ -1026,9 +1026,9 @@ Returns a single field. Will throw an error if the queries returns more than one
 </div>
 </div>
 </div>
-<div id="outline-container-org4f183cd" class="outline-4">
-<h4 id="org4f183cd">List</h4>
-<div class="outline-text-4" id="text-org4f183cd">
+<div id="outline-container-org88316af" class="outline-4">
+<h4 id="org88316af">List</h4>
+<div class="outline-text-4" id="text-org88316af">
 <p>
 Returns a list containing the selected fields. Will throw an error if the query returns more than one row
 </p>
@@ -1039,9 +1039,9 @@ Returns a list containing the selected fields. Will throw an error if the query 
 </div>
 </div>
 </div>
-<div id="outline-container-org16cef7b" class="outline-4">
-<h4 id="org16cef7b">Lists</h4>
-<div class="outline-text-4" id="text-org16cef7b">
+<div id="outline-container-orgcebaec5" class="outline-4">
+<h4 id="orgcebaec5">Lists</h4>
+<div class="outline-text-4" id="text-orgcebaec5">
 <p>
 This is the default
 </p>
@@ -1052,9 +1052,9 @@ This is the default
 </div>
 </div>
 </div>
-<div id="outline-container-org4d21548" class="outline-4">
-<h4 id="org4d21548">Alist</h4>
-<div class="outline-text-4" id="text-org4d21548">
+<div id="outline-container-orgcede354" class="outline-4">
+<h4 id="orgcede354">Alist</h4>
+<div class="outline-text-4" id="text-orgcede354">
 <p>
 Returns an alist containing the field name as a keyword and the selected fields. Will throw an error if the query returns more than one row.
 </p>
@@ -1065,9 +1065,9 @@ Returns an alist containing the field name as a keyword and the selected fields.
 </div>
 </div>
 </div>
-<div id="outline-container-org07246b0" class="outline-4">
-<h4 id="org07246b0">Str-alist</h4>
-<div class="outline-text-4" id="text-org07246b0">
+<div id="outline-container-orgbd77a6b" class="outline-4">
+<h4 id="orgbd77a6b">Str-alist</h4>
+<div class="outline-text-4" id="text-orgbd77a6b">
 <p>
 Returns an alist containing the field name as a lower case string and the selected fields. Will throw an error if the query returns more than one row.
 </p>
@@ -1078,9 +1078,9 @@ Returns an alist containing the field name as a lower case string and the select
 </div>
 </div>
 </div>
-<div id="outline-container-orgd254966" class="outline-4">
-<h4 id="orgd254966">Alists</h4>
-<div class="outline-text-4" id="text-orgd254966">
+<div id="outline-container-org048601f" class="outline-4">
+<h4 id="org048601f">Alists</h4>
+<div class="outline-text-4" id="text-org048601f">
 <p>
 Returns a list of alists containing the field name as a keyword and the selected fields.
 </p>
@@ -1092,9 +1092,9 @@ Returns a list of alists containing the field name as a keyword and the selected
 </div>
 </div>
 </div>
-<div id="outline-container-org3bce759" class="outline-4">
-<h4 id="org3bce759">Str-alists</h4>
-<div class="outline-text-4" id="text-org3bce759">
+<div id="outline-container-org345328f" class="outline-4">
+<h4 id="org345328f">Str-alists</h4>
+<div class="outline-text-4" id="text-org345328f">
 <p>
 Returns a list of alists containing the field name as a lower case string and the selected fields.
 </p>
@@ -1106,9 +1106,9 @@ Returns a list of alists containing the field name as a lower case string and th
 </div>
 </div>
 </div>
-<div id="outline-container-org1e2a92c" class="outline-4">
-<h4 id="org1e2a92c">Plist</h4>
-<div class="outline-text-4" id="text-org1e2a92c">
+<div id="outline-container-orgf965c0a" class="outline-4">
+<h4 id="orgf965c0a">Plist</h4>
+<div class="outline-text-4" id="text-orgf965c0a">
 <p>
 Returns a plist containing the field name as a keyword and the selected fields. Will throw an error if the query returns more than one row.
 </p>
@@ -1119,9 +1119,9 @@ Returns a plist containing the field name as a keyword and the selected fields. 
 </div>
 </div>
 </div>
-<div id="outline-container-org3dfd1b4" class="outline-4">
-<h4 id="org3dfd1b4">Plists</h4>
-<div class="outline-text-4" id="text-org3dfd1b4">
+<div id="outline-container-org376cc65" class="outline-4">
+<h4 id="org376cc65">Plists</h4>
+<div class="outline-text-4" id="text-org376cc65">
 <p>
 Returns a list of plists containing the field name as a keyword and the selected fields.
 </p>
@@ -1132,9 +1132,9 @@ Returns a list of plists containing the field name as a keyword and the selected
 </div>
 </div>
 </div>
-<div id="outline-container-org91f5657" class="outline-4">
-<h4 id="org91f5657">Vectors</h4>
-<div class="outline-text-4" id="text-org91f5657">
+<div id="outline-container-org70a7dda" class="outline-4">
+<h4 id="org70a7dda">Vectors</h4>
+<div class="outline-text-4" id="text-org70a7dda">
 <p>
 Returns a vector of vectors where each internal vector is a returned row from the query. The field names are not included. NOTE: It will return an empty vector instead of NIL if there is no result.
 </p>
@@ -1152,9 +1152,9 @@ Returns a vector of vectors where each internal vector is a returned row from th
 </div>
 </div>
 </div>
-<div id="outline-container-org34781e4" class="outline-4">
-<h4 id="org34781e4">Array-hash</h4>
-<div class="outline-text-4" id="text-org34781e4">
+<div id="outline-container-orga215b1e" class="outline-4">
+<h4 id="orga215b1e">Array-hash</h4>
+<div class="outline-text-4" id="text-orga215b1e">
 <p>
 Returns a vector of hashtables where each hash table is a returned row from the query with field name as the key expressed as a lower case string.
 </p>
@@ -1172,9 +1172,9 @@ Returns a vector of hashtables where each hash table is a returned row from the 
 </div>
 </div>
 </div>
-<div id="outline-container-org346d5d3" class="outline-4">
-<h4 id="org346d5d3">Dao</h4>
-<div class="outline-text-4" id="text-org346d5d3">
+<div id="outline-container-org6422ee7" class="outline-4">
+<h4 id="org6422ee7">Dao</h4>
+<div class="outline-text-4" id="text-org6422ee7">
 <p>
 Returns a list of daos of the type specified
 </p>
@@ -1188,9 +1188,9 @@ Returns a list of daos of the type specified
 </div>
 </div>
 </div>
-<div id="outline-container-org6d2acc0" class="outline-4">
-<h4 id="org6d2acc0">Column</h4>
-<div class="outline-text-4" id="text-org6d2acc0">
+<div id="outline-container-org1aae3dc" class="outline-4">
+<h4 id="org1aae3dc">Column</h4>
+<div class="outline-text-4" id="text-org1aae3dc">
 <p>
 Returns a list of field values of a single field. Will throw an error if more than one field is selected
 </p>
@@ -1204,9 +1204,9 @@ Returns a list of field values of a single field. Will throw an error if more th
 </div>
 </div>
 </div>
-<div id="outline-container-org574f0cd" class="outline-4">
-<h4 id="org574f0cd">Json-strs</h4>
-<div class="outline-text-4" id="text-org574f0cd">
+<div id="outline-container-org2746c3e" class="outline-4">
+<h4 id="org2746c3e">Json-strs</h4>
+<div class="outline-text-4" id="text-org2746c3e">
 <p>
 Return a list of strings where the row returned is a json object expressed as a string
 </p>
@@ -1244,9 +1244,9 @@ The following is an example with a simple-date timestamp.
 </div>
 </div>
 </div>
-<div id="outline-container-orgddc5227" class="outline-4">
-<h4 id="orgddc5227">Json-str</h4>
-<div class="outline-text-4" id="text-orgddc5227">
+<div id="outline-container-orgaa77e14" class="outline-4">
+<h4 id="orgaa77e14">Json-str</h4>
+<div class="outline-text-4" id="text-orgaa77e14">
 <p>
 Return a single string where the row returned is a json object expressed as a string
 </p>
@@ -1261,9 +1261,9 @@ As with :json-strs, this will also work for either simple-date or local-time tim
 </div>
 </div>
 
-<div id="outline-container-orgcd2770a" class="outline-4">
-<h4 id="orgcd2770a">Json-array-str</h4>
-<div class="outline-text-4" id="text-orgcd2770a">
+<div id="outline-container-org7a46ee8" class="outline-4">
+<h4 id="org7a46ee8">Json-array-str</h4>
+<div class="outline-text-4" id="text-org7a46ee8">
 <p>
 Return a string containing a json array, each element in the array is a selected row expressed as a json object. NOTE: If there is no result, this will return a string with an empty json array.
 </p>
@@ -1280,9 +1280,9 @@ As with :json-strs, this will also work for either simple-date or local-time tim
 </p>
 </div>
 </div>
-<div id="outline-container-org7439ead" class="outline-4">
-<h4 id="org7439ead">Second value returned</h4>
-<div class="outline-text-4" id="text-org7439ead">
+<div id="outline-container-orgde5bb8d" class="outline-4">
+<h4 id="orgde5bb8d">Second value returned</h4>
+<div class="outline-text-4" id="text-orgde5bb8d">
 <p>
 If the database returns information about the amount rows that were affected,
 such as with updating or deleting queries, this is returned as a second value.
@@ -2332,9 +2332,9 @@ Example usage where two identifiers are required would be constraints:
 </div>
 </div>
 
-<div id="outline-container-org6913271" class="outline-3">
-<h3 id="org6913271">find-comments (type identifier)</h3>
-<div class="outline-text-3" id="text-org6913271">
+<div id="outline-container-orgd9ef66f" class="outline-3">
+<h3 id="orgd9ef66f">find-comments (type identifier)</h3>
+<div class="outline-text-3" id="text-orgd9ef66f">
 <p>
 Returns the comments attached to a particular database object. The allowed
 types are :database :schema :table :columns (all the columns in a table)
@@ -3507,9 +3507,9 @@ tables from one schema to another. Returns t if successful
 </div>
 </div>
 
-<div id="outline-container-orgbe3919b" class="outline-3">
-<h3 id="orgbe3919b">function rename-column (table-name old-name new-name)</h3>
-<div class="outline-text-3" id="text-orgbe3919b">
+<div id="outline-container-org1cca6d2" class="outline-3">
+<h3 id="org1cca6d2">function rename-column (table-name old-name new-name)</h3>
+<div class="outline-text-3" id="text-org1cca6d2">
 <p>
 → boolean
 </p>
@@ -3694,10 +3694,6 @@ the test file test-execute-file-broken-transaction.sql as an example.
 <p>
 For debugging purposes, if the optional print parameter is set to t, format will
 print the count of the query and the query to the REPL.
-</p>
-
-<p>
-This function does not handle nested multiple line comments.
 </p>
 
 <p>

--- a/doc/postmodern.html
+++ b/doc/postmodern.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- 2021-08-28 Sat 14:31 -->
+<!-- 2021-09-06 Mon 20:51 -->
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Postmodern Reference Manual</title>
@@ -246,7 +246,7 @@
 <h2>Table of Contents</h2>
 <div id="text-table-of-contents">
 <ul>
-<li><a href="#org0e37726">Overview</a></li>
+<li><a href="#orgd5df816">Overview</a></li>
 <li><a href="#connecting">Connecting</a>
 <ul>
 <li><a href="#class-database-connection">class database-connection</a></li>
@@ -335,7 +335,7 @@
 <li><a href="#database-information">Database Information</a>
 <ul>
 <li><a href="#funciton-add-comment">function add-comment (type name comment &amp;optional (second-name ""))</a></li>
-<li><a href="#orgd9ef66f">find-comments (type identifier)</a></li>
+<li><a href="#orgc5f40b0">find-comments (type identifier)</a></li>
 <li><a href="#function-get-database-comment">function get-database-comment (database-name)</a></li>
 <li><a href="#function-postgresql-version">function postgresql-version ()</a></li>
 <li><a href="#function-database-version">function database-version ()</a></li>
@@ -427,7 +427,7 @@
 <li><a href="#function-get-table-comment">function get-table-comment (table-name &amp;optional schema-name)</a></li>
 <li><a href="#function-get-column-comments">function get-column-comments (database schema table)</a></li>
 <li><a href="#rename-table">function rename-table (old-name new-name)</a></li>
-<li><a href="#org1cca6d2">function rename-column (table-name old-name new-name)</a></li>
+<li><a href="#org1f998e5">function rename-column (table-name old-name new-name)</a></li>
 </ul>
 </li>
 <li><a href="#tablespaces">Tablespaces</a>
@@ -494,9 +494,9 @@
 </div>
 </nav>
 
-<div id="outline-container-org0e37726" class="outline-2">
-<h2 id="org0e37726">Overview</h2>
-<div class="outline-text-2" id="text-org0e37726">
+<div id="outline-container-orgd5df816" class="outline-2">
+<h2 id="orgd5df816">Overview</h2>
+<div class="outline-text-2" id="text-orgd5df816">
 <p>
 This is the reference manual for the component named postmodern, which is part
 of a library of the same name.
@@ -1000,9 +1000,9 @@ instead. Any of the following formats can be used, with the default being :rows:
 Some Examples:
 </p>
 </div>
-<div id="outline-container-org781b9bb" class="outline-4">
-<h4 id="org781b9bb">Default</h4>
-<div class="outline-text-4" id="text-org781b9bb">
+<div id="outline-container-org9a3342c" class="outline-4">
+<h4 id="org9a3342c">Default</h4>
+<div class="outline-text-4" id="text-org9a3342c">
 <p>
 The default is :lists
 </p>
@@ -1013,9 +1013,9 @@ The default is :lists
 </div>
 </div>
 </div>
-<div id="outline-container-org38a95c1" class="outline-4">
-<h4 id="org38a95c1">Single</h4>
-<div class="outline-text-4" id="text-org38a95c1">
+<div id="outline-container-orgf2dd32f" class="outline-4">
+<h4 id="orgf2dd32f">Single</h4>
+<div class="outline-text-4" id="text-orgf2dd32f">
 <p>
 Returns a single field. Will throw an error if the queries returns more than one field or more than one row
 </p>
@@ -1026,9 +1026,9 @@ Returns a single field. Will throw an error if the queries returns more than one
 </div>
 </div>
 </div>
-<div id="outline-container-org88316af" class="outline-4">
-<h4 id="org88316af">List</h4>
-<div class="outline-text-4" id="text-org88316af">
+<div id="outline-container-org8591f5a" class="outline-4">
+<h4 id="org8591f5a">List</h4>
+<div class="outline-text-4" id="text-org8591f5a">
 <p>
 Returns a list containing the selected fields. Will throw an error if the query returns more than one row
 </p>
@@ -1039,9 +1039,9 @@ Returns a list containing the selected fields. Will throw an error if the query 
 </div>
 </div>
 </div>
-<div id="outline-container-orgcebaec5" class="outline-4">
-<h4 id="orgcebaec5">Lists</h4>
-<div class="outline-text-4" id="text-orgcebaec5">
+<div id="outline-container-org9024d61" class="outline-4">
+<h4 id="org9024d61">Lists</h4>
+<div class="outline-text-4" id="text-org9024d61">
 <p>
 This is the default
 </p>
@@ -1052,9 +1052,9 @@ This is the default
 </div>
 </div>
 </div>
-<div id="outline-container-orgcede354" class="outline-4">
-<h4 id="orgcede354">Alist</h4>
-<div class="outline-text-4" id="text-orgcede354">
+<div id="outline-container-org5d8ed83" class="outline-4">
+<h4 id="org5d8ed83">Alist</h4>
+<div class="outline-text-4" id="text-org5d8ed83">
 <p>
 Returns an alist containing the field name as a keyword and the selected fields. Will throw an error if the query returns more than one row.
 </p>
@@ -1065,9 +1065,9 @@ Returns an alist containing the field name as a keyword and the selected fields.
 </div>
 </div>
 </div>
-<div id="outline-container-orgbd77a6b" class="outline-4">
-<h4 id="orgbd77a6b">Str-alist</h4>
-<div class="outline-text-4" id="text-orgbd77a6b">
+<div id="outline-container-org00f65fb" class="outline-4">
+<h4 id="org00f65fb">Str-alist</h4>
+<div class="outline-text-4" id="text-org00f65fb">
 <p>
 Returns an alist containing the field name as a lower case string and the selected fields. Will throw an error if the query returns more than one row.
 </p>
@@ -1078,9 +1078,9 @@ Returns an alist containing the field name as a lower case string and the select
 </div>
 </div>
 </div>
-<div id="outline-container-org048601f" class="outline-4">
-<h4 id="org048601f">Alists</h4>
-<div class="outline-text-4" id="text-org048601f">
+<div id="outline-container-org87839ba" class="outline-4">
+<h4 id="org87839ba">Alists</h4>
+<div class="outline-text-4" id="text-org87839ba">
 <p>
 Returns a list of alists containing the field name as a keyword and the selected fields.
 </p>
@@ -1092,9 +1092,9 @@ Returns a list of alists containing the field name as a keyword and the selected
 </div>
 </div>
 </div>
-<div id="outline-container-org345328f" class="outline-4">
-<h4 id="org345328f">Str-alists</h4>
-<div class="outline-text-4" id="text-org345328f">
+<div id="outline-container-orgf8967cc" class="outline-4">
+<h4 id="orgf8967cc">Str-alists</h4>
+<div class="outline-text-4" id="text-orgf8967cc">
 <p>
 Returns a list of alists containing the field name as a lower case string and the selected fields.
 </p>
@@ -1106,9 +1106,9 @@ Returns a list of alists containing the field name as a lower case string and th
 </div>
 </div>
 </div>
-<div id="outline-container-orgf965c0a" class="outline-4">
-<h4 id="orgf965c0a">Plist</h4>
-<div class="outline-text-4" id="text-orgf965c0a">
+<div id="outline-container-org972ca45" class="outline-4">
+<h4 id="org972ca45">Plist</h4>
+<div class="outline-text-4" id="text-org972ca45">
 <p>
 Returns a plist containing the field name as a keyword and the selected fields. Will throw an error if the query returns more than one row.
 </p>
@@ -1119,9 +1119,9 @@ Returns a plist containing the field name as a keyword and the selected fields. 
 </div>
 </div>
 </div>
-<div id="outline-container-org376cc65" class="outline-4">
-<h4 id="org376cc65">Plists</h4>
-<div class="outline-text-4" id="text-org376cc65">
+<div id="outline-container-orgce25ed2" class="outline-4">
+<h4 id="orgce25ed2">Plists</h4>
+<div class="outline-text-4" id="text-orgce25ed2">
 <p>
 Returns a list of plists containing the field name as a keyword and the selected fields.
 </p>
@@ -1132,9 +1132,9 @@ Returns a list of plists containing the field name as a keyword and the selected
 </div>
 </div>
 </div>
-<div id="outline-container-org70a7dda" class="outline-4">
-<h4 id="org70a7dda">Vectors</h4>
-<div class="outline-text-4" id="text-org70a7dda">
+<div id="outline-container-org766e53c" class="outline-4">
+<h4 id="org766e53c">Vectors</h4>
+<div class="outline-text-4" id="text-org766e53c">
 <p>
 Returns a vector of vectors where each internal vector is a returned row from the query. The field names are not included. NOTE: It will return an empty vector instead of NIL if there is no result.
 </p>
@@ -1152,9 +1152,9 @@ Returns a vector of vectors where each internal vector is a returned row from th
 </div>
 </div>
 </div>
-<div id="outline-container-orga215b1e" class="outline-4">
-<h4 id="orga215b1e">Array-hash</h4>
-<div class="outline-text-4" id="text-orga215b1e">
+<div id="outline-container-org031c5b3" class="outline-4">
+<h4 id="org031c5b3">Array-hash</h4>
+<div class="outline-text-4" id="text-org031c5b3">
 <p>
 Returns a vector of hashtables where each hash table is a returned row from the query with field name as the key expressed as a lower case string.
 </p>
@@ -1172,9 +1172,9 @@ Returns a vector of hashtables where each hash table is a returned row from the 
 </div>
 </div>
 </div>
-<div id="outline-container-org6422ee7" class="outline-4">
-<h4 id="org6422ee7">Dao</h4>
-<div class="outline-text-4" id="text-org6422ee7">
+<div id="outline-container-orgd732058" class="outline-4">
+<h4 id="orgd732058">Dao</h4>
+<div class="outline-text-4" id="text-orgd732058">
 <p>
 Returns a list of daos of the type specified
 </p>
@@ -1188,9 +1188,9 @@ Returns a list of daos of the type specified
 </div>
 </div>
 </div>
-<div id="outline-container-org1aae3dc" class="outline-4">
-<h4 id="org1aae3dc">Column</h4>
-<div class="outline-text-4" id="text-org1aae3dc">
+<div id="outline-container-org2932da5" class="outline-4">
+<h4 id="org2932da5">Column</h4>
+<div class="outline-text-4" id="text-org2932da5">
 <p>
 Returns a list of field values of a single field. Will throw an error if more than one field is selected
 </p>
@@ -1204,9 +1204,9 @@ Returns a list of field values of a single field. Will throw an error if more th
 </div>
 </div>
 </div>
-<div id="outline-container-org2746c3e" class="outline-4">
-<h4 id="org2746c3e">Json-strs</h4>
-<div class="outline-text-4" id="text-org2746c3e">
+<div id="outline-container-org867814d" class="outline-4">
+<h4 id="org867814d">Json-strs</h4>
+<div class="outline-text-4" id="text-org867814d">
 <p>
 Return a list of strings where the row returned is a json object expressed as a string
 </p>
@@ -1244,9 +1244,9 @@ The following is an example with a simple-date timestamp.
 </div>
 </div>
 </div>
-<div id="outline-container-orgaa77e14" class="outline-4">
-<h4 id="orgaa77e14">Json-str</h4>
-<div class="outline-text-4" id="text-orgaa77e14">
+<div id="outline-container-org5b26f6b" class="outline-4">
+<h4 id="org5b26f6b">Json-str</h4>
+<div class="outline-text-4" id="text-org5b26f6b">
 <p>
 Return a single string where the row returned is a json object expressed as a string
 </p>
@@ -1261,9 +1261,9 @@ As with :json-strs, this will also work for either simple-date or local-time tim
 </div>
 </div>
 
-<div id="outline-container-org7a46ee8" class="outline-4">
-<h4 id="org7a46ee8">Json-array-str</h4>
-<div class="outline-text-4" id="text-org7a46ee8">
+<div id="outline-container-orged8f337" class="outline-4">
+<h4 id="orged8f337">Json-array-str</h4>
+<div class="outline-text-4" id="text-orged8f337">
 <p>
 Return a string containing a json array, each element in the array is a selected row expressed as a json object. NOTE: If there is no result, this will return a string with an empty json array.
 </p>
@@ -1280,9 +1280,9 @@ As with :json-strs, this will also work for either simple-date or local-time tim
 </p>
 </div>
 </div>
-<div id="outline-container-orgde5bb8d" class="outline-4">
-<h4 id="orgde5bb8d">Second value returned</h4>
-<div class="outline-text-4" id="text-orgde5bb8d">
+<div id="outline-container-orga1ea164" class="outline-4">
+<h4 id="orga1ea164">Second value returned</h4>
+<div class="outline-text-4" id="text-orga1ea164">
 <p>
 If the database returns information about the amount rows that were affected,
 such as with updating or deleting queries, this is returned as a second value.
@@ -2332,9 +2332,9 @@ Example usage where two identifiers are required would be constraints:
 </div>
 </div>
 
-<div id="outline-container-orgd9ef66f" class="outline-3">
-<h3 id="orgd9ef66f">find-comments (type identifier)</h3>
-<div class="outline-text-3" id="text-orgd9ef66f">
+<div id="outline-container-orgc5f40b0" class="outline-3">
+<h3 id="orgc5f40b0">find-comments (type identifier)</h3>
+<div class="outline-text-3" id="text-orgc5f40b0">
 <p>
 Returns the comments attached to a particular database object. The allowed
 types are :database :schema :table :columns (all the columns in a table)
@@ -3507,9 +3507,9 @@ tables from one schema to another. Returns t if successful
 </div>
 </div>
 
-<div id="outline-container-org1cca6d2" class="outline-3">
-<h3 id="org1cca6d2">function rename-column (table-name old-name new-name)</h3>
-<div class="outline-text-3" id="text-org1cca6d2">
+<div id="outline-container-org1f998e5" class="outline-3">
+<h3 id="org1f998e5">function rename-column (table-name old-name new-name)</h3>
+<div class="outline-text-3" id="text-org1f998e5">
 <p>
 → boolean
 </p>
@@ -3682,6 +3682,16 @@ This function will execute sql queries stored in a file. Each sql statement in
 the file will be run independently, but if one statement fails, subsequent
 query statements will not be run, but any statement prior to the failing
 statement will have been commited.
+</p>
+
+<p>
+Execute-file allows the sql file to include other sql files, with the
+meta-commands \i or  \include which look for a file location relative to your
+default pathname (current working directory) or \ir or \include_relative which
+look for a file location relative to the initial sql file. If the file is not
+found in the expected location, execute-file will look to see if the requested
+file is in the other possible location. If that does not work, it will trigger
+an error with a restart which allows you to provide a new name for the file.
 </p>
 
 <p>

--- a/doc/postmodern.org
+++ b/doc/postmodern.org
@@ -2180,6 +2180,14 @@ the file will be run independently, but if one statement fails, subsequent
 query statements will not be run, but any statement prior to the failing
 statement will have been commited.
 
+Execute-file allows the sql file to include other sql files, with the
+meta-commands \i or  \include which look for a file location relative to your
+default pathname (current working directory) or \ir or \include_relative which
+look for a file location relative to the initial sql file. If the file is not
+found in the expected location, execute-file will look to see if the requested
+file is in the other possible location. If that does not work, it will trigger
+an error with a restart which allows you to provide a new name for the file.
+
 If you want the standard transction treatment such that all statements succeed
 or no statement succeeds, then ensure that the file starts with a "begin
 transaction" statement and finishes with an "end transaction" statement. See

--- a/doc/postmodern.org
+++ b/doc/postmodern.org
@@ -2188,8 +2188,6 @@ the test file test-execute-file-broken-transaction.sql as an example.
 For debugging purposes, if the optional print parameter is set to t, format will
 print the count of the query and the query to the REPL.
 
-This function does not handle nested multiple line comments.
-
 IMPORTANT NOTE: This utility function assumes that the file containing the sql
 queries can be trusted and bypasses the normal postmodern parameterization of
 queries.

--- a/doc/postmodern.org
+++ b/doc/postmodern.org
@@ -2196,6 +2196,10 @@ the test file test-execute-file-broken-transaction.sql as an example.
 For debugging purposes, if the optional print parameter is set to t, format will
 print the count of the query and the query to the REPL.
 
+The default setting is to remove sql comments from the file before executing
+the sql code. If that causes problems, the remove-comments parameter can be
+set to nil.
+
 IMPORTANT NOTE: This utility function assumes that the file containing the sql
 queries can be trusted and bypasses the normal postmodern parameterization of
 queries.
@@ -2345,7 +2349,10 @@ Read SQL queries in given string and split them, returns a list.
    :CUSTOM_ID: function-read-queries
    :END:
 
-Read SQL queries in a given file and split them, returns a list.
+Read SQL queries in a given file and split them, returns a list. Track included
+files so there is no accidental infinite loop. The default setting is to remove
+sql comments from the file before executing the sql code. If that causes problems,
+the remove-comments parameter can be set to nil.
 ** function sql-escape-string (string)
    :PROPERTIES:
    :CUSTOM_ID: function-sql-escape-string

--- a/doc/postmodern.org
+++ b/doc/postmodern.org
@@ -2188,6 +2188,8 @@ the test file test-execute-file-broken-transaction.sql as an example.
 For debugging purposes, if the optional print parameter is set to t, format will
 print the count of the query and the query to the REPL.
 
+This function does not handle nested multiple line comments.
+
 IMPORTANT NOTE: This utility function assumes that the file containing the sql
 queries can be trusted and bypasses the normal postmodern parameterization of
 queries.

--- a/postmodern.asd
+++ b/postmodern.asd
@@ -26,7 +26,6 @@
                "s-sql"
                "global-vars"
                "split-sequence"
-               "cl-unicode"
                "uiop"
                (:feature :postmodern-use-mop "closer-mop")
                (:feature :postmodern-thread-safe "bordeaux-threads"))

--- a/postmodern/execute-file.lisp
+++ b/postmodern/execute-file.lisp
@@ -377,7 +377,7 @@ and and return them in a stream. Recursively apply \i include instructions."
                                       "~a: Duplicate attempts to include sql files ~a skipped~%"
                                       *package* filename))
                              ""))))
-                   (t (format q "~a~%" line))))
+                     (format q "~a~%" line)))
           finally (return q)))
       (warn (format nil "~a: file ~a doesn't seem to exist. If this was supposed to be an included file, please note that \\i looks for a file location relative to your default pathname, in this case ~a. \\ir looks for a file location relative to the initial included file location, in the case ~a~%"
                     *package* filename

--- a/postmodern/execute-file.lisp
+++ b/postmodern/execute-file.lisp
@@ -409,7 +409,7 @@ include commands \ir or \include_relative. Returns nil otherwise."
 (defun read-sql-file (filename &key (included-files nil)
                                  (output-stream (make-string-output-stream))
                                  (remove-comments t))
-  "Read a given file and strip the comments. Read lines from the redacted result
+  "Read a given file and (default) remove the comments. Read lines from the redacted result
 and return them in a stream. Recursively apply \i include instructions."
   (if (uiop:file-exists-p filename)
       (with-input-from-string
@@ -451,7 +451,9 @@ and return them in a stream. Recursively apply \i include instructions."
 
 (defun read-queries (filename &key (remove-comments t))
   "Read SQL queries in given file and split them, returns a list. Track included
-files so there is no accidental infinite loop."
+files so there is no accidental infinite loop. The default setting is to remove
+sql comments from the file before executing the sql code. If that causes problems,
+the remove-comments parameter can be set to nil."
   (parse-queries
    (get-output-stream-string
     (read-sql-file filename :remove-comments remove-comments))))
@@ -487,6 +489,10 @@ test file test-execute-file-broken-transaction.sql as an example.
 
 For debugging purposes, if the optional print parameter is set to t, format
 will print the count of the query and the query to the REPL.
+
+The default setting is to remove sql comments from the file before executing
+the sql code. If that causes problems, the remove-comments parameter can be
+set to nil.
 
 IMPORTANT NOTE: This utility function assumes that the file containing the
 sql queries can be trusted and bypasses the normal postmodern parameterization

--- a/postmodern/execute-file.lisp
+++ b/postmodern/execute-file.lisp
@@ -201,7 +201,7 @@ should return
 ;; For multiple unnested multi-line comments in the same string.
 ;; Does not handle nested multi-line comments.
 (defparameter multi-line-comment-scanner
-  (cl-ppcre:create-scanner "//*.*?/*/" :single-line-mode t))
+  (cl-ppcre:create-scanner "/[*].*?[*]/"  :single-line-mode t))
 
 (defparameter single-line-comment-scanner
   (cl-ppcre:create-scanner "--.*"))

--- a/postmodern/execute-file.lisp
+++ b/postmodern/execute-file.lisp
@@ -41,7 +41,7 @@
                       (setf (mlc-parser-state state) :mlc)
                       (incf (mlc-parser-count state))))
              (:mlc  (setf (mlc-parser-state state) :me))
-             (:me   (setf (mlc-parser-state state) :mlc))))
+             (:me   (setf (mlc-parser-state state) :me))))
 
       (otherwise (case (mlc-parser-state state)
                    (:base
@@ -252,11 +252,6 @@ should return
     (end-of-file (e)
       (unless (eq :eat (parser-state state))
         (error e)))))
-
-;; For multiple unnested multi-line comments in the same string.
-;; Does not handle nested multi-line comments.
-(defparameter multi-line-comment-scanner
-  (cl-ppcre:create-scanner "/[*].*?[*]/"  :single-line-mode t))
 
 (defparameter single-line-comment-scanner
   (cl-ppcre:create-scanner "--.*"))

--- a/postmodern/execute-file.lisp
+++ b/postmodern/execute-file.lisp
@@ -203,6 +203,9 @@ should return
 (defparameter multi-line-comment-scanner
   (cl-ppcre:create-scanner "//*.*?/*/" :single-line-mode t))
 
+(defparameter single-line-comment-scanner
+  (cl-ppcre:create-scanner "--.*"))
+
 (defun read-lines (filename &optional (q (make-string-output-stream)))
   "Read lines from given filename and return them in a stream. Recursively
    apply \i include instructions."
@@ -219,7 +222,10 @@ should return
                                       (directory-namestring filename))))
                (read-lines include-filename q))
              (progn
-               (setf line (cl-ppcre::regex-replace "--.*" line "")) ; drop single line comments
+               (setf line (cl-ppcre::regex-replace
+                           single-line-comment-scanner
+                           line
+                           "")) ; drop single line comments
              (format q "~a~%" line)))
       finally (return q))))
 
@@ -234,9 +240,10 @@ should return
 
 (defun read-queries (filename)
   "Read SQL queries in given file and split them, returns a list"
-  (parse-queries (cl-ppcre:regex-replace-all multi-line-comment-scanner
-                                         (get-output-stream-string (read-lines filename))
-                                         "")))
+  (parse-queries (cl-ppcre:regex-replace-all
+                  multi-line-comment-scanner
+                  (get-output-stream-string (read-lines filename))
+                  "")))
 
 (defun execute-file (pathname &optional (print nil))
   "This function will execute sql queries stored in a file. Each sql statement

--- a/postmodern/execute-file.lisp
+++ b/postmodern/execute-file.lisp
@@ -270,7 +270,7 @@ replace the single line comments, returning the resulting string."
 (define-condition missing-i-file (error)
   ((%filename :reader filename :initarg :filename)
    (%base-filename :reader base-filename :initarg :base-filename)
-   ($meta-cmd :reader meta-cmd :initarg :meta-cmd))
+   (%meta-cmd :reader meta-cmd :initarg :meta-cmd))
   (:report (lambda (condition stream)
              (format stream "We tried but failed to find file ~a at the location
 specified by the ~a meta command.
@@ -303,16 +303,16 @@ include commands \ir or \include_relative. Returns nil otherwise."
   (cond ((and (> (length line) 3)
               (string= "\\i " (subseq line 0 3)))
          (values 'i (string-trim '(#\space #\tab) (subseq line 3))))
-         ((and (> (length line) 9)
+        ((and (> (length line) 9)
               (string= "\\include " (subseq line 0 9)))
          (values 'i (string-trim '(#\space #\tab) (subseq line 9))))
         ((and (> (length line) 4)
               (string= "\\ir " (subseq line 0 4)))
          (values 'ir (string-trim '(#\space #\tab) (subseq line 4))))
-         ((and (> (length line) 18)
-               (string= "\\include_relative " (subseq line 0 18)))
-          (values 'ir (string-trim '(#\space #\tab) (subseq line 18))))
-         (t nil)))
+        ((and (> (length line) 18)
+              (string= "\\include_relative " (subseq line 0 18)))
+         (values 'ir (string-trim '(#\space #\tab) (subseq line 18))))
+        (t nil)))
 
 (defun find-included-filename (meta-cmd new-filename base-filename)
   "Create full pathname if included using a \ir metacommand or \include_relative."
@@ -362,22 +362,22 @@ and and return them in a stream. Recursively apply \i include instructions."
           do
              (multiple-value-bind (meta-cmd new-filename)
                  (line-has-includes line)
-               (cond ((or (eq meta-cmd 'i)
-                          (eq meta-cmd 'ir))
-                      (let ((include-filename
-                              (find-included-filename meta-cmd new-filename filename)))
-                        (when new-filename
-                          (if (not (member include-filename included-files))
-                             (progn
-                               (push include-filename included-files)
-                               (read-sql-file include-filename included-files q))
-                             (progn
-                               (warn
-                                (format nil
-                                        "~a: Duplicate attempts to include sql files ~a skipped~%"
-                                        *package* filename))
-                               "")))))
-                     (t (format q "~a~%" line))))
+               (if (or (eq meta-cmd 'i)
+                       (eq meta-cmd 'ir))
+                   (let ((include-filename
+                           (find-included-filename meta-cmd new-filename filename)))
+                     (when new-filename
+                       (if (not (member include-filename included-files))
+                           (progn
+                             (push include-filename included-files)
+                             (read-sql-file include-filename included-files q))
+                           (progn
+                             (warn
+                              (format nil
+                                      "~a: Duplicate attempts to include sql files ~a skipped~%"
+                                      *package* filename))
+                             ""))))
+                   (t (format q "~a~%" line))))
           finally (return q)))
       (warn (format nil "~a: file ~a doesn't seem to exist. If this was supposed to be an included file, please note that \\i looks for a file location relative to your default pathname, in this case ~a. \\ir looks for a file location relative to the initial included file location, in the case ~a~%"
                     *package* filename

--- a/postmodern/tests/sub1/tef-4.sql
+++ b/postmodern/tests/sub1/tef-4.sql
@@ -1,0 +1,5 @@
+/* test' comment tef-4-1
+with multiple lines
+  --*/
+
+  insert into company_employees (id,name,age,address,include_file,join_date) values (10, 'Catharina', 32, 'Vienna', 'sub1/tef-4.sql','2011-04-13');

--- a/postmodern/tests/sub1/tef-5.sql
+++ b/postmodern/tests/sub1/tef-5.sql
@@ -1,0 +1,5 @@
+/* test' comment tef-5-1
+with multiple lines
+  --*/
+
+  insert into company_employees (id,name,age,address,include_file,join_date) values (11, 'Lisa', 32, 'Frankfurt', 'sub1/tef-5.sql','2011-04-13');

--- a/postmodern/tests/sub1/tef-7.sql
+++ b/postmodern/tests/sub1/tef-7.sql
@@ -1,0 +1,5 @@
+/* test' comment tef-7-1
+with multiple lines
+  --*/
+
+  insert into company_employees (id,name,age,address,include_file,join_date) values (155, 'Victor', 32, 'Warsaw', 'tef-7.sql','2011-04-13');

--- a/postmodern/tests/tef-1.sql
+++ b/postmodern/tests/tef-1.sql
@@ -2,10 +2,10 @@
 with multiple lines
   --*/
 
-  insert into company_employees (id,name,age,address,salary,join_date) values (7, 'robert', 32, 'Paris', 20000.00,'2011-04-13');
+  insert into company_employees (id,name,age,address,include_file,join_date) values (7, 'Robert', 32, 'Paris', 'tef-1.sql','2011-04-13');
 
 /*
 \i tef-2.sql
 */
 
-\i tef-1.sql
+-- \i tef-1.sql

--- a/postmodern/tests/tef-1.sql
+++ b/postmodern/tests/tef-1.sql
@@ -1,0 +1,11 @@
+/* test' comment tef-1-1
+with multiple lines
+  --*/
+
+  insert into company_employees (id,name,age,address,salary,join_date) values (7, 'robert', 32, 'Paris', 20000.00,'2011-04-13');
+
+/*
+\i tef-2.sql
+*/
+
+\i tef-1.sql

--- a/postmodern/tests/tef-2.sql
+++ b/postmodern/tests/tef-2.sql
@@ -2,4 +2,4 @@
 with multiple lines
   --*/
 
-  insert into company_employees (id,name,age,address,salary,join_date) values (8, 'Juan', 32, 'Madrid', 22000.00,'2011-04-13');
+  insert into company_employees (id,name,age,address,include_file,join_date) values (8, 'Juan', 32, 'Madrid', 'tef-2.sql','2011-04-13');

--- a/postmodern/tests/tef-2.sql
+++ b/postmodern/tests/tef-2.sql
@@ -1,0 +1,5 @@
+/* test' comment tef-2-1
+with multiple lines
+  --*/
+
+  insert into company_employees (id,name,age,address,salary,join_date) values (8, 'Juan', 32, 'Madrid', 22000.00,'2011-04-13');

--- a/postmodern/tests/tef-3.sql
+++ b/postmodern/tests/tef-3.sql
@@ -1,0 +1,5 @@
+/* test' comment tef-3-1
+with multiple lines
+  --*/
+
+  insert into company_employees (id,name,age,address,include_file,join_date) values (9, 'Julian', 32, 'Athens', 'tef-3.sql','2011-04-13');

--- a/postmodern/tests/tef-6.sql
+++ b/postmodern/tests/tef-6.sql
@@ -1,0 +1,5 @@
+/* test' comment tef-6-1
+with multiple lines
+  --*/
+
+  insert into company_employees (id,name,age,address,include_file,join_date) values (13, 'Stan', 32, 'Warsaw', 'tef-6.sql','2011-04-13');

--- a/postmodern/tests/test-execute-file.lisp
+++ b/postmodern/tests/test-execute-file.lisp
@@ -18,7 +18,7 @@
     (pomo:execute-file good-file)
     (is (table-exists-p 'company-employees))
     (is (equal "paul" (query (:select 'name :from 'company-employees :where (:= 'id 1)) :single)))
-    (is (equal 6 (query (:select (:count 'id) :from 'company-employees) :single)))
+    (is (equal 7 (query (:select (:count 'id) :from 'company-employees) :single)))
     (query (:drop-table :if-exists 'company-employees :cascade))))
 
 (test broken-execute-file

--- a/postmodern/tests/test-execute-file.lisp
+++ b/postmodern/tests/test-execute-file.lisp
@@ -23,8 +23,7 @@
     (pomo:execute-file *good-file*)
     (is (table-exists-p 'company-employees))
     (is (equal "Paul" (query (:select 'name :from 'company-employees :where (:= 'id 1)) :single)))
-    (is (equal 11 (query (:select (:count 'id) :from 'company-employees) :single)))
-    (query (:drop-table :if-exists 'company-employees :cascade))))
+    (is (equal 11 (query (:select (:count 'id) :from 'company-employees) :single)))))
 
 (test broken-execute-file
   (with-test-connection
@@ -52,3 +51,87 @@
       (query (:drop-table :if-exists 'company-employees :cascade)))
     (signals error (pomo:execute-file *fail-include-file*))
     (query (:drop-table :if-exists 'company-employees :cascade))))
+
+;; Test Parse Comments
+
+(test basic-multi-line1
+  (is (equal (postmodern::parse-comments " something1 /* comment */ something2")
+             " something1  something2")))
+
+(test basic-multi-line2
+  (is (equal (postmodern::parse-comments " something1 /*
+  comment */ something2")
+             " something1  something2")))
+
+(test basic-single-line
+  (is (equal (postmodern::parse-comments " something1 -- comment */ something2")
+             " something1 ")))
+
+(test multi-line-within-single-line
+  (is (equal (postmodern::parse-comments " something1 -- /* comment */ something2")
+             " something1 ")))
+
+(test multi-line-within-multi-line
+  (is (equal (postmodern::parse-comments " something1 /* outside comment
+ /* inside comment */ bad-something2 */ something2")
+             " something1  something2")))
+
+(test broken-nested-muli-line-comments
+  (is (equal (pomo::parse-comments "/* comment /* still the same comment */")
+             "")))
+
+(test single-line-within-multi-line
+  (is (equal (postmodern::parse-comments " something1 /* comm -- ent */ something2")
+             " something1  something2")))
+
+(test basic-fake-single-line
+  (is (equal (postmodern::parse-comments " something1 - something2")
+             " something1 - something2")))
+
+(test basic-fake-muli-line
+  (is (equal (postmodern::parse-comments " something1 / something2")
+             " something1 / something2")))
+
+(test multi-line-within-sql-string1
+  (is (equal (postmodern::parse-comments " something ('my wonder /* something */ company ')")
+             " something ('my wonder /* something */ company ')")))
+
+(test multi-line-within-sql-string2
+  (is (equal (postmodern::parse-comments "insert into a (d) values ('/*');")
+             "insert into a (d) values ('/*');")))
+
+(test single-line-within-sql-string1
+  (is (equal (postmodern::parse-comments " something ('my wonder -- company ')")
+             " something ('my wonder -- company ')")))
+
+(test single-line-within-sql-string2
+  (is (equal (postmodern::parse-comments "insert into a (d) values ('-- /*');")
+             "insert into a (d) values ('-- /*');")))
+
+(test asterisk-no-comment
+  (is (equal (pomo::parse-comments "select * from x")
+             "select * from x")))
+
+(test unicode-escapes
+  (is (equal (pomo::parse-comments "U&'d\\0061t\\+000061'")
+             "U&'d\\0061t\\+000061'")))
+
+(test dollar-quoted-string-constants1
+  (is (equal (pomo::parse-comments "$$Dianne's horse$$")
+             "$$Dianne's horse$$")))
+
+(test dollar-quoted-string-constants2
+  (is (equal (pomo::parse-comments "$function$
+BEGIN
+    RETURN ($1 ~ $q$[\\t\\r\\n\\v\\]$q$);
+END;
+$function$")
+             "$function$
+BEGIN
+    RETURN ($1 ~ $q$[\\t\\r\\n\\v\\]$q$);
+END;
+$function$")))
+
+(test single-quote-sql
+  (is (equal (pomo::parse-comments "REAL '1.23'  -- string style")
+             "REAL '1.23'  ")))

--- a/postmodern/tests/test-execute-file.sql
+++ b/postmodern/tests/test-execute-file.sql
@@ -1,3 +1,5 @@
+drop table if exists company_employees;
+
 create table company_employees(
    id bigserial primary key     not null,
    name           text    not null,
@@ -6,16 +8,20 @@ create table company_employees(
    salary         real,
    join_date	  date
 );
--- Test comment 1
+-- ;Test comment 1;;
 insert into company_employees (id,name,age,address,salary,join_date) values (1, 'paul', 32, 'London', 20100.00,'2001-07-13');
 insert into company_employees (id,name,age,address,salary,join_date) values (2, 'ziad', 32, 'Beirut', 20000.00,'2003-03-13');
-/* test comment 2
+/* test' comment 2
 with multiple lines
 */
 insert into company_employees (id,name,age,address,salary,join_date) values (3, 'john', 32, 'Toronto', 20100.00,'2005-07-13');
 insert into company_employees (id,name,age,address,salary,join_date) values (4, 'yasmin', 32, 'Mumbai', 20000.00,'2007-03-13');
-/* test comment 3 (asterisk in second line of multiline comment)
- * with multiple lines
+/* ;test comment 3 (asterisk in second line of multiline comment)
+ * with multiple lines;;
 */
-insert into company_employees (id,name,age,address,salary,join_date) values (5, 'susan', 32, 'Vancouver', 20100.00,'2009-07-13');
+  insert into company_employees (id,name,age,address,salary,join_date) values (5, 'susan', 32, 'Vancouver', 20100.00,'2009-07-13');
+/* ;test comment 4 (asterisk in second line of multiline comment)
+ * with multiple lines;;
+ * did I say something wrong?
+*/
 insert into company_employees (id,name,age,address,salary,join_date) values (6, 'johanna', 32, 'Berlin', 20000.00,'2011-03-13');

--- a/postmodern/tests/test-execute-file.sql
+++ b/postmodern/tests/test-execute-file.sql
@@ -13,18 +13,27 @@ insert into company_employees (id,name,age,address,salary,join_date) values (1, 
 insert into company_employees (id,name,age,address,salary,join_date) values (2, 'ziad', 32, 'Beirut', 20000.00,'2003-03-13');
 /* test' comment 2
 with multiple lines
+  --*/
+/*
+/*
+
 */
-insert into company_employees (id,name,age,address,salary,join_date) values (3, 'john', 32, 'Toronto', 20100.00,'2005-07-13');
+  ***/
+\i tef-1.sql
+
+  insert into company_employees (id,name,age,address,salary,join_date) values (3, 'john', 32, 'Toronto', 20100.00,'2005-07-13');
+  -- Yet another comments
 insert into company_employees (id,name,age,address,salary,join_date) values (4, 'yasmin', 32, 'Mumbai', 20000.00,'2007-03-13');
 /* ;test comment 3 (asterisk in /second/ line of multiline comment)
  * with multiple lines;;
 */
   insert into company_employees (id,name,age,address,salary,join_date) values (5, 'susan', 32, 'Vancouver', 20100.00,'2009-07-13');
 /* ;test comment 4 (asterisk in second line of multiline comment)
- * with multiple lines;;
+ *** with multiple lines;;
   /* test' comment 4-1
    with multiple lines
+  /***/
   */
  * did I say something wrong?
-*/
+--*/
 insert into company_employees (id,name,age,address,salary,join_date) values (6, 'johanna', 32, 'Berlin', 20000.00,'2011-03-13');

--- a/postmodern/tests/test-execute-file.sql
+++ b/postmodern/tests/test-execute-file.sql
@@ -5,12 +5,12 @@ create table company_employees(
    name           text    not null,
    age            int     not null,
    address        char(50),
-   salary         real,
+   include_file         text,
    join_date	  date
 );
 -- ;Test comment 1;;
-insert into company_employees (id,name,age,address,salary,join_date) values (1, 'paul', 32, 'London', 20100.00,'2001-07-13');
-insert into company_employees (id,name,age,address,salary,join_date) values (2, 'ziad', 32, 'Beirut', 20000.00,'2003-03-13');
+insert into company_employees (id,name,age,address,include_file,join_date) values (1, 'Paul', 32, 'London', 'test-execute-file','2001-07-13');
+insert into company_employees (id,name,age,address,include_file,join_date) values (2, 'Ziad', 32, 'Beirut', 'test-execute-file','2003-03-13');
 /* test' comment 2
 with multiple lines
   --*/
@@ -18,16 +18,21 @@ with multiple lines
 /*
 
 */
-  ***/
-\i tef-1.sql
+***/
+  --\i ./postmodern/tests/tef-11.sql
+\i tef-1.sql  -- an included file, will need to use fallback to find it
+\ir     tef-6.sql -- an included file using file location relative to this file
+  \ir   tef-3.sql
+\i sub1/tef-4.sql
+\ir ./sub1/tef-5.sql
 
-  insert into company_employees (id,name,age,address,salary,join_date) values (3, 'john', 32, 'Toronto', 20100.00,'2005-07-13');
+  insert into company_employees (id,name,age,address,include_file,join_date) values (3, 'John', 32, 'Toronto', 'test-execute-file','2005-07-13');
   -- Yet another comments
-insert into company_employees (id,name,age,address,salary,join_date) values (4, 'yasmin', 32, 'Mumbai', 20000.00,'2007-03-13');
+insert into company_employees (id,name,age,address,include_file,join_date) values (4, 'Yasmin', 32, 'Mumbai', 'test-execute-file','2007-03-13');
 /* ;test comment 3 (asterisk in /second/ line of multiline comment)
  * with multiple lines;;
 */
-  insert into company_employees (id,name,age,address,salary,join_date) values (5, 'susan', 32, 'Vancouver', 20100.00,'2009-07-13');
+  insert into company_employees (id,name,age,address,include_file,join_date) values (5, 'Susan', 32, 'Vancouver', 'test-execute-file','2009-07-13');
 /* ;test comment 4 (asterisk in second line of multiline comment)
  *** with multiple lines;;
   /* test' comment 4-1
@@ -36,4 +41,4 @@ insert into company_employees (id,name,age,address,salary,join_date) values (4, 
   */
  * did I say something wrong?
 --*/
-insert into company_employees (id,name,age,address,salary,join_date) values (6, 'johanna', 32, 'Berlin', 20000.00,'2011-03-13');
+insert into company_employees (id,name,age,address,include_file,join_date) values (6, 'Johanna', 32, 'Berlin', 'test-execute-file','2011-03-13');

--- a/postmodern/tests/test-execute-file.sql
+++ b/postmodern/tests/test-execute-file.sql
@@ -16,7 +16,7 @@ with multiple lines
 */
 insert into company_employees (id,name,age,address,salary,join_date) values (3, 'john', 32, 'Toronto', 20100.00,'2005-07-13');
 insert into company_employees (id,name,age,address,salary,join_date) values (4, 'yasmin', 32, 'Mumbai', 20000.00,'2007-03-13');
-/* ;test comment 3 (asterisk in second line of multiline comment)
+/* ;test comment 3 (asterisk in /second/ line of multiline comment)
  * with multiple lines;;
 */
   insert into company_employees (id,name,age,address,salary,join_date) values (5, 'susan', 32, 'Vancouver', 20100.00,'2009-07-13');

--- a/postmodern/tests/test-execute-file.sql
+++ b/postmodern/tests/test-execute-file.sql
@@ -22,6 +22,9 @@ insert into company_employees (id,name,age,address,salary,join_date) values (4, 
   insert into company_employees (id,name,age,address,salary,join_date) values (5, 'susan', 32, 'Vancouver', 20100.00,'2009-07-13');
 /* ;test comment 4 (asterisk in second line of multiline comment)
  * with multiple lines;;
+  /* test' comment 4-1
+   with multiple lines
+  */
  * did I say something wrong?
 */
 insert into company_employees (id,name,age,address,salary,join_date) values (6, 'johanna', 32, 'Berlin', 20000.00,'2011-03-13');

--- a/postmodern/tests/test-fail-include-execute-file.sql
+++ b/postmodern/tests/test-fail-include-execute-file.sql
@@ -1,0 +1,33 @@
+drop table if exists company_employees;
+
+create table company_employees(
+   id bigserial primary key     not null,
+   name           text    not null,
+   age            int     not null,
+   address        char(50),
+   include_file   text  ,
+   join_date	  date
+);
+
+insert into company_employees (id,name,age,address,include_file,join_date) values (1, 'Paul', 32, 'London', 'first-include-execute-file','2001-07-13');
+
+\i ./postmodern/tests/tef-11.sql
+
+  insert into company_employees (id,name,age,address,include_file,join_date) values (3, 'John', 32, 'Toronto', 'first-include-execute-file','2005-07-13');
+
+  \ir   tef-6.sql
+
+  insert into company_employees (id,name,age,address,include_file,join_date) values (6, 'Johanna', 32, 'Berlin', 'first-include-execute-file','2011-03-13');
+
+    \ir tef-3.sql
+
+    insert into company_employees (id,name,age,address,include_file,join_date) values (4, 'Yasmin', 32, 'Mumbai', 'first-include-execute-file','2007-03-13');
+
+  \i ./postmodern/tests/sub1/tef-4.sql
+
+    insert into company_employees (id,name,age,address,include_file,join_date) values (5, 'Susan', 32, 'Vancouver', 'first-include-execute-file','2009-07-13');
+
+\ir ./sub1/tef-5.sql
+
+
+insert into company_employees (id,name,age,address,include_file,join_date) values (2, 'Ziad', 32, 'Beirut', 'first-include-execute-file','2003-03-13');

--- a/postmodern/util.lisp
+++ b/postmodern/util.lisp
@@ -6,7 +6,7 @@
 
 (defun valid-sql-character-p (chr)
   "Returns t if chr is letter, underscore, digits or dollar sign"
-  (or (cl-unicode:has-property chr "Letter")
+  (or (uax-15:unicode-letter-p chr)
       (digit-char-p chr)
       (eq chr #\_)
       (eq chr #\$)))
@@ -25,7 +25,7 @@ First test is for a quoted string, which has less restrictions. "
               (notany #'code-char-0-p str))
         str)
         ((and (stringp str)
-              (or (cl-unicode:has-property (char str 0) "Letter")
+              (or (uax-15:unicode-letter-p (char str 0))
                   (eq (char str 0) #\_))
               (every #'valid-sql-character-p str)))
         (t nil)))


### PR DESCRIPTION
The execute-file function reads files of sql commands (which may include pulling 
in other files). Certain characters or combination of characters in sql comments 
would cause execute-file to fail. This commit fixes that and provides additional 
flexibility and safeguards.

Execute-file now by default removes single and multi-line comments from
sql files first before trying to parse them. This behavior can be changed
by passing nil as the new remove-comments optional parameter to execute-file.

The existing parsing code which looks at the sql commands themselves is 
untouched with this commit.

This commit adds \include and \include_relative and follows the
Postgresql practice that \i (and \include) and \ir (and
\include_relative) resolve differently.

Specifically \i or  \include which look for a file location relative
to your default pathname (current working directory) or \ir or
\include_relative which look for a file location relative to the
initial sql file.

If the file is not found in the expected location,
execute-file will look to see if the requested file is in the other
command location. In other words, if not found where \i would expect
it, is the file in the location that \ir would expect it? If the file
is not found in either location, a restart will be triggered
which allows you to provide a new name (including pathname) for the
file.

Execute-file now allows more flexibility in formatting in that
preceding spaces or tabs are now ignored at the beginning of an
inclusion meta-command line or excess spaces or tabs between the
meta-command and the filename of the file to be included.

Execute-file now tracks the files which have been included and will
not include a file twice (which would lead to infinite loops).

As a minor matter, this commit also removes the dependency on cl-unicode.