### PR TITLE
Flagging potential man-in-the-middle attack

### DIFF
--- a/cl-postgres/config.lisp
+++ b/cl-postgres/config.lisp
@@ -29,3 +29,7 @@ functionality, you will have to call LOG-QUERY from your callback function")
 (defvar *retry-connect-delay* 0.5
   "How many seconds to wait before trying to connect again. Borrowed from
 pgloader")
+
+(defparameter *on-evidence-of-man-in-the-middle-attack* :error
+  "If Postmodern sees evidence of an attempted man-in-the-middle attack,
+what should Postmodern do? Acceptable values are :error, :warn or :ignore")

--- a/cl-postgres/package.lisp
+++ b/cl-postgres/package.lisp
@@ -78,6 +78,7 @@
            #:parameter-lists-match-oid-types-p
            #:parameter-list-types
            #:param-to-oid
+           #:*on-evidence-of-man-in-the-middle-attack*
            #+(and sbcl unix) #:*unix-socket-dir*))
 
 (defpackage :cl-postgres-error

--- a/doc/cl-postgres.html
+++ b/doc/cl-postgres.html
@@ -236,6 +236,7 @@
 <li><a href="#variable-unix-socket-dir">variable <code>*unix-socket-dir*</code></a></li>
 <li><a href="#variable-ssl-certificate-file">variable <code>*ssl-certificate-file*</code></a></li>
 <li><a href="#variable-ssl-key-files">variable <code>*ssl-key-file*</code></a></li>
+<li><a href="#variable-on-evidence-of-man-in-the-middle-attack">variable <code>*on-evidence-of-man-in-the-middle-attack*</code></a></li>
 <li><a href="#variable-retry-connect-times">variable <code>*retry-connect-times*</code> (5)</a></li>
 <li><a href="#variable-retry-connect-delay">variable <code>*retry-connect-delay*</code> (0.5)</a></li>
 <li><a href="#function-wait-for-notification">function wait-for-notification (database-connection)</a></li>
@@ -546,6 +547,15 @@ will look for the socket file.
 <p>
 When using SSL (see open-database), these can be used to provide client key
 and certificate files. They can be either NIL, for no file, or a pathname.
+</p>
+</div>
+</div>
+
+<div id="outline-container-variable-on-evidence-of-man-in-the-middle-attack" class="outline-3">
+<h3 id="variable-on-evidence-of-man-in-the-middle-attack">variable <code>*on-evidence-of-man-in-the-middle-attack*</code></h3>
+<div class="outline-text-3" id="text-variable-on-evidence-of-man-in-the-middle-attack">
+  <p>
+    When establishing an SSL connection, Postmodern will check to see if unexpected extra data was received prior to the connection being encrypted. Unexpected extra data may indicate an attempted man-in-the-middle attack. By default, this variable is set to :error. You can set the response to be a simple warning (by setting this to :warn) or you can set this to :ignore.
 </p>
 </div>
 </div>

--- a/doc/cl-postgres.org
+++ b/doc/cl-postgres.org
@@ -185,6 +185,13 @@ will look for the socket file.
 When using SSL (see open-database), these can be used to provide client key
 and certificate files. They can be either NIL, for no file, or a pathname.
 
+** variable =*on-evidence-of-man-in-the-middle-attack*=
+   :PROPERTIES:
+   :CUSTOM_ID: variable-on-evidence-of-man-in-the-middle-attack
+   :END:
+
+When establishing an SSL connection, Postmodern will check to see if unexpected extra data was received prior to the connection being encrypted. Unexpected extra data may indicate an attempted man-in-the-middle attack. By default, this variable is set to :error. You can set the response to be a simple warning (by setting this to :warn) or you can set this to :ignore.
+
 ** variable =*retry-connect-times*= (5)
    :PROPERTIES:
    :CUSTOM_ID: variable-retry-connect-times


### PR DESCRIPTION
Postgresql discovered a potential security issue in its server and standard driver which might allow a potential man-in-the-middle attack while attempting to make an ssl connection. See
[https://www.postgresql.org/about/news/postgresql-141-135-129-1114-1019-and-9624-released-2349/](https://www.postgresql.org/about/news/postgresql-141-135-129-1114-1019-and-9624-released-2349/)
for more details. Whilst Postmodern does not have this issue, after discussions  with the Postgresql security team, we agreed to flag evidence of attempted attacks using this vector.

If Postmodern is trying to set up an ssl connection and unexpected extra data was received prior to an ssl connection being created, such unexpected extra data may indicate an attempted man-in-the-middle attack. With this commit, in such a situation, Postmodern will check the new cl-postgres exported variable *on-evidence-of-man-in-the-middle-attack* to determine its response. By default, this variable is set to :error. You can set the response to be a simple warning (by setting it to :warn) or you can set it to :ignore.