### PR TITLE
Added retry-transaction restart in the call-with-transaction function.

### DIFF
--- a/postmodern/package.lisp
+++ b/postmodern/package.lisp
@@ -65,6 +65,7 @@
    #:ensure-transaction-with-isolation-level
    #:abort-hooks
    #:commit-hooks
+   #:retry-transaction
    #:deftable
    #:*table-name*
    #:*table-symbol*

--- a/postmodern/transaction.lisp
+++ b/postmodern/transaction.lisp
@@ -62,7 +62,7 @@ arguments) to be executed at commit and abort time, respectively."))
   "Invokes the retry-transaction restart, if found."
   (let ((restart (find-restart 'retry-transaction condition)))
     (if (null restart)
-        (error "Attempting to invoke-restart RETRY-TRANSACTION but not such restart is active. Are you in the transaction block?")
+        (error "Attempting to invoke-restart RETRY-TRANSACTION but no such restart is active. Are you in the transaction block?")
         (invoke-restart restart))))
 
 (defun call-with-transaction (body &optional (isolation-level *isolation-level*))


### PR DESCRIPTION
This commit allows restarting transactions directly from the call-with-transaction call. Not safe for mutable code, obviously.