### PR TITLE
Remove (safety 0)

### DIFF
--- a/cl-postgres/messages.lisp
+++ b/cl-postgres/messages.lisp
@@ -128,7 +128,7 @@ message definitions themselves stay readable."
 (defun parse-message-binary-parameters (s name query parameters)
   "Like parse-message but specifically when binary parameters are parsed."
   (declare (type stream s)
-           (optimize (speed 3) (safety 0) (space 1) (debug 1)
+           (optimize (speed 3) (space 1) (debug 1)
                      (compilation-speed 0)))
   (let ((len (length parameters)))
     (write-uint1 s 80)


### PR DESCRIPTION
We should remove (safety 0) here.  With sbcl 2.2.7, we get ....

```
CORRUPTION WARNING in SBCL pid 17 tid 17:
Memory fault at (nil) (pc=0x54100a44 [code 0x54100750+0x2F4 ID 0xc530], fp=0x7facf1b374d0, sp=0x7facf1b374a0) tid 17
The integrity of this image is possibly compromised.
Exiting.
   0: fp=0x7facf1b374d0 pc=0x54100a44 CL-POSTGRES::PARSE-MESSAGE-BINARY-PARAMETERS
   1: fp=0x7facf1b375c0 pc=0x541163e9 CL-POSTGRES::SEND-PARSE
   2: fp=0x7facf1b376f8 pc=0x541230c5 (SB-PCL::FAST-METHOD DBI.DRIVER::PING (DBD.POSTGRES::<DBD-POSTGRES-CONNECTION>))
   3: fp=0x7facf1b37790 pc=0x53a6f194 DBI::CONNECT-CACHED
   4: fp=0x7facf1b37838 pc=0x53adc8bb (SB-PCL::FAST-METHOD INITIALIZE-INSTANCE :AFTER (RLGL.DB::DB/POSTGRESQL))
   5: fp=0x7facf1b37880 pc=0x540eb8a9 (LAMBDA (SB-PCL::.P0. SB-PCL::.P1. SB-PCL::.P2. SB-PCL::.P3. SB-PCL::.P4.))
   6: fp=0x7facf1b37960 pc=0x540e948d RLGL-SERVER::START-RLGL-SERVER
   7: fp=0x7facf1b37a28 pc=0x52b4e457 SB-INT::SIMPLE-EVAL-IN-LEXENV
   8: fp=0x7facf1b37a40 pc=0x52a47513 EVAL
   9: fp=0x7facf1b37bf0 pc=0x52c6c95a SB-IMPL::PROCESS-EVAL/LOAD-OPTIONS
  10: fp=0x7facf1b37dc0 pc=0x52ba472a SB-IMPL::TOPLEVEL-INIT
  11: fp=0x7facf1b37e60 pc=0x52f4af75 (FLET SB-UNIX::BODY :IN SB-IMPL::START-LISP)
  12: fp=0x7facf1b37f28 pc=0x52f4ad76 (FLET "WITHOUT-INTERRUPTS-BODY-3" :IN SB-IMPL::START-LISP)
  13: fp=0x7facf1b37fc8 pc=0x52f4ab23 SB-IMPL::%START-LISP
```
