### PR TITLE
Minor fixes and clarifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# Changelog v. 1.33.5
+Discontinue support for versions of sbcl < 1.2.5 which were compiled without support for bsd-sockets.
+
+Drop unwarrented assumption that the role 'postgres' will always exist when dropping a role resulting in ownership changes of postgresql objects.
+
+Add more documentation on the limitation in s-sql on using lists in a parameterized statement. If you are trying to use a list in a parametized statement, you can't. You have to convert the list to a vector and use "any" rather than "in."
+
+Add additional support for ssl connections to allow use of a root certificate for validation. Set \*ssl-root-ca-file* to the pathname for the root certificate.
+
 # Changelog v. 1.33.4
 Fix bug in a warning in execute-file that referred to the current package rather than Postmodern.
 
@@ -605,7 +614,7 @@ Examples:
     and https://www.b-list.org/weblog/2018/feb/11/usernames/
 
     :allow-disallowed-names defaults to nil. If nil, the user name will be checked
-    against *disallowed-role-names*.
+    against \*disallowed-role-names*.
 
     As an aside, if allowing utf8 in names, you might want to think about whether
     you should create second copy of the username in the original casing and normalized

--- a/README.md
+++ b/README.md
@@ -99,7 +99,16 @@ If the Postgresql server is running on a port other than 5432, you would also pa
 (connect-toplevel "testdb" "foucault" "surveiller" "localhost" :port 5434)
 ```
 
-Ssl connections would similarly use the keyword parameter :use-ssl and pass :yes, :no or :try
+Ssl connections would similarly use the keyword parameter :use-ssl and pass :yes, :no, :try, :require or :full
+
+
+- :try means if the server supports it
+- :require means use provided ssl certificate with no verification
+- :yes means verify that the server cert is issued by a trusted CA, but does not verify the server hostname
+- :full means expect a CA-signed cert for the supplied hostname and verify the server hostname
+
+When using ssl, you can set the cl-postgres exported variables \*ssl-certificate-file\*,  \*ssl-key-file\* and  \*ssl-root-ca-file\* to provide client key, certificate files
+and root ca files. They can be either NIL, for no file, or a pathname.
 
 If you have multiple roles connecting to one or more databases, i.e. 1:many or
 many:1, (in other words, changing connections) or you are using threads (each thread will need to have its own connection) then with-connection form which establishes a connection with a lexical scope is more appropriate.
@@ -134,7 +143,7 @@ will take additiona time and create more overhead.
 
 Postgresql can be tuned to limit the number of connections allowed at any one time. It defaults to 100. The parameter is set in the postgresql.conf file. Depending on the size of your server and what you are doing, the sweet spot generally seems to be between 200-400 connections before you need to bring in connection pooling.
 
-If your application is threaded, each thread should use its own connection. Connections are stateful and attempts to use the same connection for multiple threads will
+If your application is threaded, each thread should use its own connection. Connections are stateful and attempts to use the same connection for multiple threads will likely have problems.
 
 If you have an application like a web app which will make many connections, you also
 generally do not want to create and drop connections for every query. The usual solution

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Common Lisp PostgreSQL programming interface
 
 ---
 
-Version 1.33.4
+Version 1.33.5
 
 Postmodern is a Common Lisp library for interacting with [PostgreSQL](http://www.postgresql.org) databases. It is under active development. Features are:
 

--- a/cl-postgres.asd
+++ b/cl-postgres.asd
@@ -16,7 +16,7 @@
   :author "Marijn Haverbeke <marijnh@gmail.com>"
   :maintainer "Sabra Crolleton <sabra.crolleton@gmail.com>"
   :license "zlib"
-  :version "1.33.4"
+  :version "1.33.5"
   :depends-on ("md5" "split-sequence" "ironclad" "cl-base64" "uax-15"
                      (:feature (:or :allegro :ccl :clisp :genera
                                 :armedbear :cmucl :lispworks)

--- a/cl-postgres.asd
+++ b/cl-postgres.asd
@@ -18,7 +18,7 @@
   :license "zlib"
   :version "1.33.4"
   :depends-on ("md5" "split-sequence" "ironclad" "cl-base64" "uax-15"
-                     (:feature (:or :sbcl :allegro :ccl :clisp :genera
+                     (:feature (:or :allegro :ccl :clisp :genera
                                 :armedbear :cmucl :lispworks)
                                "usocket")
                      (:feature :sbcl (:require :sb-bsd-sockets)))

--- a/cl-postgres/package.lisp
+++ b/cl-postgres/package.lisp
@@ -63,6 +63,7 @@
            #:close-db-writer
            #:*ssl-certificate-file*
            #:*ssl-key-file*
+           #:*ssl-root-ca-file*
            #:*retry-connect-times*
            #:*retry-connect-delay*
            #:string-mapped-to-nothing
@@ -72,7 +73,7 @@
            #:int4
            #:int8
            #:uuid-string
-           #:-uuip-p
+           #:uuip-p
            #:types-match-p
            #:oid-types-match-p
            #:parameter-lists-match-oid-types-p

--- a/doc/cl-postgres.html
+++ b/doc/cl-postgres.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- 2021-08-03 Tue 10:58 -->
+<!-- 2022-04-02 Sat 13:13 -->
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Cl-Postgres Reference Manual</title>
@@ -236,6 +236,7 @@
 <li><a href="#variable-unix-socket-dir">variable <code>*unix-socket-dir*</code></a></li>
 <li><a href="#variable-ssl-certificate-file">variable <code>*ssl-certificate-file*</code></a></li>
 <li><a href="#variable-ssl-key-files">variable <code>*ssl-key-file*</code></a></li>
+<li><a href="#variable-ssl-root-ca-files">variable <code>*ssl-root-ca-file*</code></a></li>
 <li><a href="#variable-on-evidence-of-man-in-the-middle-attack">variable <code>*on-evidence-of-man-in-the-middle-attack*</code></a></li>
 <li><a href="#variable-retry-connect-times">variable <code>*retry-connect-times*</code> (5)</a></li>
 <li><a href="#variable-retry-connect-delay">variable <code>*retry-connect-delay*</code> (0.5)</a></li>
@@ -369,6 +370,12 @@ use-ssl may be :no, :try, :require, :yes, or :full
 <p>
 If you set it to anything other than :no be sure to also load the CL+SSL library.
 When it is anything but :no, you must have the CL+SSL package loaded to initiate the connection.
+</p>
+
+<p>
+When using ssl, you can set the exported variables <code>*ssl-certificate-file*</code>,  <code>*ssl-key-file*</code>
+and  <code>*ssl-root-ca-file*</code> to provide client key, certificate files
+and root ca files. They can be either NIL, for no file, or a pathname.
 </p>
 
 <p>
@@ -544,9 +551,14 @@ will look for the socket file.
 <div id="outline-container-variable-ssl-key-files" class="outline-3">
 <h3 id="variable-ssl-key-files">variable <code>*ssl-key-file*</code></h3>
 <div class="outline-text-3" id="text-variable-ssl-key-files">
+</div>
+</div>
+<div id="outline-container-variable-ssl-root-ca-files" class="outline-3">
+<h3 id="variable-ssl-root-ca-files">variable <code>*ssl-root-ca-file*</code></h3>
+<div class="outline-text-3" id="text-variable-ssl-root-ca-files">
 <p>
-When using SSL (see open-database), these can be used to provide client key
-and certificate files. They can be either NIL, for no file, or a pathname.
+When using SSL (see open-database), these can be used to provide client key, certificate files
+and root ca files. They can be either NIL, for no file, or a pathname.
 </p>
 </div>
 </div>
@@ -554,8 +566,8 @@ and certificate files. They can be either NIL, for no file, or a pathname.
 <div id="outline-container-variable-on-evidence-of-man-in-the-middle-attack" class="outline-3">
 <h3 id="variable-on-evidence-of-man-in-the-middle-attack">variable <code>*on-evidence-of-man-in-the-middle-attack*</code></h3>
 <div class="outline-text-3" id="text-variable-on-evidence-of-man-in-the-middle-attack">
-  <p>
-    When establishing an SSL connection, Postmodern will check to see if unexpected extra data was received prior to the connection being encrypted. Unexpected extra data may indicate an attempted man-in-the-middle attack. By default, this variable is set to :error. You can set the response to be a simple warning (by setting this to :warn) or you can set this to :ignore.
+<p>
+When establishing an SSL connection, Postmodern will check to see if unexpected extra data was received prior to the connection being encrypted. Unexpected extra data may indicate an attempted man-in-the-middle attack. By default, this variable is set to :error. You can set the response to be a simple warning (by setting this to :warn) or you can set this to :ignore.
 </p>
 </div>
 </div>

--- a/doc/cl-postgres.org
+++ b/doc/cl-postgres.org
@@ -52,6 +52,10 @@ use-ssl may be :no, :try, :require, :yes, or :full
 If you set it to anything other than :no be sure to also load the CL+SSL library.
 When it is anything but :no, you must have the CL+SSL package loaded to initiate the connection.
 
+When using ssl, you can set the exported variables =*ssl-certificate-file*=,  =*ssl-key-file*=
+and  =*ssl-root-ca-file*= to provide client key, certificate files
+and root ca files. They can be either NIL, for no file, or a pathname.
+
 On SBCL and Clozure CL, the value :unix may be passed for host, in order to
 connect using a Unix domain socket instead of a TCP socket.
 
@@ -181,9 +185,12 @@ will look for the socket file.
    :PROPERTIES:
    :CUSTOM_ID: variable-ssl-key-files
    :END:
-
-When using SSL (see open-database), these can be used to provide client key
-and certificate files. They can be either NIL, for no file, or a pathname.
+** variable =*ssl-root-ca-file*=
+   :PROPERTIES:
+   :CUSTOM_ID: variable-ssl-root-ca-files
+   :END:
+When using SSL (see open-database), these can be used to provide client key, certificate files
+and root ca files. They can be either NIL, for no file, or a pathname.
 
 ** variable =*on-evidence-of-man-in-the-middle-attack*=
    :PROPERTIES:

--- a/doc/index.html
+++ b/doc/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- 2022-02-11 Fri 10:51 -->
+<!-- 2022-04-02 Sat 13:13 -->
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Postmodern</title>
@@ -250,8 +250,8 @@
 <ul>
 <li><a href="#e5c68251-0ca6-4f96-8d36-175cec626eeb">Timezones and Simple-Date and Local-Time</a>
 <ul>
-<li><a href="#orga2d6dea">Simple-Date Library Use</a></li>
-<li><a href="#org58574b4">Local-Time Library Use</a></li>
+<li><a href="#orgad0d64e">Simple-Date Library Use</a></li>
+<li><a href="#org104debd">Local-Time Library Use</a></li>
 </ul>
 </li>
 <li><a href="#bdf9ddb0-5f95-4807-8862-8970b35bd142">Portability</a></li>
@@ -432,6 +432,11 @@ pass :no, :try, :require, :yes, or :full
 </ul>
 
 <p>
+When using ssl, you can set the cl-postgres exported variables <code>*ssl-certificate-file*</code>,  <code>*ssl-key-file*</code> and  <code>*ssl-root-ca-file*</code> to provide client key, certificate files
+and root ca files. They can be either NIL, for no file, or a pathname.
+</p>
+
+<p>
 If you have multiple roles connecting to one or more databases, i.e. 1:many or
 many:1, (in other words, changing connections) or you are using threads (each thread must have its own connection) then with Postmodern you can use the <code>with-connection</code> form which establishes a connection with a lexical scope is more appropriate.
 </p>
@@ -477,7 +482,7 @@ Postgresql can be tuned to limit the number of connections allowed at any one ti
 </p>
 
 <p>
-If your application is threaded, each thread should use its own connection. Connections are stateful and attempts to use the same connection for multiple threads will
+If your application is threaded, each thread should use its own connection. Connections are stateful and attempts to use the same connection for multiple threads will likely have problems.
 </p>
 
 <p>
@@ -1530,9 +1535,9 @@ Now the s-sql version:
 </pre>
 </div>
 </div>
-<div id="outline-container-orga2d6dea" class="outline-4">
-<h4 id="orga2d6dea">Simple-Date Library Use</h4>
-<div class="outline-text-4" id="text-orga2d6dea">
+<div id="outline-container-orgad0d64e" class="outline-4">
+<h4 id="orgad0d64e">Simple-Date Library Use</h4>
+<div class="outline-text-4" id="text-orgad0d64e">
 <p>
 The Simple-date add-on library (not enabled by default)
 provides types (CLOS classes) for dates, timestamps, and intervals
@@ -1654,9 +1659,9 @@ used to convert it to proper UTC timestamp.
 </div>
 </div>
 
-<div id="outline-container-org58574b4" class="outline-4">
-<h4 id="org58574b4">Local-Time Library Use</h4>
-<div class="outline-text-4" id="text-org58574b4">
+<div id="outline-container-org104debd" class="outline-4">
+<h4 id="org104debd">Local-Time Library Use</h4>
+<div class="outline-text-4" id="text-org104debd">
 <p>
 For those who want to use local-time, to enable the local-time reader:
 </p>

--- a/doc/index.org
+++ b/doc/index.org
@@ -117,6 +117,9 @@ pass :no, :try, :require, :yes, or :full
 - :yes means verify that the server cert is issued by a trusted CA, but does not verify the server hostname
 - :full means expect a CA-signed cert for the supplied hostname and verify the server hostname
 
+When using ssl, you can set the cl-postgres exported variables =*ssl-certificate-file*=,  =*ssl-key-file*= and  =*ssl-root-ca-file*= to provide client key, certificate files
+and root ca files. They can be either NIL, for no file, or a pathname.
+
 If you have multiple roles connecting to one or more databases, i.e. 1:many or
 many:1, (in other words, changing connections) or you are using threads (each thread must have its own connection) then with Postmodern you can use the =with-connection= form which establishes a connection with a lexical scope is more appropriate.
 #+BEGIN_SRC lisp
@@ -148,7 +151,7 @@ more overhead.
 
 Postgresql can be tuned to limit the number of connections allowed at any one time. It defaults to 100. The parameter is set in the postgresql.conf file. Depending on the size of your server and what you are doing, the sweet spot generally seems to be between 200-400 connections before you need to bring in connection pooling.
 
-If your application is threaded, each thread should use its own connection. Connections are stateful and attempts to use the same connection for multiple threads will
+If your application is threaded, each thread should use its own connection. Connections are stateful and attempts to use the same connection for multiple threads will likely have problems.
 
 If you have an application like a web app which will make many connections, you also
 generally do not want to create and drop connections for every query. The usual solution
@@ -162,7 +165,7 @@ To use postmodern's simple connection pooler, the =with-connection= call would l
 #+END_SRC
 
 The maximum number of connections in the pool is set in the special variable
-*max-pool-size*, which defaults to nil (no maximum).
+=*max-pool-size*=, which defaults to nil (no maximum).
 
 Now for a basic sanity test which does not need a database connection at all:
 

--- a/doc/postmodern.html
+++ b/doc/postmodern.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- 2022-01-21 Fri 15:02 -->
+<!-- 2022-04-02 Sat 13:13 -->
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Postmodern Reference Manual</title>
@@ -568,8 +568,11 @@ and defaults to the value of <code>*default-use-ssl*</code>
 <li>:yes means verify that the server cert is issued by a trusted CA, but does not verify the server hostname</li>
 <li>:full means expect a CA-signed cert for the supplied hostname and verify the server hostname</li>
 </ul>
+
 <p>
-If you set it to anything other than :no be sure to also load the CL+SSL library.
+If you set it to anything other than :no be sure to also load the CL+SSL library. When using ssl, you can set the cl-postgres exported variables <code>*ssl-certificate-file*</code>,  <code>*ssl-key-file*</code>
+and  <code>*ssl-root-ca-file*</code> to provide client key, certificate files
+and root ca files. They can be either NIL, for no file, or a pathname.
 </p>
 
 <p>

--- a/doc/postmodern.org
+++ b/doc/postmodern.org
@@ -62,7 +62,10 @@ and defaults to the value of =*default-use-ssl*=
 - :require means use provided ssl certificate with no verification
 - :yes means verify that the server cert is issued by a trusted CA, but does not verify the server hostname
 - :full means expect a CA-signed cert for the supplied hostname and verify the server hostname
-If you set it to anything other than :no be sure to also load the CL+SSL library.
+
+If you set it to anything other than :no be sure to also load the CL+SSL library. When using ssl, you can set the cl-postgres exported variables =*ssl-certificate-file*=,  =*ssl-key-file*=
+and  =*ssl-root-ca-file*= to provide client key, certificate files
+and root ca files. They can be either NIL, for no file, or a pathname.
 
 Service defaults to "postgres".
 

--- a/doc/s-sql.html
+++ b/doc/s-sql.html
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- 2021-04-25 Sun 12:36 -->
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
+<!-- 2022-07-06 Wed 06:10 -->
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>S-SQL Reference Manual</title>
-<meta name="generator" content="Org mode">
-<meta name="author" content="Sabra Crolleton">
-<style type="text/css">
- <!--/*--><![CDATA[/*><!--*/
+<meta name="author" content="Sabra Crolleton" />
+<meta name="generator" content="Org Mode" />
+<style>
+  #content { max-width: 60em; margin: auto; }
   .title  { text-align: center;
              margin-bottom: .2em; }
   .subtitle { text-align: center;
@@ -29,8 +29,9 @@
   #postamble p, #preamble p { font-size: 90%; margin: .2em; }
   p.verse { margin-left: 3%; }
   pre {
-    border: 1px solid #ccc;
-    box-shadow: 3px 3px 3px #eee;
+    border: 1px solid #e6e6e6;
+    border-radius: 3px;
+    background-color: #f2f2f2;
     padding: 8pt;
     font-family: monospace;
     overflow: auto;
@@ -39,21 +40,21 @@
   pre.src {
     position: relative;
     overflow: auto;
-    padding-top: 1.2em;
   }
   pre.src:before {
     display: none;
     position: absolute;
-    background-color: white;
-    top: -10px;
-    right: 10px;
+    top: -8px;
+    right: 12px;
     padding: 3px;
-    border: 1px solid black;
+    color: #555;
+    background-color: #f2f2f299;
   }
   pre.src:hover:before { display: inline; margin-top: 14px;}
   /* Languages per Org manual */
   pre.src-asymptote:before { content: 'Asymptote'; }
   pre.src-awk:before { content: 'Awk'; }
+  pre.src-authinfo::before { content: 'Authinfo'; }
   pre.src-C:before { content: 'C'; }
   /* pre.src-C++ doesn't work in CSS */
   pre.src-clojure:before { content: 'Clojure'; }
@@ -189,32 +190,9 @@
   .org-info-js_search-highlight
     { background-color: #ffff00; color: #000000; font-weight: bold; }
   .org-svg { width: 90%; }
-  /*]]>*/-->
 </style>
 <link rel="stylesheet" type="text/css" href="style.css" />
 <style>pre.src{background:#343131;color:white;} </style>
-<script type="text/javascript">
-// @license magnet:?xt=urn:btih:e95b018ef3580986a04669f1b5879592219e2a7a&dn=public-domain.txt Public Domain
-<!--/*--><![CDATA[/*><!--*/
-     function CodeHighlightOn(elem, id)
-     {
-       var target = document.getElementById(id);
-       if(null != target) {
-         elem.classList.add("code-highlighted");
-         target.classList.add("code-highlighted");
-       }
-     }
-     function CodeHighlightOff(elem, id)
-     {
-       var target = document.getElementById(id);
-       if(null != target) {
-         elem.classList.remove("code-highlighted");
-         target.classList.remove("code-highlighted");
-       }
-     }
-    /*]]>*///-->
-// @license-end
-</script>
 <script type="text/x-mathjax-config">
     MathJax.Hub.Config({
         displayAlign: "center",
@@ -235,16 +213,15 @@
              }
 });
 </script>
-<script type="text/javascript"
-        src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS_HTML"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS_HTML"></script>
 </head>
 <body>
-<div id="content">
+<div id="content" class="content">
 <header>
 <h1 class="title">S-SQL Reference Manual</h1>
-</header><nav id="table-of-contents">
+</header><nav id="table-of-contents" role="doc-toc">
 <h2>Table of Contents</h2>
-<div id="text-table-of-contents">
+<div id="text-table-of-contents" role="doc-toc">
 <ul>
 <li><a href="#interface">Interface</a>
 <ul>
@@ -373,14 +350,14 @@
 <li><a href="#sql-op-variance">sql-op :variance (&amp;rest args)</a></li>
 <li><a href="#sql-op-var-pop">sql-op :var-pop (&amp;rest args)</a></li>
 <li><a href="#sql-op-var-samp">sql-op :var-samp (&amp;rest args)</a></li>
-<li><a href="#org2555f16">sql-op :range-between (&amp;rest args)</a></li>
-<li><a href="#orgfb601b4">sql-op :rows-between (&amp;rest args)</a></li>
+<li><a href="#org54b48f2">sql-op :range-between (&amp;rest args)</a></li>
+<li><a href="#org58a5871">sql-op :rows-between (&amp;rest args)</a></li>
 <li><a href="#sql-op-over">sql-op :over (form &amp;rest args)</a></li>
 <li><a href="#sql-op-partition-by">sql-op :partition-by (&amp;rest args)</a></li>
 <li><a href="#sql-op-window">sql-op :window (form)</a></li>
 <li><a href="#sql-op-with">sql-op :with (&amp;rest args)</a></li>
 <li><a href="#sql-op-with-recursive">sql-op :with-recursive (&amp;rest args)</a></li>
-<li><a href="#org6f9c3d3">sql-op :with-ordinality, :with-ordinality-as</a></li>
+<li><a href="#org4765d57">sql-op :with-ordinality, :with-ordinality-as</a></li>
 </ul>
 </li>
 <li><a href="#table-functions">Table Functions</a>
@@ -1361,6 +1338,9 @@ Going back to our earlier example, remember that I said that unless you use a su
 ((<span style="color: #e67128;">"Bermuda"</span>) (<span style="color: #e67128;">"Greenland"</span>))
 </pre>
 </div>
+<p>
+IMPORTANT: If you are trying to use a list in a parameterized statement, you can't. You have to convert the list to a vector and use "any" rather than "in."
+</p>
 </div>
 </div>
 
@@ -1496,9 +1476,9 @@ out the quotes entirely).
         <span style="color: #23d7d7;">:alists</span>)
 
 (((<span style="color: #23d7d7;">:COUNTRY</span> . <span style="color: #e67128;">"Belize"</span>) (<span style="color: #23d7d7;">:REGION</span> . <span style="color: #e67128;">"Central America"</span>)) ((<span style="color: #23d7d7;">:COUNTRY</span> . <span style="color: #e67128;">"Costa Rica"</span>)
-(<span style="color: #23d7d7;">:REGION</span> . <span style="color: #e67128;">"Central America"</span>)) ((<span style="color: #23d7d7;">:COUNTRY</span> . <span style="color: #e67128;">"El Salvador"</span>)
-(<span style="color: #23d7d7;">:REGION</span> . <span style="color: #e67128;">"Central America"</span>)) ((<span style="color: #23d7d7;">:COUNTRY</span> . <span style="color: #e67128;">"Guatemala"</span>)
-(<span style="color: #23d7d7;">:REGION</span> . <span style="color: #e67128;">"Central America"</span>)) ((<span style="color: #23d7d7;">:COUNTRY</span> . <span style="color: #e67128;">"Panama"</span>) (<span style="color: #23d7d7;">:REGION</span> . <span style="color: #e67128;">"Central America"</span>))
+(<span style="color: #23d7d7;">:REGION</span> . <span style="color: #e67128;">"Central America"</span>)) <span style="color: #ff4242; font-weight: bold;">((</span><span style="color: #ff4242; font-weight: bold;">:COUNTRY</span><span style="color: #ff4242; font-weight: bold;"> . </span><span style="color: #ff4242; font-weight: bold;">"El Salvador"</span><span style="color: #ff4242; font-weight: bold;">)</span>
+(<span style="color: #23d7d7;">:REGION</span> . <span style="color: #e67128;">"Central America"</span>)) <span style="color: #ff4242; font-weight: bold;">((</span><span style="color: #ff4242; font-weight: bold;">:COUNTRY</span><span style="color: #ff4242; font-weight: bold;"> . </span><span style="color: #ff4242; font-weight: bold;">"Guatemala"</span><span style="color: #ff4242; font-weight: bold;">)</span>
+(<span style="color: #23d7d7;">:REGION</span> . <span style="color: #e67128;">"Central America"</span>)) <span style="color: #ff4242; font-weight: bold;">((</span><span style="color: #ff4242; font-weight: bold;">:COUNTRY</span><span style="color: #ff4242; font-weight: bold;"> . </span><span style="color: #ff4242; font-weight: bold;">"Panama"</span><span style="color: #ff4242; font-weight: bold;">) (</span><span style="color: #ff4242; font-weight: bold;">:REGION</span><span style="color: #ff4242; font-weight: bold;"> . </span><span style="color: #ff4242; font-weight: bold;">"Central America"</span><span style="color: #ff4242; font-weight: bold;">))</span>
 ((<span style="color: #23d7d7;">:COUNTRY</span> . <span style="color: #e67128;">"Nicaragua"</span>) (<span style="color: #23d7d7;">:REGION</span> . <span style="color: #e67128;">"Central America"</span>)))
 </pre>
 </div>
@@ -1631,30 +1611,28 @@ applied to a subquery.
 <h3 id="sql-op-is-false">sql-op :is-false (arg)</h3>
 <div class="outline-text-3" id="text-sql-op-is-false">
 <p>
-Test whether a binary value is false.
+Test whether a boolean value is false.
 </p>
 <div class="org-src-container">
 <pre class="src src-lisp">(query (<span style="color: #23d7d7;">:select</span> 'ta <span style="color: #23d7d7;">:from</span> 'a <span style="color: #23d7d7;">:where</span> (<span style="color: #23d7d7;">:is-false</span> 'ta)))
-
-(select-dao 'account (:is-false 'active))</pre>
+(select-dao 'account (<span style="color: #23d7d7;">:is-false</span> 'active))
+</pre>
 </div>
 </div>
 </div>
-
 <div id="outline-container-sql-op-is-true" class="outline-3">
 <h3 id="sql-op-is-true">sql-op :is-true (arg)</h3>
 <div class="outline-text-3" id="text-sql-op-is-true">
 <p>
-Test whether a binary value is true.
+Test whether a boolean value is true.
 </p>
 <div class="org-src-container">
 <pre class="src src-lisp">(query (<span style="color: #23d7d7;">:select</span> 'ta <span style="color: #23d7d7;">:from</span> 'a <span style="color: #23d7d7;">:where</span> (<span style="color: #23d7d7;">:is-true</span> 'ta)))
-
-(select-dao 'account (:is-true 'active))</pre>
+(select-dao 'account (<span style="color: #23d7d7;">:is-true</span> 'active))
+</pre>
 </div>
 </div>
 </div>
-
 <div id="outline-container-sql-op-is-null" class="outline-3">
 <h3 id="sql-op-is-null">sql-op :is-null (arg)</h3>
 <div class="outline-text-3" id="text-sql-op-is-null">
@@ -1667,7 +1645,6 @@ Test whether a value is null.
 </div>
 </div>
 </div>
-
 <div id="outline-container-sql-op-not-null" class="outline-3">
 <h3 id="sql-op-not-null">sql-op :not-null (arg)</h3>
 <div class="outline-text-3" id="text-sql-op-not-null">
@@ -1699,8 +1676,12 @@ Test whether a value is in a set of values.
                 <span style="color: #23d7d7;">:group-by</span> 'region 'product))
 </pre>
 </div>
+<p>
+IMPORTANT: If you are trying to use a list in a parameterized statement, you can't. You have to convert the list to a vector and use "any" rather than "in."
+</p>
 </div>
 </div>
+
 <div id="outline-container-sql-op-not-in" class="outline-3">
 <h3 id="sql-op-not-in">sql-op :not-in (value set)</h3>
 <div class="outline-text-3" id="text-sql-op-not-in">
@@ -1781,7 +1762,7 @@ Note that the responses will still come back in a list of lists
 </p>
 
 <p>
-IMPORTANT: If you are trying to use a list in a parametized statement, you can't. You have to convert the list to a vector and use "any" rather than "in."
+IMPORTANT: If you are trying to use a list in a parameterized statement, you can't. You have to convert the list to a vector and use "any" rather than "in."
 </p>
 </div>
 </div>
@@ -2744,9 +2725,9 @@ Window Functions
 </p>
 </div>
 </div>
-<div id="outline-container-org2555f16" class="outline-3">
-<h3 id="org2555f16">sql-op :range-between (&amp;rest args)</h3>
-<div class="outline-text-3" id="text-org2555f16">
+<div id="outline-container-org54b48f2" class="outline-3">
+<h3 id="org54b48f2">sql-op :range-between (&amp;rest args)</h3>
+<div class="outline-text-3" id="text-org54b48f2">
 <p>
 Range-between allows window functions to apply to different segments of a result set.
 It accepts the following keywords: :order-by, :rows-between, :range-between,
@@ -2774,9 +2755,9 @@ An example which calculates a running total could look like this:
 </div>
 </div>
 
-<div id="outline-container-orgfb601b4" class="outline-3">
-<h3 id="orgfb601b4">sql-op :rows-between (&amp;rest args)</h3>
-<div class="outline-text-3" id="text-orgfb601b4">
+<div id="outline-container-org58a5871" class="outline-3">
+<h3 id="org58a5871">sql-op :rows-between (&amp;rest args)</h3>
+<div class="outline-text-3" id="text-org58a5871">
 <p>
 Rows-between allows window functions to apply to different segments of a result set.
 It accepts the following keywords:
@@ -2977,9 +2958,9 @@ Recursive modifier to a WITH statement, allowing the query to refer to its own o
 </div>
 </div>
 </div>
-<div id="outline-container-org6f9c3d3" class="outline-3">
-<h3 id="org6f9c3d3">sql-op :with-ordinality, :with-ordinality-as</h3>
-<div class="outline-text-3" id="text-org6f9c3d3">
+<div id="outline-container-org4765d57" class="outline-3">
+<h3 id="org4765d57">sql-op :with-ordinality, :with-ordinality-as</h3>
+<div class="outline-text-3" id="text-org4765d57">
 <p>
 Selects can use :with-ordinality or :with-ordinality-as parameters. Postgresql will give the new ordinality column the name of ordinality. :with-ordinality-as allows you to set different names for the columns in the result set.
 </p>
@@ -4000,6 +3981,10 @@ to an sql injection attack.
 </p>
 
 <p>
+IMPORTANT: If you are trying to use a list in a parameterized statement, you can't. You have to convert the list to a vector and use "any" rather than "in."
+</p>
+
+<p>
 If you are not using s-sql, then it becomes easy. The query macro
 assumes that everything that is not a list starting with a keyword will
 evaluate to a string. That means you can build it with a simple format
@@ -4048,8 +4033,8 @@ For purposes of this example, we will use the following employee table:
 <div class="outline-text-5" id="text-symbols-in-variables">
 </div>
 <ul class="org-ul">
-<li><a id="orgb3aab1e"></a>Select Statements<br>
-<div class="outline-text-6" id="text-orgb3aab1e">
+<li><a id="org96239ab"></a>Select Statements<br>
+<div class="outline-text-6" id="text-org96239ab">
 <p>
 Consider the following two toy examples where we determine the table and columns
 to be selected using symbols (either keyword or quoted) inside variables.
@@ -4073,8 +4058,8 @@ string constants in the middle of a select statement.
 </div>
 </li>
 
-<li><a id="org0a3c30e"></a>Update Statements<br>
-<div class="outline-text-6" id="text-org0a3c30e">
+<li><a id="org3094e00"></a>Update Statements<br>
+<div class="outline-text-6" id="text-org3094e00">
 <p>
 This works with update statements as well
 </p>
@@ -4087,8 +4072,8 @@ This works with update statements as well
 </div>
 </div>
 </li>
-<li><a id="orga8790bf"></a>Insert Statements<br>
-<div class="outline-text-6" id="text-orga8790bf">
+<li><a id="orgcdd9f92"></a>Insert Statements<br>
+<div class="outline-text-6" id="text-orgcdd9f92">
 <p>
 This works with insert-into statements as well
 </p>
@@ -4109,8 +4094,8 @@ This works with insert-into statements as well
 </li>
 </ul>
 </li>
-<li><a id="org7846f41"></a>Delete Statements<br>
-<div class="outline-text-5" id="text-org7846f41">
+<li><a id="org9244f20"></a>Delete Statements<br>
+<div class="outline-text-5" id="text-org9244f20">
 <p>
 This works with delete statements as well
 </p>

--- a/doc/s-sql.org
+++ b/doc/s-sql.org
@@ -664,6 +664,7 @@ Going back to our earlier example, remember that I said that unless you use a su
                                    (:any* South-America))))))
 (("Bermuda") ("Greenland"))
 #+END_SRC
+IMPORTANT: If you are trying to use a list in a parameterized statement, you can't. You have to convert the list to a vector and use "any" rather than "in."
 
 ** sql-op :function (name (&rest arg-types) return-type stability body)
    :PROPERTIES:
@@ -937,6 +938,8 @@ Test whether a value is in a set of values.
                 :where (:in 'region (:select 'region :from 'top-regions))
                 :group-by 'region 'product))
 #+END_SRC
+IMPORTANT: If you are trying to use a list in a parameterized statement, you can't. You have to convert the list to a vector and use "any" rather than "in."
+
 ** sql-op :not-in (value set)
    :PROPERTIES:
    :CUSTOM_ID: sql-op-not-in
@@ -998,7 +1001,7 @@ Now with selecting from a vector. Note both the use of any* and := instead of :i
 #+END_SRC
 Note that the responses will still come back in a list of lists
 
-IMPORTANT: If you are trying to use a list in a parametized statement, you can't. You have to convert the list to a vector and use "any" rather than "in."
+IMPORTANT: If you are trying to use a list in a parameterized statement, you can't. You have to convert the list to a vector and use "any" rather than "in."
 
 ** sql-op :array (query)
    :PROPERTIES:
@@ -2722,6 +2725,8 @@ that is not a list starting with a keyword will evaluate to a string.
 In any case you will need to ensure that either you have control over the inputs
 or they still result in parameterized queries. If not you have opened yourself up
 to an sql injection attack.
+
+IMPORTANT: If you are trying to use a list in a parameterized statement, you can't. You have to convert the list to a vector and use "any" rather than "in."
 
 If you are not using s-sql, then it becomes easy. The query macro
 assumes that everything that is not a list starting with a keyword will

--- a/postmodern.asd
+++ b/postmodern.asd
@@ -20,7 +20,7 @@
   :maintainer "Sabra Crolleton <sabra.crolleton@gmail.com>"
   :homepage  "https://github.com/marijnh/Postmodern"
   :license "zlib"
-  :version "1.33.4"
+  :version "1.33.5"
   :depends-on ("alexandria"
                "cl-postgres"
                "s-sql"

--- a/postmodern/tests/test-roles.lisp
+++ b/postmodern/tests/test-roles.lisp
@@ -321,13 +321,14 @@
 
 (test default-privileges-1
   (with-test-connection
-    (let ((port (cl-postgres::connection-port *database*)))
+      (let ((port (cl-postgres::connection-port *database*))
+            (superuser-name (cl-postgres::connection-user *database*)))
       (when (schema-exists-p "a")
         (drop-schema "a" :cascade t))
       (when (schema-exists-p "b")
         (drop-schema "b" :cascade t))
-      (when (role-exists-p "a") (drop-role "a"))
-      (when (role-exists-p "b") (drop-role "b"))
+      (when (role-exists-p "a") (drop-role "a" superuser-name))
+      (when (role-exists-p "b") (drop-role "b" superuser-name))
       (create-role "a" "a")
       (create-schema "a" "a")
       (alter-role-search-path "a" "a")
@@ -365,13 +366,14 @@
 
 (test default-privileges-2
   (with-test-connection
-    (let ((port (cl-postgres::connection-port *database*)))
+      (let ((port (cl-postgres::connection-port *database*))
+            (superuser-name (cl-postgres::connection-user *database*)))
     (when (schema-exists-p "a")
       (drop-schema "a" :cascade t))
     (when (schema-exists-p "b")
       (drop-schema "b" :cascade t))
-    (when (role-exists-p "a") (drop-role "a"))
-    (when (role-exists-p "b") (drop-role "b"))
+    (when (role-exists-p "a") (drop-role "a" superuser-name))
+    (when (role-exists-p "b") (drop-role "b" superuser-name))
     (create-role "a" "a")
     (create-schema "a" "a")
     (alter-role-search-path "a" "a")

--- a/postmodern/util.lisp
+++ b/postmodern/util.lisp
@@ -886,10 +886,12 @@ the names will be returned as strings with underscores converted to hyphens."
                                  WHERE (table_schema = $1))
                                  ORDER BY table_name)"
                     (to-sql-name schema-name))))))
+    (setf result (alexandria:flatten result))
     (if strings-p
-        (mapcar 'to-sql-name result)
-        result)
-    (alexandria:flatten result)))
+        (mapcar (lambda (x)
+                  (substitute #\- #\_ x))
+                result)
+        result)))
 
 (defun list-tables (&optional (strings-p nil))
   "DEPRECATED FOR LIST-ALL-TABLES. Return a list of the tables in the public

--- a/postmodern/util.lisp
+++ b/postmodern/util.lisp
@@ -298,7 +298,8 @@ connection limit = ~a"
                              (cl-postgres::connection-host *database*)
                              :port (cl-postgres::connection-port *database*)
                              :use-ssl (cl-postgres::connection-use-ssl *database*))
-                (query "CREATE EXTENSION IF NOT EXISTS pg_stat_statements;")))
+    (when (member "pg_stat_statements" (list-available-extensions) :test #'equal)
+        (query "CREATE EXTENSION IF NOT EXISTS pg_stat_statements;"))))
 
 (defun drop-database (database)
   "Drop the specified database. The database parameter can be a string or a

--- a/postmodern/util.lisp
+++ b/postmodern/util.lisp
@@ -1072,7 +1072,7 @@ to be the public schema. Returns t or nil."
 
 (defun rename-column (table old-name new-name)
   "Rename a column in a table. Parameters can be strings or symbols. If the table
-is not in the public schema, it needs to be fully qualified - e.g. schema.table.
+is not in the public schema, it needs to be fully qualified - e.g. schema.table.column
 Returns t if successful."
   (setf table (to-sql-name table))
   (setf old-name (to-sql-name old-name))

--- a/s-sql.asd
+++ b/s-sql.asd
@@ -9,7 +9,7 @@
   :author "Marijn Haverbeke <marijnh@gmail.com>"
   :maintainer "Sabra Crolleton <sabra.crolleton@gmail.com>"
   :license "zlib"
-  :version "1.33.4"
+  :version "1.33.5"
   :depends-on ("cl-postgres"
                "alexandria")
   :components

--- a/s-sql/tests/test-intervals.lisp
+++ b/s-sql/tests/test-intervals.lisp
@@ -67,7 +67,7 @@
     (is (equal (sql (:select (:to-char (:* 900 (:type "1 second" interval)) "HH24:MI:SS")))
                "(SELECT to_char((900 * E'1 second'::INTERVAL), E'HH24:MI:SS'))"))
     (is (equal (query (:select (:extract "hour" (:type "2001-02-16 20:38:40" timestamp))) :single)
-        20.0d0))
+        20))
     (is (equal (query (:select (:isfinite (:type "2001-02-16" date))) :single) t))
     (is (equal (query (:select (:justify_days (:type  "35 days" interval))) :single)
                '((:MONTHS 1) (:DAYS 5) (:SECONDS 0) (:USECONDS 0))))
@@ -146,21 +146,21 @@
   (with-test-connection
     (is (equal
          (query (:select (:extract "minute" (:interval "5 hours 21 minutes"))) :single)
-         21.0d0))
+         21))
     (is (equal
          (query (:select (:extract "hour" (:interval "35 hours 21 minutes"))) :single)
-         35.0d0))
+         35))
     (is (equal (query (:select (:extract "day" (:interval "6 years 5 months 4 days 3 hours 2 minutes 1 second"))) :single)
-               4.0d0))
+               4))
     (is (equal
          (query (:select (:extract "year" (:interval "6 years 5 months 4 days 3 hours 2 minutes 1 second"))) :single)
-         6.0d0))
+         6))
     (is (equal
          (query (:select (:extract "year" (:interval "6 years 15 months 4 days 3 hours 2 minutes 1 second"))) :single)
-         7.0d0))
+         7))
     (is (equal
          (query (:select (:extract "month" (:interval "6 years 15 months 4 days 3 hours 2 minutes 1 second"))) :single)
-         3.0d0))))
+         3))))
 
 (test interval-addition
   "Testing interval addition"
@@ -275,28 +275,28 @@
   (with-test-connection
     (is (equal
          (query (:select (:extract "year" (:timestamp "2016-12-31 13:30:15"))) :single)
-         2016.0d0))
+         2016))
     (is (equal
          (query (:select (:extract "quarter" (:timestamp "2016-12-31 13:30:15"))) :single)
-         4.0d0))
+         4))
     (is (equal
          (query (:select (:extract "month" (:timestamp "2016-12-31 13:30:15"))) :single)
-         12.0d0))
+         12))
     (is (equal
          (query (:select (:extract "day" (:timestamp "2016-12-31 13:30:15"))) :single)
-         31.0d0))
+         31))
     (is (equal
          (query (:select (:extract "century" (:timestamp "2016-12-31 13:30:15"))) :single)
-         21.0d0))
+         21))
     (is (equal
          (query (:select (:extract "dow" (:timestamp "2016-12-31 13:30:15"))) :single)
-         6.0d0))
+         6))
     (is (equal
          (query (:select (:extract "doy" (:timestamp "2016-12-31 13:30:15"))) :single)
-         366.0d0))
+         366))
     (is (equal
          (query (:select (:extract "hour" (:timestamp "2016-12-31 13:30:15"))) :single)
-         13.0d0))
+         13))
     (is (equal
          (query (:select (:extract "minute" (:timestamp "2016-12-31 13:30:15"))) :single)
-         30.0d0))))
+         30))))

--- a/s-sql/tests/tests.lisp
+++ b/s-sql/tests/tests.lisp
@@ -1008,14 +1008,15 @@ To sum the column len of all films and group the results by kind:"
                                             (:set 'd2 'd3)))))
              "(SELECT d1, d2, d3, SUM(v) FROM test_cube GROUP BY GROUPING SETS ((d1), (d2, d3)))"))
   (is (equal (with-test-connection
-               (query (:select 'city (:as (:extract 'year 'start-date)  'joining-year)
-                               (:as (:count 1) 'employee_count)
-                               :from 'employee
-                               :group-by (:grouping-sets (:set 'city (:extract 'year 'start-date))))))
-             '(("Vancouver" :NULL 3) ("New York" :NULL 3) ("Toronto" :NULL 3)
-               (:NULL 2001.0d0 1) (:NULL 1997.0d0 1) (:NULL 1994.0d0 1) (:NULL 2000.0d0 1)
-               (:NULL 2002.0d0 1) (:NULL 1996.0d0 1) (:NULL 1995.0d0 1) (:NULL 1998.0d0 1)
-               (:NULL 1999.0d0 1))))
+               (query (:order-by
+                       (:select 'city (:as (:extract 'year 'start-date)  'joining-year)
+                                (:as (:count 1) 'employee_count)
+                        :from 'employee
+                        :group-by (:grouping-sets (:set 'city (:extract 'year 'start-date))))
+                       'city (:desc 'joining-year))))
+             '(("New York" :NULL 3) ("Toronto" :NULL 3) ("Vancouver" :NULL 3) (:NULL 2002 1)
+ (:NULL 2001 1) (:NULL 2000 1) (:NULL 1999 1) (:NULL 1998 1) (:NULL 1997 1)
+ (:NULL 1996 1) (:NULL 1995 1) (:NULL 1994 1))))
   (is (equal (sql (:select 'appnumber 'day (:sum 'inserts) (:sum 'updates)
                            (:sum 'deletes) (:sum 'transactions)
                            :from 'db-details

--- a/s-sql/tests/tests.lisp
+++ b/s-sql/tests/tests.lisp
@@ -1015,8 +1015,8 @@ To sum the column len of all films and group the results by kind:"
                         :group-by (:grouping-sets (:set 'city (:extract 'year 'start-date))))
                        'city (:desc 'joining-year))))
              '(("New York" :NULL 3) ("Toronto" :NULL 3) ("Vancouver" :NULL 3) (:NULL 2002 1)
- (:NULL 2001 1) (:NULL 2000 1) (:NULL 1999 1) (:NULL 1998 1) (:NULL 1997 1)
- (:NULL 1996 1) (:NULL 1995 1) (:NULL 1994 1))))
+               (:NULL 2001 1) (:NULL 2000 1) (:NULL 1999 1) (:NULL 1998 1) (:NULL 1997 1)
+               (:NULL 1996 1) (:NULL 1995 1) (:NULL 1994 1))))
   (is (equal (sql (:select 'appnumber 'day (:sum 'inserts) (:sum 'updates)
                            (:sum 'deletes) (:sum 'transactions)
                            :from 'db-details


### PR DESCRIPTION
Discontinue support for versions of sbcl < 1.2.5 which were compiled without support for bsd-sockets. I do not think anyone (even in the BSD crowd) is running on sbcl that old.

Drop unwarrented assumption that the role 'postgres' will always exist when dropping a role resulting in ownership changes of postgresql objects. 

Add more documentation on the limitation in s-sql on using lists in a parameterized statement. If you are trying to use a list in a parametized statement, you can't. You have to convert the list to a vector and use "any" rather than "in."

Add additional support for ssl connections to allow use of a root certificate for validation. Set \*ssl-root-ca-file* to the pathname for the root certificate.