### PR TITLE
Fix bug 315

### DIFF
--- a/simple-date.asd
+++ b/simple-date.asd
@@ -22,7 +22,7 @@
              (uiop:symbol-call :fiveam '#:run! :simple-date)))
 
 (defsystem "simple-date/postgres-glue"
-  :depends-on ("simple-date" "cl-postgres" "cl-postgres/tests")
+  :depends-on ("simple-date" "cl-postgres" "s-sql" "cl-postgres/tests")
   :components
   ((:module "simple-date"
             :components


### PR DESCRIPTION
cl-postgres/simple-date-tests and simple-date/postgres-glue were failing to load due to missing new dependency on s-sql. Now fixed.