### PR TITLE
Fix for other packages methods for cl-postgres:to-sql-string

### DIFF
--- a/s-sql/s-sql.lisp
+++ b/s-sql/s-sql.lisp
@@ -161,7 +161,7 @@ You can define to-s-sql-string methods for your own datatypes.")
   (:method ((arg (eql :null)))
     "NULL")
   (:method ((arg t))
-    (error "Value ~S can not be converted to an SQL literal." arg)))
+    (cl-postgres:to-sql-string arg)))
 
 (defun to-sql-name (name &optional (escape-p *escape-sql-names-p*)
                            (ignore-reserved-words nil))


### PR DESCRIPTION
This commit changes s-sql::to-s-sql-string
to call cl-postgres:to-sql-string for unknown types, picking up other packages providing new methods for cl-postgres:to-sql-string.