### PR TITLE
Add cube operators

### DIFF
--- a/s-sql/s-sql.lisp
+++ b/s-sql/s-sql.lisp
@@ -579,6 +579,9 @@ string."
 ;; hstore operators
 (register-sql-operators :2+-ary :-> :=> :? :?& :?\| :|<@| :|#=| :unary :%% :%#)
 
+;; cube operators
+(register-sql-operators :2+-ary :&& :|@>| :|<@| :-> :~> :<-> :<#> :<=>)
+
 ;;; sql-op :+, :*, :%, :&, :|, :| |, :and, :or, :=, :/, :!=, :<, :>, :<=, :>=,
 ;;;  :^, :union, :union-all,
 ;;;  :intersect, :intersect-all, :except, :except-all (&rest args)


### PR DESCRIPTION
Adds [cube operators](https://www.postgresql.org/docs/current/cube.html#CUBE-OPERATORS-TABLE) (re: item 5 from #327)

Tested with SBCL 2.3.10 on Mac