### PR TITLE
Updated :with & :with-recursive to be wrapped in parens.

### DIFF
--- a/s-sql/s-sql.lisp
+++ b/s-sql/s-sql.lisp
@@ -1942,10 +1942,10 @@ Example:
 
 (def-sql-op :with (&rest args)
   (let ((x (butlast args)) (y (last args)))
-    `("WITH " ,@(sql-expand-list x) ,@(sql-expand (car y)))))
+    `("( WITH " ,@(sql-expand-list x) ,@(sql-expand (car y)) " )")))
 
 (def-sql-op :with-recursive (form1 form2)
-  `("WITH RECURSIVE " ,@(sql-expand form1) ,@(sql-expand form2)))
+  `("( WITH RECURSIVE " ,@(sql-expand form1) ,@(sql-expand form2) " )"))
 
 (def-sql-op :window (form)
   `("WINDOW " ,@(sql-expand form)))


### PR DESCRIPTION
When doing a union over queries that use a with clause the with clauses aren't inside parens when they need to be for valid syntax.

e.g.
```common-lisp
(:union
   (:with (:as 'cte1 (:parens (:select '* :from 'demo)))
	  (:select '*
	    :from 'base
	    :inner-join 'cte1
	    :on t))
   (:with (:as 'cte2 (:parens (:select '* :from 'example)))
	  (:select '*
	    :from 'level
	    :left-join 'cte2
	    :on t))))
```
without this PR produces:
```SQL
(WITH cte1 AS  ((SELECT * FROM demo))
    (SELECT *
     FROM base 
     INNER JOIN cte1 
     ON true) 
union 
WITH cte2 AS  ((SELECT * FROM example))
    (SELECT * 
     FROM level 
     LEFT JOIN cte2
     ON true))
```
which fails.

with this PR it produces:
```SQL
(( WITH cte1 AS  ((SELECT * FROM demo))
    (SELECT *
     FROM base
     INNER JOIN cte1
     ON true) ) 
union
( WITH cte2 AS  ((SELECT * FROM example))
    (SELECT *
     FROM level
     LEFT JOIN cte2
     ON true) ))
```