### PR TITLE
Feat: add define-dao-class

### DIFF
--- a/postmodern/package.lisp
+++ b/postmodern/package.lisp
@@ -8,6 +8,7 @@
   #+postmodern-use-mop
   (:export
    #:dao-class #:dao-exists-p #:dao-keys #:query-dao #:select-dao #:get-dao
+   #:define-dao-class
    #:fetch-defaults
    #:do-query-dao #:do-select-dao
    #:with-column-writers

--- a/postmodern/tests/test-dao.lisp
+++ b/postmodern/tests/test-dao.lisp
@@ -1570,3 +1570,31 @@ Note that you need to handle :NULLs."
       (fiveam:is (equal
                   (pomo::field-name-to-slot-name (find-class 'postmodern-tests::listy) "r-list")
                   'postmodern-tests::r-list)))
+
+(define-dao-class test-define-dao-class ()
+  ((id integer :initarg :id :accessor test-id)
+   (a :col-type text :initarg :a :accessor test-a))
+  (:table-name test-define-dao-class)
+  (:documentation "test-codumentation")
+  (:keys id))
+
+(test define-dao-class
+  (is (equal (macroexpand-1
+	      '(define-dao-class test-define-dao-class ()
+		((id integer :initarg :id :accessor test-id)
+		 (a :col-type text :initarg :a :accessor test-a))
+		(:table-name test-define-dao-class)
+		(:keys id)))
+	     '(defclass test-define-dao-class nil
+	       ((id :col-type integer :initarg :id :accessor test-id)
+		(a :col-type text :initarg :a :accessor test-a))
+	       (:metaclass dao-class) (:table-name test-define-dao-class)
+	       (:keys id))))
+  (let ((class
+	  (class-of (make-instance 'test-define-dao-class))))
+    (is (eq (pomo::find-col-type class 'id)
+	    'integer))
+    (is (eq (pomo::find-col-type class 'a)
+	    'text))
+    (is (equal (dao-keys class)
+	       (list 'id)))))


### PR DESCRIPTION
- `define-dao-class` is like `defclass` except two postmodern specific changes:
  1. The `dao-class` metaclass options is automatically added.
  2. If second value in a slot is not a keyword, it is assumed to be `col-type`.
- `define-dao-class` symbol is added to the exported symbols
- new tests have been added

The text for the docs could be taken from the `define-dao-class` macro-function docstring. Let me know if you want more in-depth documentation.

Closes #341 