### PR TITLE
Fix issue 357

### DIFF
--- a/postmodern/prepare.lisp
+++ b/postmodern/prepare.lisp
@@ -70,7 +70,9 @@ overwrite unless postgresql throws a duplicate-prepared-statement error."
                                        #'pomo:reset-prepared-statement))
                                   (cond (overwrite
                                          (setf overwrite nil)
-                                         (drop-prepared-statement statement-id :remove-function nil)
+                                         (when (prepared-statement-exists-p statement-id)
+                                             (drop-prepared-statement statement-id
+                                                                      :remove-function nil))
                                          (ensure-prepared *database* statement-id
                                                           query t params))
                                         ((not (connection-use-binary *database*))

--- a/postmodern/tests/test-transactions.lisp
+++ b/postmodern/tests/test-transactions.lisp
@@ -258,3 +258,21 @@
                          '((0) (1))))))
         (is (equal (query "select * from test_data")
                    '((0) (1))))))))
+
+(test transaction-with-prepared-statement
+  (with-test-connection
+    (let ((one-fn (prepare "select 1" :single)))
+      (with-transaction ()
+        (is (equal (funcall one-fn) 1))))
+    (let ((one-fn (prepare "select 1" :single)))
+      (with-logical-transaction ()
+        (is (equal (funcall one-fn) 1))))
+    (let ((one-fn (prepare "select 1" :single)))
+      (with-logical-transaction ()
+        (is (equal (funcall one-fn) 1))
+        (is (equal (funcall one-fn) 1)))))
+  (defprepared 'dp3 "select 3" :single)
+  (with-test-connection 
+    (with-transaction ()
+      (is (equal (funcall 'dp3)
+                 3)))))


### PR DESCRIPTION
This fixes the problem identified in issue 357 that a prepared statement inside a transaction could try to drop a non-existent prepared statement, resulting in the entire transaction failing.