### PR TITLE
Allow dao class with no keys

### DIFF
--- a/postmodern/table.lisp
+++ b/postmodern/table.lisp
@@ -236,7 +236,8 @@ such a class)."
     (error "Class ~A has a key that is not also a slot." (class-name class)))
   (when (not (dao-keys class))
     (setf (slot-value class 'effective-keys)
-          (list (find-primary-key-column class))))
+          (let ((primary-key (find-primary-key-column class)))
+            (when primary-key (list primary-key)))))
   (build-dao-methods class))
 
 

--- a/postmodern/tests/test-dao.lisp
+++ b/postmodern/tests/test-dao.lisp
@@ -89,6 +89,11 @@
   (:metaclass dao-class)
   (:table-name users1))
 
+(defclass test-data-no-keys ()
+  ((username :col-type text :initarg :username :accessor username)
+   (department-id :col-type integer :initarg :department-id :accessor department-id))
+  (:metaclass dao-class))
+
 (defclass test-data-col-identity-with-references ()
   ((id :col-type integer :col-identity t :accessor id)
    (username :col-type text :col-unique t :initarg :username :accessor username)
@@ -221,6 +226,9 @@
                  "boolean test dao 1"))
       (is (equal (test-a (first (select-dao 'test-data (:is-false 'b))))
                  "boolean test dao 2")))))
+
+(test dao-class-no-keys
+  (finalize-inheritance (find-class 'test-data-no-keys)))  ;; should not raise an error
 
 (defclass test-data-nil ()
   ((id :col-type serial :initarg :id :accessor test-id)


### PR DESCRIPTION
If I make a dao class with no keys, such as

```
(postmodern:define-dao-class test-no-keys ()
  ((current boolean :accessor get-current :initarg :current)
   (value text :accessor get-value :initarg :value)))
```

and finalize it, I get an error

```
The value NIL is not of type STRING when binding STRING
```

This is caused by `(defmethod finalize-inheritance :after ((class dao-class))` that does

```
 (when (not (dao-keys class))
    (setf (slot-value class 'effective-keys)
          (list (find-primary-key-column class))))
```

so the `effective-keys` is `(NIL)`.

The patch sets the effective keys to `nil` (not a list) in such case.

If you wonder why I create a class without any key, I use it to query-dao views to it.